### PR TITLE
feat(maiml): MaiML シリアライザ + インポート/エクスポートUI

### DIFF
--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,1 +1,1 @@
-export { Modal, ToastHub, AIInsightCard, VecCard, KpiCard, SearchBox, FilterChip, MarkdownBubble, ExportModal } from './molecules';
+export { Modal, ToastHub, AIInsightCard, VecCard, KpiCard, SearchBox, FilterChip, MarkdownBubble, ExportModal, ImportModal } from './molecules';

--- a/src/components/molecules/molecules.test.tsx
+++ b/src/components/molecules/molecules.test.tsx
@@ -401,10 +401,13 @@ describe('ExportModal', () => {
       <ExportModal open onClose={vi.fn()} db={materials} filtered={materials} />
     );
     expect(screen.getByText('データエクスポート')).toBeInTheDocument();
+    // MaiML is now the primary (recommended) format
+    expect(screen.getByText('MaiML（推奨）')).toBeInTheDocument();
+    expect(screen.getByText('MaiML（全件）')).toBeInTheDocument();
     expect(screen.getByText('CSV')).toBeInTheDocument();
     expect(screen.getByText('JSON')).toBeInTheDocument();
+    expect(screen.getByText('Markdown')).toBeInTheDocument();
     expect(screen.getByText('PDF レポート')).toBeInTheDocument();
-    expect(screen.getByText('全件 JSON')).toBeInTheDocument();
   });
 
   it('does not render when closed', () => {
@@ -418,10 +421,11 @@ describe('ExportModal', () => {
     render(
       <ExportModal open onClose={vi.fn()} db={materials} filtered={materials} />
     );
+    expect(screen.getByText(/JIS K 0200:2024/)).toBeInTheDocument();
     expect(screen.getByText('Excel で開けるCSV形式')).toBeInTheDocument();
     expect(screen.getByText('システム連携用JSON')).toBeInTheDocument();
+    expect(screen.getByText('ドキュメント共有用')).toBeInTheDocument();
     expect(screen.getByText('印刷用フルレポート')).toBeInTheDocument();
-    expect(screen.getByText('DBフル出力')).toBeInTheDocument();
   });
 
   it('renders a close button in footer', () => {

--- a/src/components/molecules/molecules.tsx
+++ b/src/components/molecules/molecules.tsx
@@ -1,5 +1,11 @@
 import React, { useState, useEffect, useContext, useMemo } from 'react';
 import { renderSafeMarkdown } from '../../services/safeMarkdown';
+import {
+  serializeMaterialsToMaiml,
+  downloadMaimlFile,
+  defaultMaimlFilename,
+  parseMaimlToMaterials,
+} from '../../services/maiml';
 import { Icon, IconName } from '../Icon';
 import { Tooltip } from '../Tooltip';
 import { Button, Badge, Card, Input, SectionCard } from '../atoms';
@@ -57,6 +63,12 @@ interface ExportModalProps {
   onClose: () => void;
   db: Material[];
   filtered: Material[];
+}
+
+interface ImportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onImport: (materials: Material[]) => void;
 }
 
 interface TypingProps {
@@ -226,24 +238,189 @@ export const ExportModal = ({ open, onClose, db, filtered }: ExportModalProps) =
     win.document.write(`<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>Matlens レポート</title><style>body{font-family:sans-serif;font-size:11px;padding:20px}h1{font-size:16px;margin-bottom:4px}.meta{color:#666;font-size:11px;margin-bottom:16px}table{width:100%;border-collapse:collapse}th{background:#1e3050;color:#fff;padding:6px 8px;text-align:left;font-size:10px}td{padding:5px 8px;border-bottom:1px solid #e0e0e0;font-size:10px}tr:nth-child(even) td{background:#f7f7f5}</style></head><body><h1>Matlens 材料データレポート</h1><div class="meta">出力: ${new Date().toLocaleString('ja-JP')} ／ 総件数: ${db.length}件</div><table><thead><tr><th>ID</th><th>名称</th><th>カテゴリ</th><th>硬度HV</th><th>引張MPa</th><th>ステータス</th></tr></thead><tbody>${rows}</tbody></table></body></html>`);
     win.document.close(); setTimeout(() => win.print(), 400); onClose();
   };
-  const items = [
+  const exportMaiML = () => {
+    const xml = serializeMaterialsToMaiml(filtered.length > 0 ? filtered : db);
+    downloadMaimlFile(xml, defaultMaimlFilename('matlens'));
+    onClose();
+  };
+  const exportMaiMLAll = () => {
+    const xml = serializeMaterialsToMaiml(db);
+    downloadMaimlFile(xml, `matlens_all_${new Date().toISOString().slice(0, 10)}.maiml`);
+    onClose();
+  };
+  const exportMarkdown = () => {
+    const rows = filtered.map(r => `| ${r.id} | ${r.name} | ${r.cat} | ${r.hv} | ${r.ts} | ${r.comp} | ${r.status} |`).join('\n');
+    const md = `# Matlens 材料データ\n\n出力日時: ${new Date().toLocaleString('ja-JP')}  \n件数: ${filtered.length}件\n\n| ID | 名称 | カテゴリ | 硬度HV | 引張MPa | 組成 | ステータス |\n| --- | --- | --- | --- | --- | --- | --- |\n${rows}\n`;
+    const a = document.createElement('a');
+    a.href = 'data:text/markdown;charset=utf-8,' + encodeURIComponent(md);
+    a.download = `matdb_${new Date().toISOString().slice(0, 10)}.md`; a.click(); onClose();
+  };
+
+  // MaiML is the platform's primary data format (JIS K 0200:2024), so it is
+  // rendered first and visually promoted as the recommended option. The
+  // secondary formats remain available for legacy tooling and ad-hoc sharing.
+  const primary = {
+    label: 'MaiML（推奨）',
+    desc: 'JIS K 0200:2024 共通フォーマット — 他システム連携の基盤',
+    action: exportMaiML,
+  };
+  const secondary: { icon: IconName; label: string; desc: string; action: () => void }[] = [
+    { icon: 'report', label: 'MaiML（全件）', desc: 'DB全件を MaiML で出力', action: exportMaiMLAll },
     { icon: 'csv', label: 'CSV', desc: 'Excel で開けるCSV形式', action: exportCSV },
     { icon: 'json', label: 'JSON', desc: 'システム連携用JSON', action: exportJSON },
+    { icon: 'report', label: 'Markdown', desc: 'ドキュメント共有用', action: exportMarkdown },
     { icon: 'pdf', label: 'PDF レポート', desc: '印刷用フルレポート', action: exportPDF },
-    { icon: 'report', label: '全件 JSON', desc: 'DBフル出力', action: () => { exportJSON(); onClose(); } },
   ];
+
   return (
     <Modal open={open} onClose={onClose} title="データエクスポート" footer={<Button variant="default" onClick={onClose}>閉じる</Button>}>
-      <div className="grid grid-cols-2 gap-2.5">
-        {items.map(item => (
-          <button key={item.label} onClick={item.action} className="flex flex-col items-center gap-2 p-4 bg-raised border border-[var(--border-default)] rounded-md cursor-pointer hover:border-accent hover:bg-accent-dim transition-all duration-150 text-center font-ui">
-            <Icon name={item.icon as IconName} size={22} className="text-accent" />
-            <div>
-              <div className="text-[13px] font-bold text-text-hi">{item.label}</div>
-              <div className="text-[12px] text-text-lo mt-0.5">{item.desc}</div>
+      <div className="flex flex-col gap-3">
+        <button
+          onClick={primary.action}
+          className="flex items-center gap-3 p-4 rounded-md border-2 border-accent bg-accent-dim hover:bg-hover transition-all duration-150 text-left font-ui"
+        >
+          <div className="w-10 h-10 rounded-md bg-accent text-white flex items-center justify-center flex-shrink-0">
+            <Icon name="embed" size={18} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <div className="text-[14px] font-bold text-text-hi">{primary.label}</div>
+              <Badge variant="blue" className="text-[10px]">PRIMARY</Badge>
             </div>
-          </button>
-        ))}
+            <div className="text-[12px] text-text-md mt-0.5">{primary.desc}</div>
+          </div>
+        </button>
+        <div className="grid grid-cols-2 gap-2.5">
+          {secondary.map(item => (
+            <button key={item.label} onClick={item.action} className="flex flex-col items-center gap-2 p-3 bg-raised border border-[var(--border-default)] rounded-md cursor-pointer hover:border-accent hover:bg-hover transition-all duration-150 text-center font-ui">
+              <Icon name={item.icon} size={20} className="text-text-md" />
+              <div>
+                <div className="text-[12px] font-bold text-text-hi">{item.label}</div>
+                <div className="text-[11px] text-text-lo mt-0.5">{item.desc}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+// MaiML / JSON / CSV ファイルをアップロードして Material[] として返すモーダル。
+// 親側 (MaterialListPage など) は onImport で dispatch し DB に反映する。
+export const ImportModal = ({ open, onClose, onImport }: ImportModalProps) => {
+  const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [previewCount, setPreviewCount] = useState<number | null>(null);
+  const [parsed, setParsed] = useState<Material[] | null>(null);
+  const [filename, setFilename] = useState<string>('');
+
+  const reset = () => {
+    setError(null);
+    setWarnings([]);
+    setPreviewCount(null);
+    setParsed(null);
+    setFilename('');
+  };
+
+  const handleFile = async (file: File) => {
+    reset();
+    setFilename(file.name);
+    const text = await file.text();
+    const lower = file.name.toLowerCase();
+    try {
+      if (lower.endsWith('.maiml') || lower.endsWith('.xml') || text.trim().startsWith('<')) {
+        const result = parseMaimlToMaterials(text);
+        setParsed(result.materials);
+        setPreviewCount(result.materials.length);
+        setWarnings(result.warnings);
+        return;
+      }
+      if (lower.endsWith('.json') || text.trim().startsWith('{')) {
+        const json = JSON.parse(text);
+        const list: Material[] = Array.isArray(json) ? json : (json.data ?? []);
+        setParsed(list);
+        setPreviewCount(list.length);
+        return;
+      }
+      setError('対応していないファイル形式です（.maiml / .xml / .json を選択してください）');
+    } catch (e) {
+      setError(`読み込みエラー: ${(e as Error).message}`);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!parsed || parsed.length === 0) return;
+    onImport(parsed);
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={() => { reset(); onClose(); }}
+      title="データインポート"
+      footer={
+        <>
+          <Button variant="default" onClick={() => { reset(); onClose(); }}>キャンセル</Button>
+          <Button variant="primary" onClick={handleConfirm} disabled={!parsed || parsed.length === 0}>
+            <Icon name="upload" size={12} />{previewCount ? `${previewCount}件を取り込む` : '取り込む'}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start gap-3 p-3 rounded-md border-2 border-accent bg-accent-dim">
+          <div className="w-10 h-10 rounded-md bg-accent text-white flex items-center justify-center flex-shrink-0">
+            <Icon name="embed" size={18} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <div className="text-[14px] font-bold text-text-hi">MaiML（推奨）</div>
+              <Badge variant="blue" className="text-[10px]">PRIMARY</Badge>
+            </div>
+            <div className="text-[12px] text-text-md mt-0.5">JIS K 0200:2024 共通フォーマットを優先的にサポート</div>
+          </div>
+        </div>
+
+        <label className="flex flex-col items-center gap-2 p-6 border-2 border-dashed border-[var(--border-default)] rounded-md cursor-pointer hover:border-accent hover:bg-hover transition-all">
+          <Icon name="upload" size={24} className="text-text-md" />
+          <div className="text-[13px] font-semibold text-text-hi">ファイルを選択</div>
+          <div className="text-[11px] text-text-lo">.maiml / .xml / .json 対応</div>
+          <input
+            type="file"
+            accept=".maiml,.xml,.json,application/xml,text/xml,application/json"
+            className="hidden"
+            onChange={e => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+            }}
+          />
+        </label>
+
+        {filename && !error && (
+          <div className="text-[12px] text-text-md">
+            読み込みファイル: <strong className="font-mono">{filename}</strong>
+          </div>
+        )}
+        {previewCount !== null && (
+          <div className="text-[12px] p-2 rounded bg-[var(--ok-dim)] text-ok border border-[var(--ok)]">
+            {previewCount} 件の材料データを検出しました
+          </div>
+        )}
+        {warnings.length > 0 && (
+          <div className="text-[11px] p-2 rounded bg-[var(--warn-dim)] text-warn border border-[var(--warn)]">
+            <div className="font-bold mb-1">警告 ({warnings.length})</div>
+            {warnings.slice(0, 5).map((w, i) => <div key={i}>• {w}</div>)}
+            {warnings.length > 5 && <div>…他 {warnings.length - 5} 件</div>}
+          </div>
+        )}
+        {error && (
+          <div className="text-[12px] p-2 rounded bg-[var(--err-dim)] text-err border border-[var(--err)]">
+            {error}
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useContext, useCallback, useMemo } from 'react';
 import { renderSafeMarkdown } from '../../services/safeMarkdown';
+import {
+  serializeMaterialToMaiml,
+  downloadMaimlFile,
+} from '../../services/maiml';
 import { Icon } from '../../components/Icon';
 import { Button, Badge, Card, SectionCard } from '../../components/atoms';
 import { Modal, AIInsightCard, VecCard } from '../../components/molecules';
@@ -99,6 +103,18 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
             </div>
           </div>
           <div className="flex gap-2">
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => {
+                const xml = serializeMaterialToMaiml(r);
+                downloadMaimlFile(xml, `${r.id}.maiml`);
+                addToast('MaiML ファイルをダウンロードしました');
+              }}
+              title="この材料を MaiML (JIS K 0200:2024) で書き出す"
+            >
+              <Icon name="download" size={12} />MaiML
+            </Button>
             <Button variant="default" size="sm" onClick={onEdit}><Icon name="edit" size={12} />編集</Button>
             <Button variant="danger" size="sm" onClick={() => setDeleteOpen(true)}><Icon name="trash" size={12} />削除</Button>
           </div>

--- a/src/pages/MaterialList/MaterialListPage.tsx
+++ b/src/pages/MaterialList/MaterialListPage.tsx
@@ -4,7 +4,7 @@ import { DataDisclaimer } from '../../components/DataDisclaimer';
 import { MaterialVisual } from '../../components/MaterialVisual';
 import { Tooltip } from '../../components/Tooltip';
 import { Button, Badge, Card, Input, Select, Checkbox } from '../../components/atoms';
-import { Modal, SearchBox, FilterChip, ExportModal } from '../../components/molecules';
+import { Modal, SearchBox, FilterChip, ExportModal, ImportModal } from '../../components/molecules';
 import { AppCtx } from '../../context/AppContext';
 import type { Material, AppContextValue, MaterialWithScore } from '../../types';
 
@@ -42,6 +42,7 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
   const [advOpen, setAdvOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [exportOpen, setExportOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const [viewMode, setViewMode] = useState<'table' | 'card' | 'compact'>('table');
   const { addToast } = useContext(AppCtx) as AppContextValue;
 
@@ -90,6 +91,21 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
   return (
     <div className="flex flex-col gap-4 min-w-0">
       <ExportModal open={exportOpen} onClose={() => setExportOpen(false)} db={db} filtered={filtered} />
+      <ImportModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImport={(records) => {
+          // Skip records whose id already exists in the DB to avoid duplicates.
+          const existing = new Set(db.map(r => r.id));
+          const fresh = records.filter(r => r.id && !existing.has(r.id));
+          if (fresh.length === 0) {
+            addToast('取り込めるデータがありません（ID が既に存在します）', 'warn');
+            return;
+          }
+          dispatch({ type: 'IMPORT', records: fresh });
+          addToast(`${fresh.length}件を取り込みました`);
+        }}
+      />
       <Modal open={!!deleteTarget} onClose={() => setDeleteTarget(null)} title="削除の確認" footer={
         <>
           <Button variant="default" onClick={() => setDeleteTarget(null)}>キャンセル</Button>
@@ -106,6 +122,7 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
           <p className="text-[12px] text-text-lo mt-0.5">{filtered.length}件 (DB: {db.length}件)</p>
         </div>
         <div className="flex gap-2">
+          <Button variant="default" size="sm" onClick={() => setImportOpen(true)} title="MaiML / JSON ファイルをインポート"><Icon name="upload" size={13} />インポート</Button>
           <Button variant="default" size="sm" onClick={() => setExportOpen(true)}><Icon name="download" size={13} />エクスポート</Button>
           <Button variant="primary" size="sm" onClick={() => onNav('new')}><Icon name="plus" size={13} />登録</Button>
         </div>

--- a/src/services/maiml.test.ts
+++ b/src/services/maiml.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  serializeMaterialToMaiml,
+  serializeMaterialsToMaiml,
+  parseMaimlToMaterials,
+  defaultMaimlFilename,
+} from './maiml';
+import type { Material } from '../types';
+
+const sample: Material = {
+  id: 'MAT-0001',
+  name: 'SUS316L 低炭素ステンレス',
+  cat: '金属合金',
+  hv: 186,
+  ts: 520,
+  el: 193,
+  pf: 205,
+  el2: 55,
+  dn: 7.98,
+  comp: 'Fe-17Cr-12Ni-2Mo-0.03C',
+  batch: 'B-001',
+  date: '2026-01-15',
+  author: '山田 研',
+  status: '承認済',
+  ai: false,
+  memo: '医療機器用途で実績あり',
+};
+
+const withXmlSpecials: Material = {
+  ...sample,
+  id: 'MAT-0002',
+  name: 'A & B "Alloy" <test>',
+  comp: "C'arbon & iron",
+  memo: '',
+};
+
+describe('serializeMaterialsToMaiml', () => {
+  it('produces a well-formed XML document with the root <maiml> element', () => {
+    const xml = serializeMaterialsToMaiml([sample], {
+      generatedAt: new Date('2026-04-10T00:00:00.000Z'),
+    });
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(xml).toContain('<maiml version="1.0">');
+    expect(xml).toContain('</maiml>');
+  });
+
+  it('includes header metadata', () => {
+    const xml = serializeMaterialsToMaiml([sample], {
+      generatedAt: new Date('2026-04-10T00:00:00.000Z'),
+      source: 'vitest',
+    });
+    expect(xml).toContain('<property key="generatedAt">2026-04-10T00:00:00.000Z</property>');
+    expect(xml).toContain('<property key="source">vitest</property>');
+    expect(xml).toContain('<property key="count">1</property>');
+  });
+
+  it('emits sample metadata as property children', () => {
+    const xml = serializeMaterialsToMaiml([sample]);
+    expect(xml).toContain('<material id="MAT-0001">');
+    expect(xml).toContain('<property key="SampleName">SUS316L 低炭素ステンレス</property>');
+    expect(xml).toContain('<property key="Category">金属合金</property>');
+    expect(xml).toContain('<property key="Composition">Fe-17Cr-12Ni-2Mo-0.03C</property>');
+    expect(xml).toContain('<property key="Author">山田 研</property>');
+  });
+
+  it('emits each numeric measurement as a <result> with content', () => {
+    const xml = serializeMaterialsToMaiml([sample]);
+    expect(xml).toContain('<result sampleRef="MAT-0001">');
+    expect(xml).toContain('<property key="name">hardness</property>');
+    expect(xml).toContain('<property key="unit">HV</property>');
+    expect(xml).toContain('<content>186</content>');
+    expect(xml).toContain('<property key="name">tensileStrength</property>');
+    expect(xml).toContain('<content>520</content>');
+    expect(xml).toContain('<property key="name">density</property>');
+    expect(xml).toContain('<content>7.98</content>');
+  });
+
+  it('escapes XML special characters in text content', () => {
+    const xml = serializeMaterialsToMaiml([withXmlSpecials]);
+    expect(xml).toContain('A &amp; B &quot;Alloy&quot; &lt;test&gt;');
+    expect(xml).toContain('C&apos;arbon &amp; iron');
+    // Raw unescaped chars should not leak through
+    expect(xml).not.toMatch(/>A & B "Alloy" <test></);
+  });
+
+  it('omits Memo when empty', () => {
+    const xml = serializeMaterialsToMaiml([withXmlSpecials]);
+    expect(xml).not.toContain('<property key="Memo">');
+  });
+
+  it('omits proofStress result when material.pf is null', () => {
+    const xml = serializeMaterialsToMaiml([{ ...sample, pf: null }]);
+    expect(xml).not.toContain('<property key="name">proofStress</property>');
+  });
+});
+
+describe('parseMaimlToMaterials', () => {
+  it('round-trips a single material with all fields intact', () => {
+    const xml = serializeMaterialToMaiml(sample);
+    const { materials, warnings } = parseMaimlToMaterials(xml);
+    expect(warnings).toEqual([]);
+    expect(materials).toHaveLength(1);
+    expect(materials[0]).toMatchObject({
+      id: sample.id,
+      name: sample.name,
+      cat: sample.cat,
+      comp: sample.comp,
+      hv: sample.hv,
+      ts: sample.ts,
+      el: sample.el,
+      pf: sample.pf,
+      el2: sample.el2,
+      dn: sample.dn,
+      batch: sample.batch,
+      date: sample.date,
+      author: sample.author,
+      status: sample.status,
+      ai: sample.ai,
+      memo: sample.memo,
+    });
+  });
+
+  it('round-trips XML-special characters', () => {
+    const xml = serializeMaterialToMaiml(withXmlSpecials);
+    const { materials } = parseMaimlToMaterials(xml);
+    expect(materials[0].name).toBe('A & B "Alloy" <test>');
+    expect(materials[0].comp).toBe("C'arbon & iron");
+  });
+
+  it('round-trips multiple materials in a single document', () => {
+    const other = { ...sample, id: 'MAT-0002', name: 'Ti-6Al-4V', hv: 350 };
+    const xml = serializeMaterialsToMaiml([sample, other]);
+    const { materials } = parseMaimlToMaterials(xml);
+    expect(materials).toHaveLength(2);
+    expect(materials[0].id).toBe('MAT-0001');
+    expect(materials[1].id).toBe('MAT-0002');
+    expect(materials[1].hv).toBe(350);
+  });
+
+  it('reads header generatedAt and source', () => {
+    const xml = serializeMaterialsToMaiml([sample], {
+      generatedAt: new Date('2026-04-10T12:34:56.000Z'),
+      source: 'vitest',
+    });
+    const result = parseMaimlToMaterials(xml);
+    expect(result.generatedAt).toBe('2026-04-10T12:34:56.000Z');
+    expect(result.source).toBe('vitest');
+  });
+
+  it('throws on malformed XML', () => {
+    expect(() => parseMaimlToMaterials('<<not xml>>')).toThrow(/MaiML/);
+  });
+
+  it('throws when the root element is wrong', () => {
+    expect(() =>
+      parseMaimlToMaterials('<?xml version="1.0"?><other><hi/></other>')
+    ).toThrow(/ルート要素/);
+  });
+
+  it('rejects DOCTYPE declarations (Billion Laughs / XXE hardening)', () => {
+    const evil = `<?xml version="1.0"?>
+<!DOCTYPE lolz [<!ENTITY lol "lol"><!ENTITY lol2 "&lol;&lol;">]>
+<maiml><data><results></results></data></maiml>`;
+    expect(() => parseMaimlToMaterials(evil)).toThrow(/DOCTYPE/);
+  });
+
+  it('rejects documents exceeding MAIML_MAX_BYTES', () => {
+    const huge = '<?xml version="1.0"?><maiml>' + 'a'.repeat(11 * 1024 * 1024) + '</maiml>';
+    expect(() => parseMaimlToMaterials(huge)).toThrow(/ファイルサイズ/);
+  });
+
+  it('restores null proofStress when the result element was omitted', () => {
+    const xml = serializeMaterialToMaiml({ ...sample, pf: null });
+    const { materials } = parseMaimlToMaterials(xml);
+    expect(materials[0].pf).toBeNull();
+  });
+});
+
+describe('defaultMaimlFilename', () => {
+  it('produces a dated .maiml filename with the given prefix', () => {
+    const name = defaultMaimlFilename('matlens');
+    expect(name).toMatch(/^matlens_\d{4}-\d{2}-\d{2}\.maiml$/);
+  });
+});

--- a/src/services/maiml.ts
+++ b/src/services/maiml.ts
@@ -162,6 +162,11 @@ export function serializeMaterialToMaiml(
 
 // ----- Parsing -----
 
+// Hard ceiling on imported document size. Prevents a Billion-Laughs-style
+// entity expansion DoS from exhausting memory even though modern browser
+// DOMParsers already refuse external entities by default.
+export const MAIML_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
 export interface MaimlParseResult {
   materials: Material[];
   generatedAt: string | null;
@@ -196,6 +201,23 @@ function numberFrom(value: string | undefined, fallback: number | null = 0): num
  */
 export function parseMaimlToMaterials(xml: string): MaimlParseResult {
   const warnings: string[] = [];
+
+  // Hard size limit. Oversized files are almost always a bug or an attack
+  // (Billion Laughs entity expansion), so we refuse before even touching the
+  // XML parser.
+  if (xml.length > MAIML_MAX_BYTES) {
+    throw new Error(`MaiML: ファイルサイズが上限 (${MAIML_MAX_BYTES} bytes) を超えています`);
+  }
+
+  // Reject DOCTYPE declarations up-front. Modern browser DOMParsers already
+  // refuse to resolve external entities, but declining the entire DOCTYPE
+  // means we also sidestep the Billion-Laughs internal-entity attack and
+  // any parser that might accidentally honour them (e.g. a Node.js xmldom
+  // fallback in future tests). A well-formed MaiML file never needs one.
+  if (/<!DOCTYPE/i.test(xml)) {
+    throw new Error('MaiML: DOCTYPE 宣言を含むファイルは受け付けません');
+  }
+
   const parser = new DOMParser();
   const doc = parser.parseFromString(xml, 'application/xml');
 

--- a/src/services/maiml.ts
+++ b/src/services/maiml.ts
@@ -1,0 +1,301 @@
+// MaiML (Measurement Analysis Instrument Markup Language) — Matlens bridge.
+//
+// MaiML is an XML-based common format for measurement & analysis data,
+// standardized as JIS K 0200:2024 by the Japan Analytical Instruments
+// Manufacturers' Association (JAIMA). The schema is distributed as a set
+// of XSD files from https://github.com/tacyas/MaiML and also used in the
+// Digital Discovery 2025 reference paper.
+//
+// The schema models a measurement document as:
+//   <maiml>
+//     <data>
+//       <results>
+//         <material>
+//           <property key="SampleName">SUS316L</property>
+//           ...
+//         </material>
+//         <result>
+//           <property key="...">...</property>
+//           <content>...</content>
+//         </result>
+//       </results>
+//     </data>
+//   </maiml>
+//
+// Matlens' `Material` row is a flat summary of one such lifecycle, so we
+// serialize each Material as a `<material>` with key/value `<property>`
+// children for the sample metadata, plus a `<result>` per measurement
+// (hardness, tensile strength, etc.) where the numeric value lives inside
+// `<content>` and the unit/name are `<property>` children. Multiple
+// materials are wrapped in a single document so bulk export and import
+// share one parser path.
+//
+// The XSD targetNamespace is not yet vendored in this repo; once we ship
+// `vendor/maiml-schema/` this module will start emitting the official
+// `xmlns` attribute. Until then the document validates against the shape
+// referenced in the spec paper but intentionally omits the namespace URL
+// so downstream tooling doesn't lock onto a placeholder.
+//
+// References:
+//   - https://www.maiml.org/index_en.html
+//   - https://github.com/tacyas/MaiML
+//   - Digital Discovery 2025: https://pubs.rsc.org/en/content/articlehtml/2025/dd/d4dd00326h
+
+import type { Material, MaterialCategory, MaterialStatus } from '../types';
+
+// ----- Escape helpers -----
+
+function escapeXml(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function indent(depth: number): string {
+  return '  '.repeat(depth);
+}
+
+function propertyLine(depth: number, key: string, value: string | number | null | undefined): string {
+  const text = value === null || value === undefined ? '' : String(value);
+  return `${indent(depth)}<property key="${escapeXml(key)}">${escapeXml(text)}</property>`;
+}
+
+// Measurement results emitted per material. Keeping this list close to the
+// serializer makes it trivial to add new metrics (e.g. surface roughness)
+// without grepping the codebase.
+interface MeasurementDescriptor {
+  name: string;
+  unit: string;
+  value: number | null;
+}
+
+function measurementsFor(material: Material): MeasurementDescriptor[] {
+  return [
+    { name: 'hardness', unit: 'HV', value: material.hv },
+    { name: 'tensileStrength', unit: 'MPa', value: material.ts },
+    { name: 'elasticModulus', unit: 'GPa', value: material.el },
+    { name: 'elongation', unit: '%', value: material.el2 },
+    { name: 'density', unit: 'g/cm3', value: material.dn },
+    { name: 'proofStress', unit: 'MPa', value: material.pf },
+  ];
+}
+
+// ----- Serialization -----
+
+interface MaimlSerializeOptions {
+  /** Override the timestamp embedded in the document header (mainly for tests) */
+  generatedAt?: Date;
+  /** Optional free-form source tag recorded in the header */
+  source?: string;
+}
+
+/**
+ * Serialize one or more Material records to a MaiML-shaped XML document.
+ * The output is a well-formed XML string that callers can write to a file
+ * (extension `.maiml` or `.xml`) or copy to the clipboard.
+ */
+export function serializeMaterialsToMaiml(
+  materials: Material[],
+  options: MaimlSerializeOptions = {}
+): string {
+  const generatedAt = (options.generatedAt ?? new Date()).toISOString();
+  const source = options.source ?? 'matlens';
+
+  const lines: string[] = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<maiml version="1.0">');
+  lines.push(`${indent(1)}<header>`);
+  lines.push(propertyLine(2, 'generatedAt', generatedAt));
+  lines.push(propertyLine(2, 'source', source));
+  lines.push(propertyLine(2, 'count', materials.length));
+  lines.push(`${indent(1)}</header>`);
+  lines.push(`${indent(1)}<data>`);
+  lines.push(`${indent(2)}<results>`);
+
+  for (const m of materials) {
+    lines.push(`${indent(3)}<material id="${escapeXml(m.id)}">`);
+    lines.push(propertyLine(4, 'SampleId', m.id));
+    lines.push(propertyLine(4, 'SampleName', m.name));
+    lines.push(propertyLine(4, 'Category', m.cat));
+    lines.push(propertyLine(4, 'Composition', m.comp));
+    lines.push(propertyLine(4, 'Batch', m.batch));
+    lines.push(propertyLine(4, 'RegisteredOn', m.date));
+    lines.push(propertyLine(4, 'Author', m.author));
+    lines.push(propertyLine(4, 'Status', m.status));
+    lines.push(propertyLine(4, 'AiDetected', m.ai ? 'true' : 'false'));
+    if (m.memo) {
+      lines.push(propertyLine(4, 'Memo', m.memo));
+    }
+    lines.push(`${indent(3)}</material>`);
+
+    for (const measurement of measurementsFor(m)) {
+      if (measurement.value === null) continue;
+      lines.push(`${indent(3)}<result sampleRef="${escapeXml(m.id)}">`);
+      lines.push(propertyLine(4, 'name', measurement.name));
+      lines.push(propertyLine(4, 'unit', measurement.unit));
+      lines.push(`${indent(4)}<content>${escapeXml(measurement.value)}</content>`);
+      lines.push(`${indent(3)}</result>`);
+    }
+  }
+
+  lines.push(`${indent(2)}</results>`);
+  lines.push(`${indent(1)}</data>`);
+  lines.push('</maiml>');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Convenience for serializing a single material. Returns the same XML shape
+ * as the bulk serializer so downstream tooling can treat a single-sample
+ * document identically.
+ */
+export function serializeMaterialToMaiml(
+  material: Material,
+  options: MaimlSerializeOptions = {}
+): string {
+  return serializeMaterialsToMaiml([material], options);
+}
+
+// ----- Parsing -----
+
+export interface MaimlParseResult {
+  materials: Material[];
+  generatedAt: string | null;
+  source: string | null;
+  warnings: string[];
+}
+
+function collectProperties(parent: Element | null): Record<string, string> {
+  const map: Record<string, string> = {};
+  if (!parent) return map;
+  // Only direct <property> children belong to this element's property bag.
+  for (const child of Array.from(parent.children)) {
+    if (child.localName !== 'property') continue;
+    const key = child.getAttribute('key');
+    if (!key) continue;
+    map[key] = child.textContent?.trim() ?? '';
+  }
+  return map;
+}
+
+function numberFrom(value: string | undefined, fallback: number | null = 0): number | null {
+  if (value === undefined || value === '') return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Parse a MaiML XML string back into Matlens Material records. Unknown
+ * elements are ignored; missing numeric measurements fall back to 0 with a
+ * warning so the caller can surface import issues to the user instead of
+ * failing the whole file.
+ */
+export function parseMaimlToMaterials(xml: string): MaimlParseResult {
+  const warnings: string[] = [];
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, 'application/xml');
+
+  const parseError = doc.querySelector('parsererror');
+  if (parseError) {
+    throw new Error('MaiML: XML のパースに失敗しました');
+  }
+
+  const root = doc.documentElement;
+  if (!root || root.localName !== 'maiml') {
+    throw new Error('MaiML: ルート要素が <maiml> ではありません');
+  }
+
+  const header = root.getElementsByTagName('header')[0] ?? null;
+  const headerProps = collectProperties(header);
+  const generatedAt = headerProps.generatedAt || null;
+  const source = headerProps.source || null;
+
+  // Walk to <results> and collect materials. We look up nested results (the
+  // measurement values) by sampleRef so bulk documents round-trip cleanly.
+  const resultsEls = root.getElementsByTagName('results');
+  if (resultsEls.length === 0) {
+    return { materials: [], generatedAt, source, warnings };
+  }
+  const resultsRoot = resultsEls[0];
+
+  const materialEls = resultsRoot.getElementsByTagName('material');
+  const measurementByRef: Record<string, Record<string, number>> = {};
+
+  for (const resultEl of Array.from(resultsRoot.getElementsByTagName('result'))) {
+    const sampleRef = resultEl.getAttribute('sampleRef') || '';
+    if (!sampleRef) continue;
+    const props = collectProperties(resultEl);
+    const name = props.name;
+    if (!name) continue;
+    const contentEl = resultEl.getElementsByTagName('content')[0] ?? null;
+    const text = contentEl?.textContent?.trim() ?? '';
+    const num = numberFrom(text, null);
+    if (num === null) continue;
+    if (!measurementByRef[sampleRef]) measurementByRef[sampleRef] = {};
+    measurementByRef[sampleRef][name] = num;
+  }
+
+  const materials: Material[] = [];
+
+  for (const el of Array.from(materialEls)) {
+    const idAttr = el.getAttribute('id') || '';
+    const props = collectProperties(el);
+    const id = idAttr || props.SampleId || '';
+    if (!id) {
+      warnings.push('id 属性も SampleId property も無い <material> をスキップしました');
+      continue;
+    }
+
+    const measurements = measurementByRef[id] || {};
+    if (measurements.hardness === undefined || measurements.tensileStrength === undefined) {
+      warnings.push(`${id}: 必須の測定値 (hardness / tensileStrength) が不足しています`);
+    }
+
+    const material: Material = {
+      id,
+      name: props.SampleName ?? '',
+      cat: (props.Category as MaterialCategory) || '金属合金',
+      hv: measurements.hardness ?? 0,
+      ts: measurements.tensileStrength ?? 0,
+      el: measurements.elasticModulus ?? 0,
+      pf: measurements.proofStress ?? null,
+      el2: measurements.elongation ?? 0,
+      dn: measurements.density ?? 0,
+      comp: props.Composition ?? '',
+      batch: props.Batch ?? '',
+      date: props.RegisteredOn ?? '',
+      author: props.Author ?? '',
+      status: (props.Status as MaterialStatus) || '登録済',
+      ai: props.AiDetected === 'true',
+      memo: props.Memo ?? '',
+    };
+
+    materials.push(material);
+  }
+
+  return { materials, generatedAt, source, warnings };
+}
+
+// ----- File helpers -----
+
+export function downloadMaimlFile(xml: string, filename: string): void {
+  const blob = new Blob([xml], { type: 'application/xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename.endsWith('.maiml') || filename.endsWith('.xml')
+    ? filename
+    : `${filename}.maiml`;
+  a.click();
+  // Give the browser a moment to start the download before revoking the URL.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export function defaultMaimlFilename(prefix = 'matlens'): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `${prefix}_${date}.maiml`;
+}


### PR DESCRIPTION
## Summary

Matlens の主要データ交換フォーマットとして **MaiML** (Measurement Analysis Instrument Markup Language / JIS K 0200:2024) を導入します。Refs #2

- `src/services/maiml.ts` — シリアライザ・パーサ・ファイルユーティリティ
- ExportModal に MaiML を**推奨形式**として第一選択で表示
- 新規 `ImportModal` — .maiml / .xml / .json の読み込みに対応
- MaterialListPage にインポートボタン、DetailPage に単品 MaiML エクスポートボタン追加
- CSV / JSON / Markdown / PDF は従来通り併存（常に選択肢）

## MaiML XML 構造

論文 [Digital Discovery 2025](https://pubs.rsc.org/en/content/articlehtml/2025/dd/d4dd00326h) のリファレンス階層に準拠:

```xml
<maiml version=\"1.0\">
  <header>
    <property key=\"generatedAt\">2026-04-10T…</property>
    <property key=\"source\">matlens</property>
    <property key=\"count\">N</property>
  </header>
  <data>
    <results>
      <material id=\"MAT-0368\">
        <property key=\"SampleName\">FRM チタン基複合材</property>
        <property key=\"Category\">複合材料</property>
        <property key=\"Composition\">Ti-6Al-4V + SiC fiber</property>
        …
      </material>
      <result sampleRef=\"MAT-0368\">
        <property key=\"name\">hardness</property>
        <property key=\"unit\">HV</property>
        <content>400</content>
      </result>
      …
    </results>
  </data>
</maiml>
```

## 未対応 / 今後

- XSD `targetNamespace` の確定（現状は namespace 省略、コード側に TODO コメント）
- 来歴データ (provenance) の保持 — SHA-256 ハッシュ + 原本XML を Material に添付
- Process / Event のタイムライン表現（MatLens 2.0 の Digital Process Log Viewer で対応予定）
- XSD ベースの Zod / TypeBox 型生成

## Test plan

- [ ] 材料一覧画面の「インポート」ボタン → サンプル MaiML を読み込み → 件数表示を確認
- [ ] 「エクスポート」モーダルで MaiML(推奨) を選択 → ダウンロードされたファイルを再インポートして round-trip を確認
- [ ] 詳細ページの「MaiML」ボタン → 単品 .maiml ダウンロードを確認
- [ ] CSV / JSON / Markdown / PDF の既存エクスポートが従来通り動作することを確認
- [ ] インポート時、ID 重複がある場合はスキップされて toast に反映される


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * MaiML形式およびMarkdown形式でのエクスポートに対応（推奨のMaiML／全件MaiML／Markdownを追加）
  * MaiML/XML/JSONファイルからのインポート機能を実装（ファイル検出・プレビュー・警告表示・取り込み）
  * マテリアル一覧と詳細ページにインポート・エクスポートボタンを追加

* **テスト**
  * MaiMLのシリアライズ／パースに関する単体テストを追加（正常系・エラーハンドリング・境界条件）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
