### PR TITLE
feat(announcements): お知らせバナー + タブ + 未読バッジ

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -141,6 +141,8 @@ export function App() {
           embStatus={embedding.status} embCount={embedding.embCount} embEngine={embedding.engine}
           onGlobalSearch={handleGlobalSearch} globalQuery={globalQuery} setGlobalQuery={setGlobalQuery}
           db={db} onDetail={showDetail}
+          unreadNotifications={announcements.unreadCount}
+          onOpenNotifications={() => openSupportPanel('news')}
         />
         {announcements.latestUnread && !bannerHidden && (
           <AnnouncementBanner

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,7 +160,7 @@ export function App() {
             dbCount={db.length}
             embStatus={embedding.status} embCount={embedding.embCount}
           />
-          <main id="main" className="flex-1 overflow-y-auto p-6 flex flex-col min-h-0" role="main" aria-label="メインコンテンツ">
+          <main id="main" className="flex-1 overflow-y-auto p-3 sm:p-4 md:p-6 flex flex-col min-h-0" role="main" aria-label="メインコンテンツ">
             {renderPage()}
           </main>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,10 @@ import { Icon } from './components/Icon';
 import { Topbar } from './components/Topbar';
 import { Sidebar } from './components/Sidebar';
 import { SupportPanel } from './components/SupportPanel';
+import { AnnouncementBanner } from './components/AnnouncementBanner';
 import { ToastHub } from './components/molecules';
 import { Typing } from './components/atoms';
+import { useAnnouncements } from './hooks/useAnnouncements';
 import { DashboardPage } from './pages/Dashboard';
 import { MaterialListPage } from './pages/MaterialList';
 import { MaterialFormPage } from './pages/MaterialForm';
@@ -52,9 +54,17 @@ export function App() {
   const ai = useAI();
   const claude = ai;
   const [settingsVisible, setSettingsVisible] = useState(false);
+  const [settingsInitialTab, setSettingsInitialTab] = useState<string>('help');
   const [globalQuery, setGlobalQuery] = useState('');
   const [ragInitialQuery, setRagInitialQuery] = useState('');
   const [simInitialBase, setSimInitialBase] = useState('');
+  const announcements = useAnnouncements();
+  const [bannerHidden, setBannerHidden] = useState(false);
+
+  const openSupportPanel = (tab: string = 'help') => {
+    setSettingsInitialTab(tab);
+    setSettingsVisible(true);
+  };
 
   useEffect(() => { installMockAPI(() => db, dispatch); }, []);
 
@@ -132,6 +142,14 @@ export function App() {
           onGlobalSearch={handleGlobalSearch} globalQuery={globalQuery} setGlobalQuery={setGlobalQuery}
           db={db} onDetail={showDetail}
         />
+        {announcements.latestUnread && !bannerHidden && (
+          <AnnouncementBanner
+            announcement={announcements.latestUnread}
+            unreadCount={announcements.unreadCount}
+            onDismiss={() => { announcements.markAsSeen(); setBannerHidden(true); }}
+            onOpenAll={() => { openSupportPanel('news'); setBannerHidden(true); }}
+          />
+        )}
         <div className="flex flex-1 overflow-hidden">
           <Sidebar
             currentPage={page} onNav={navTo}
@@ -145,11 +163,28 @@ export function App() {
           </main>
         </div>
       </div>
-      <SupportPanel ai={ai} visible={settingsVisible} onClose={() => setSettingsVisible(false)} onNav={navTo} />
-      <button onClick={() => setSettingsVisible(v => !v)}
+      <SupportPanel
+        ai={ai}
+        visible={settingsVisible}
+        onClose={() => setSettingsVisible(false)}
+        onNav={navTo}
+        initialTab={settingsInitialTab}
+        announcements={announcements}
+      />
+      <button
+        onClick={() => { if (settingsVisible) setSettingsVisible(false); else openSupportPanel('help'); }}
         className="fixed bottom-6 right-6 z-[2000] flex items-center justify-center w-12 h-12 rounded-full bg-accent text-white shadow-lg hover:bg-[var(--accent-hover)] transition-all"
-        title="サポート / ヘルプ / AI設定">
+        title={announcements.unreadCount > 0 ? `サポート / 未読 ${announcements.unreadCount} 件` : 'サポート / ヘルプ / AI設定'}
+      >
         <Icon name={settingsVisible ? 'close' : 'help'} size={20} />
+        {announcements.unreadCount > 0 && !settingsVisible && (
+          <span
+            aria-hidden="true"
+            className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-[var(--err)] text-white text-[10px] font-bold flex items-center justify-center border-2 border-[var(--bg-base)]"
+          >
+            {announcements.unreadCount > 9 ? '9+' : announcements.unreadCount}
+          </span>
+        )}
       </button>
       <ToastHub />
     </AppCtx.Provider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useReducer, useCallback, lazy, Suspense } from 'react';
+import { useState, useEffect, useReducer, useCallback, useRef, lazy, Suspense } from 'react';
 import type { Toast, AppContextValue } from './types';
 import { AppCtx, dbReducer } from './context/AppContext';
 import { INITIAL_DB } from './data/initialDb';
@@ -39,13 +39,32 @@ const LazyFallback = () => (
   </div>
 );
 
-type NavEntry = { page: string; detailId: string | null };
+// Hash routing — persisted in window.location so reload / browser back-forward
+// / copy-paste URL all "just work". Detail / edit pages embed the record id as
+// a second segment (#/detail/MAT-0368); everything else is a single segment.
+// One-shot query state (rag initial query, sim base material) is intentionally
+// NOT persisted — those are one-action kickstarts that would be annoying to
+// replay on reload.
+function parseHash(): { page: string; detailId: string | null } {
+  if (typeof window === 'undefined') return { page: 'dash', detailId: null };
+  const parts = window.location.hash.slice(1).split('/').filter(Boolean);
+  if (parts.length === 0) return { page: 'dash', detailId: null };
+  return { page: parts[0], detailId: parts[1] ?? null };
+}
+
+function buildHash(page: string, detailId: string | null): string {
+  if (detailId && (page === 'detail' || page === 'edit')) {
+    return `#/${page}/${detailId}`;
+  }
+  return `#/${page}`;
+}
 
 export function App() {
   const [db, dispatch] = useReducer(dbReducer, INITIAL_DB);
-  const [page, setPage] = useState('dash');
-  const [detailId, setDetailId] = useState<string | null>(null);
-  const [history, setHistory] = useState<NavEntry[]>([]);
+  const initialRoute = parseHash();
+  const [page, setPage] = useState(initialRoute.page);
+  const [detailId, setDetailId] = useState<string | null>(initialRoute.detailId);
+  const isFirstRender = useRef(true);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -76,18 +95,60 @@ export function App() {
     setTimeout(() => setToasts(t => t.filter(x => x.id !== id)), 3200);
   }, []);
 
-  // Push the current page onto history before navigating to a new one
-  const pushHistory = () => {
-    setHistory(h => {
-      const last = h[h.length - 1];
-      // Avoid pushing duplicate consecutive entries
-      if (last && last.page === page && last.detailId === detailId) return h;
-      return [...h, { page, detailId }];
-    });
-  };
+  // Write state back to location.hash so reload / back-forward buttons work.
+  // The first render uses replaceState so we don't inject an extra history
+  // entry for the initial paint.
+  useEffect(() => {
+    const nextHash = buildHash(page, detailId);
+    if (window.location.hash === nextHash) return;
+    if (isFirstRender.current) {
+      window.history.replaceState(null, '', nextHash);
+    } else {
+      window.history.pushState(null, '', nextHash);
+    }
+  }, [page, detailId]);
+
+  useEffect(() => {
+    isFirstRender.current = false;
+  }, []);
+
+  // Browser back / forward (including Cmd+[, Cmd+], and the buttons) fires
+  // popstate — sync our React state back from the URL.
+  useEffect(() => {
+    const handler = () => {
+      const next = parseHash();
+      setPage(next.page);
+      setDetailId(next.detailId);
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  // Cmd+Arrow (macOS) / Alt+Arrow (Windows / Linux) should walk the browser
+  // history just like the back/forward buttons, but only when the user isn't
+  // editing a text field (Cmd+Left / Cmd+Right are also cursor navigation in
+  // <input> on macOS, and we must not hijack them there).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (target?.isContentEditable) return;
+      if (!(e.metaKey || e.altKey)) return;
+      if (e.ctrlKey || e.shiftKey) return;
+      if (e.key === 'ArrowLeft' || e.key === '[') {
+        e.preventDefault();
+        window.history.back();
+      } else if (e.key === 'ArrowRight' || e.key === ']') {
+        e.preventDefault();
+        window.history.forward();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   const navTo = (p: string) => {
-    pushHistory();
     if (p.startsWith('edit_')) { setDetailId(p.slice(5)); setPage('edit'); return; }
     if (p.startsWith('detail_')) { setDetailId(p.slice(7)); setPage('detail'); return; }
     if (p.startsWith('rag:')) { setRagInitialQuery(p.slice(4)); setPage('rag'); return; }
@@ -95,17 +156,11 @@ export function App() {
     setPage(p); if (p !== 'detail') setDetailId(null);
   };
 
-  const goBack = () => {
-    setHistory(h => {
-      if (h.length === 0) { setPage('list'); setDetailId(null); return h; }
-      const prev = h[h.length - 1];
-      setPage(prev.page);
-      setDetailId(prev.detailId);
-      return h.slice(0, -1);
-    });
-  };
+  const goBack = useCallback(() => {
+    window.history.back();
+  }, []);
 
-  const showDetail = (id: string) => { pushHistory(); setDetailId(id); setPage('detail'); };
+  const showDetail = (id: string) => { setDetailId(id); setPage('detail'); };
   const handleGlobalSearch = useCallback((q: string) => { setGlobalQuery(q); setPage('list'); }, []);
 
   const renderPage = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,11 @@ export function App() {
   const [page, setPage] = useState(initialRoute.page);
   const [detailId, setDetailId] = useState<string | null>(initialRoute.detailId);
   const isFirstRender = useRef(true);
+  // Track how many hash navigations the app itself has pushed. Used by
+  // goBack() to know whether window.history.back() will stay inside Matlens
+  // or step off the site entirely (e.g. when the user landed on a shared
+  // detail URL with no prior in-app navigation).
+  const navDepth = useRef(0);
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
@@ -105,6 +110,7 @@ export function App() {
       window.history.replaceState(null, '', nextHash);
     } else {
       window.history.pushState(null, '', nextHash);
+      navDepth.current += 1;
     }
   }, [page, detailId]);
 
@@ -113,12 +119,16 @@ export function App() {
   }, []);
 
   // Browser back / forward (including Cmd+[, Cmd+], and the buttons) fires
-  // popstate — sync our React state back from the URL.
+  // popstate — sync our React state back from the URL. Every popstate means
+  // the user walked one entry in the browser history, so decrement the
+  // counter (but never below zero — forward navigation is also popstate and
+  // we don't track a separate forward depth).
   useEffect(() => {
     const handler = () => {
       const next = parseHash();
       setPage(next.page);
       setDetailId(next.detailId);
+      navDepth.current = Math.max(0, navDepth.current - 1);
     };
     window.addEventListener('popstate', handler);
     return () => window.removeEventListener('popstate', handler);
@@ -157,7 +167,15 @@ export function App() {
   };
 
   const goBack = useCallback(() => {
-    window.history.back();
+    if (navDepth.current > 0) {
+      window.history.back();
+    } else {
+      // No in-app navigations to pop (e.g. user opened a shared detail URL
+      // directly). Route to the material list instead of letting back()
+      // navigate off the site.
+      setPage('list');
+      setDetailId(null);
+    }
   }, []);
 
   const showDetail = (id: string) => { setDetailId(id); setPage('detail'); };

--- a/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -60,15 +60,15 @@ export const AnnouncementBanner = ({
       aria-live="polite"
       className={`${style.bg} border-b border-[var(--border-faint)]`}
     >
-      <div className="flex items-center gap-3 px-4 py-2">
+      <div className="flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2">
         <Icon name={style.icon} size={14} className={`${style.accent} flex-shrink-0`} />
         <span
-          className={`text-[10px] font-bold tracking-[.08em] uppercase ${style.accent} flex-shrink-0`}
+          className={`text-[10px] font-bold tracking-[.08em] uppercase ${style.accent} flex-shrink-0 hidden sm:inline`}
         >
           {style.label}
         </span>
         <div className="flex-1 min-w-0 flex items-center gap-2">
-          <span className="text-[12px] text-text-lo flex-shrink-0 hidden sm:inline">
+          <span className="text-[12px] text-text-lo flex-shrink-0 hidden md:inline">
             {announcement.date}
           </span>
           <span className="text-[12px] font-semibold text-text-hi truncate">
@@ -78,11 +78,12 @@ export const AnnouncementBanner = ({
         <button
           type="button"
           onClick={onOpenAll}
-          className={`text-[11px] font-semibold ${style.accent} hover:underline flex-shrink-0 font-ui`}
+          className={`text-[11px] font-semibold ${style.accent} hover:underline flex-shrink-0 font-ui whitespace-nowrap`}
         >
-          すべて見る
+          <span className="hidden sm:inline">すべて見る</span>
+          <span className="sm:hidden">詳細</span>
           {unreadCount > 1 && (
-            <span className="ml-1 opacity-70">（他 {unreadCount - 1} 件）</span>
+            <span className="ml-1 opacity-70 hidden md:inline">（他 {unreadCount - 1} 件）</span>
           )}
         </button>
         <button

--- a/src/components/AnnouncementBanner/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner/AnnouncementBanner.tsx
@@ -1,0 +1,99 @@
+// Slim sticky banner shown just below the topbar when there are unread
+// announcements. Clicking "すべて見る" opens the SupportPanel on the
+// announcements tab, and the × button marks every current unread entry
+// as seen so returning users don't get nagged.
+//
+// Designed to be visible-but-quiet: one line of text, one accent color
+// based on the announcement type, and dismissible.
+
+import { Icon, IconName } from '../Icon';
+import type { Announcement, AnnouncementType } from '../../data/announcements';
+
+interface AnnouncementBannerProps {
+  announcement: Announcement;
+  unreadCount: number;
+  onDismiss: () => void;
+  onOpenAll: () => void;
+}
+
+const TYPE_STYLE: Record<
+  AnnouncementType,
+  { icon: IconName; bg: string; accent: string; label: string }
+> = {
+  feature: {
+    icon: 'spark',
+    bg: 'bg-ai-dim',
+    accent: 'text-ai',
+    label: 'NEW',
+  },
+  fix: {
+    icon: 'check',
+    bg: 'bg-[var(--ok-dim)]',
+    accent: 'text-ok',
+    label: 'FIX',
+  },
+  info: {
+    icon: 'info',
+    bg: 'bg-accent-dim',
+    accent: 'text-accent',
+    label: 'INFO',
+  },
+  warn: {
+    icon: 'warning',
+    bg: 'bg-[var(--warn-dim)]',
+    accent: 'text-warn',
+    label: 'NOTICE',
+  },
+};
+
+export const AnnouncementBanner = ({
+  announcement,
+  unreadCount,
+  onDismiss,
+  onOpenAll,
+}: AnnouncementBannerProps) => {
+  const style = TYPE_STYLE[announcement.type];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`${style.bg} border-b border-[var(--border-faint)]`}
+    >
+      <div className="flex items-center gap-3 px-4 py-2">
+        <Icon name={style.icon} size={14} className={`${style.accent} flex-shrink-0`} />
+        <span
+          className={`text-[10px] font-bold tracking-[.08em] uppercase ${style.accent} flex-shrink-0`}
+        >
+          {style.label}
+        </span>
+        <div className="flex-1 min-w-0 flex items-center gap-2">
+          <span className="text-[12px] text-text-lo flex-shrink-0 hidden sm:inline">
+            {announcement.date}
+          </span>
+          <span className="text-[12px] font-semibold text-text-hi truncate">
+            {announcement.title}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onOpenAll}
+          className={`text-[11px] font-semibold ${style.accent} hover:underline flex-shrink-0 font-ui`}
+        >
+          すべて見る
+          {unreadCount > 1 && (
+            <span className="ml-1 opacity-70">（他 {unreadCount - 1} 件）</span>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="お知らせを閉じる"
+          className="flex items-center justify-center w-5 h-5 rounded hover:bg-hover text-text-lo hover:text-text-hi transition-colors flex-shrink-0"
+        >
+          <Icon name="close" size={12} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AnnouncementBanner/index.ts
+++ b/src/components/AnnouncementBanner/index.ts
@@ -1,0 +1,1 @@
+export { AnnouncementBanner } from './AnnouncementBanner';

--- a/src/components/SupportPanel/SupportPanel.tsx
+++ b/src/components/SupportPanel/SupportPanel.tsx
@@ -1,19 +1,43 @@
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { Icon, IconName } from '../Icon';
 import { Button, Badge, Input, FormGroup, Divider, ProgressBar } from '../atoms';
 import { AppCtx } from '../../context/AppContext';
 import { PROVIDERS, SUPPORT_TABS, FAQ_ITEMS, STORYBOOK_URL } from '../../data/constants';
 import type { AIHook, AppContextValue } from '../../types';
+import type { AnnouncementsState } from '../../hooks/useAnnouncements';
+import type { AnnouncementType } from '../../data/announcements';
 
 interface SupportPanelProps {
   ai: AIHook;
   visible: boolean;
   onClose: () => void;
   onNav: (page: string) => void;
+  initialTab?: string;
+  announcements?: AnnouncementsState;
 }
 
-export const SupportPanel = ({ ai, visible, onClose, onNav }: SupportPanelProps) => {
-  const [tab, setTab] = useState('help');
+const ANNOUNCEMENT_TYPE_LABEL: Record<AnnouncementType, { label: string; color: string }> = {
+  feature: { label: 'NEW', color: 'text-ai' },
+  fix: { label: 'FIX', color: 'text-ok' },
+  info: { label: 'INFO', color: 'text-accent' },
+  warn: { label: 'NOTICE', color: 'text-warn' },
+};
+
+export const SupportPanel = ({ ai, visible, onClose, onNav, initialTab = 'help', announcements }: SupportPanelProps) => {
+  const [tab, setTab] = useState(initialTab);
+
+  // When the parent re-opens the panel with a different target tab (e.g. news),
+  // reflect that on every visible transition.
+  useEffect(() => {
+    if (visible) setTab(initialTab);
+  }, [visible, initialTab]);
+
+  // Open the news tab → flush the unread state so the badge clears.
+  useEffect(() => {
+    if (visible && tab === 'news' && announcements && announcements.unreadCount > 0) {
+      announcements.markAsSeen();
+    }
+  }, [visible, tab, announcements]);
   const [keyInput, setKeyInput] = useState(ai.ownKey ? '••••••••' : '');
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle');
@@ -51,12 +75,25 @@ export const SupportPanel = ({ ai, visible, onClose, onNav }: SupportPanelProps)
         <button onClick={onClose} className="text-text-lo hover:text-text-hi"><Icon name="close" size={14}/></button>
       </div>
       <div className="flex border-b border-[var(--border-faint)] px-4 gap-1 flex-shrink-0">
-        {SUPPORT_TABS.map(t => (
-          <button key={t.id} onClick={() => setTab(t.id)}
-            className={`flex items-center gap-1 px-3 py-2 text-[12px] font-semibold border-b-2 transition-all font-ui ${tab === t.id ? 'border-accent text-accent' : 'border-transparent text-text-lo hover:text-text-md'}`}>
-            <Icon name={t.icon as IconName} size={12} />{t.label}
-          </button>
-        ))}
+        {SUPPORT_TABS.map(t => {
+          const isNews = t.id === 'news';
+          const unread = isNews ? announcements?.unreadCount ?? 0 : 0;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`relative flex items-center gap-1 px-3 py-2 text-[12px] font-semibold border-b-2 transition-all font-ui ${tab === t.id ? 'border-accent text-accent' : 'border-transparent text-text-lo hover:text-text-md'}`}
+            >
+              <Icon name={t.icon as IconName} size={12} />
+              {t.label}
+              {unread > 0 && (
+                <span className="ml-0.5 min-w-[16px] h-[16px] px-1 rounded-full bg-[var(--err)] text-white text-[9px] font-bold flex items-center justify-center">
+                  {unread > 9 ? '9+' : unread}
+                </span>
+              )}
+            </button>
+          );
+        })}
       </div>
       <div className="flex-1 overflow-y-auto p-4">
         {tab === 'help' && (
@@ -92,6 +129,39 @@ export const SupportPanel = ({ ai, visible, onClose, onNav }: SupportPanelProps)
                 <div className="text-[11px] text-text-lo">コンポーネント・デザインシステムを参照</div>
               </div>
             </a>
+          </div>
+        )}
+        {tab === 'news' && (
+          <div className="flex flex-col gap-3">
+            <div className="text-[12px] text-text-lo">最新の更新履歴と運用情報をまとめています。</div>
+            {announcements && announcements.all.length > 0 ? (
+              <ul className="flex flex-col gap-2" role="list">
+                {announcements.all.map((a, i) => {
+                  const typeInfo = ANNOUNCEMENT_TYPE_LABEL[a.type];
+                  const isUnread = i < announcements.unreadCount;
+                  return (
+                    <li
+                      key={a.id}
+                      className={`rounded-md border p-3 transition-colors ${isUnread ? 'border-accent bg-accent-dim/40' : 'border-[var(--border-faint)] bg-raised'}`}
+                    >
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className={`text-[10px] font-bold tracking-[.06em] uppercase ${typeInfo.color}`}>
+                          {typeInfo.label}
+                        </span>
+                        <span className="text-[11px] text-text-lo font-mono">{a.date}</span>
+                        {isUnread && (
+                          <Badge variant="red" className="text-[9px]">未読</Badge>
+                        )}
+                      </div>
+                      <div className="text-[13px] font-bold text-text-hi leading-snug">{a.title}</div>
+                      <p className="text-[12px] text-text-md mt-1 leading-relaxed">{a.body}</p>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="text-[12px] text-text-lo text-center py-6">お知らせはありません</div>
+            )}
           </div>
         )}
         {tab === 'faq' && (

--- a/src/components/Topbar/Topbar.tsx
+++ b/src/components/Topbar/Topbar.tsx
@@ -18,9 +18,11 @@ interface TopbarProps {
   setGlobalQuery: (q: string) => void;
   db: Material[];
   onDetail: (id: string) => void;
+  unreadNotifications?: number;
+  onOpenNotifications?: () => void;
 }
 
-export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, embEngine, onGlobalSearch, globalQuery, setGlobalQuery, db, onDetail }: TopbarProps) => {
+export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, embEngine, onGlobalSearch, globalQuery, setGlobalQuery, db, onDetail, unreadNotifications = 0, onOpenNotifications }: TopbarProps) => {
   const THEMES = [
     { id: 'light', label: 'Light' },
     { id: 'dark',  label: 'Dark' },
@@ -188,6 +190,24 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
           </button>
         ))}
       </div>
+      <Tooltip label={unreadNotifications > 0 ? `お知らせ (未読 ${unreadNotifications} 件)` : 'お知らせ'} placement="bottom">
+        <button
+          type="button"
+          onClick={onOpenNotifications}
+          className="relative flex items-center justify-center w-9 h-9 rounded-full border border-white/20 bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all duration-200"
+          aria-label={unreadNotifications > 0 ? `お知らせ 未読 ${unreadNotifications} 件` : 'お知らせ'}
+        >
+          <Icon name="info" size={15} />
+          {unreadNotifications > 0 && (
+            <span
+              aria-hidden="true"
+              className="absolute -top-0.5 -right-0.5 min-w-[16px] h-[16px] px-1 rounded-full bg-[var(--err)] text-white text-[9px] font-bold flex items-center justify-center border-[1.5px] border-[var(--topbar-bg)]"
+            >
+              {unreadNotifications > 9 ? '9+' : unreadNotifications}
+            </span>
+          )}
+        </button>
+      </Tooltip>
       <Tooltip label={embStatus === "fallback" ? "キーワード検索モード" : `ベクトル検索: ${vecStatusLabel}`} placement="left">
         <button className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold border transition-all duration-200 ${embStatus === 'ready' ? 'bg-vec-dim text-vec border-[var(--vec-mid)]' : 'bg-white/10 text-white/80 border-white/20'}`} aria-label="ベクトル検索ページへ">
           <Icon name="embed" size={12} />

--- a/src/components/Topbar/Topbar.tsx
+++ b/src/components/Topbar/Topbar.tsx
@@ -105,23 +105,23 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
   };
 
   return (
-    <header className="flex-shrink-0 flex items-center gap-3 px-5 h-[52px] border-b border-[rgba(255,255,255,.06)]" style={{ background: 'var(--topbar-bg)' }} role="banner">
+    <header className="flex-shrink-0 flex items-center gap-3 px-5 h-[52px] border-b border-[rgba(255,255,255,.06)] overflow-x-auto no-scrollbar" style={{ background: 'var(--topbar-bg)' }} role="banner">
       <Tooltip label="サイドバーを開閉" placement="bottom">
       <button onClick={onToggleSidebar} className="w-8 h-8 flex items-center justify-center rounded bg-white/10 border border-white/20 text-white hover:bg-white/25 transition-all flex-shrink-0" aria-label="サイドバーを開閉する">
         <svg viewBox="0 0 16 16" fill="currentColor" width={15} height={15}><rect x="1" y="3" width="14" height="1.5" rx="0.75"/><rect x="1" y="7.25" width="14" height="1.5" rx="0.75"/><rect x="1" y="11.5" width="14" height="1.5" rx="0.75"/></svg>
       </button>
       </Tooltip>
-      <div className="flex items-center gap-2 text-white select-none">
+      <div className="flex items-center gap-2 text-white select-none flex-shrink-0">
         <div className="w-6 h-6 rounded flex items-center justify-center bg-white/20 border border-white/25">
           <Icon name="dashboard" size={13} className="text-white" />
         </div>
         <span className="text-[15px] font-bold tracking-tight">Matlens</span>
       </div>
-      <div className="w-px h-4 bg-white/20" />
-      <span className="text-[12px] text-white/60 leading-none hidden sm:inline">研究・実験データ管理 v3</span>
+      <div className="w-px h-4 bg-white/20 hidden md:block flex-shrink-0" />
+      <span className="text-[12px] text-white/60 leading-none hidden lg:inline flex-shrink-0">研究・実験データ管理 v3</span>
 
       {/* Global search with live results */}
-      <div className="flex-1 max-w-lg mx-3 relative">
+      <div className="flex-1 min-w-[160px] max-w-lg mx-1 md:mx-3 relative">
         <div className="relative">
           <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-white/40 pointer-events-none"><Icon name="search" size={13} /></span>
           <input
@@ -183,7 +183,7 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
         )}
       </div>
 
-      <div className="flex gap-0.5 bg-black/25 p-0.5 rounded-md border border-white/10" role="group" aria-label="テーマ切替">
+      <div className="hidden md:flex gap-0.5 bg-black/25 p-0.5 rounded-md border border-white/10 flex-shrink-0" role="group" aria-label="テーマ切替">
         {THEMES.map(t => (
           <button key={t.id} className={`px-2.5 py-1 rounded text-[12px] font-medium transition-all duration-150 font-ui ${theme === t.id ? 'bg-white/18 text-white' : 'text-white/50 hover:text-white/80'}`} onClick={() => setTheme(t.id)} aria-pressed={theme === t.id}>
             {t.label}
@@ -194,7 +194,7 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
         <button
           type="button"
           onClick={onOpenNotifications}
-          className="relative flex items-center justify-center w-9 h-9 rounded-full border border-white/20 bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all duration-200"
+          className="relative flex-shrink-0 flex items-center justify-center w-9 h-9 rounded-full border border-white/20 bg-white/10 text-white/80 hover:bg-white/20 hover:text-white transition-all duration-200"
           aria-label={unreadNotifications > 0 ? `お知らせ 未読 ${unreadNotifications} 件` : 'お知らせ'}
         >
           <Icon name="info" size={15} />
@@ -209,7 +209,7 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
         </button>
       </Tooltip>
       <Tooltip label={embStatus === "fallback" ? "キーワード検索モード" : `ベクトル検索: ${vecStatusLabel}`} placement="left">
-        <button className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold border transition-all duration-200 ${embStatus === 'ready' ? 'bg-vec-dim text-vec border-[var(--vec-mid)]' : 'bg-white/10 text-white/80 border-white/20'}`} aria-label="ベクトル検索ページへ">
+        <button className={`flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold border transition-all duration-200 ${embStatus === 'ready' ? 'bg-vec-dim text-vec border-[var(--vec-mid)]' : 'bg-white/10 text-white/80 border-white/20'}`} aria-label="ベクトル検索ページへ">
           <Icon name="embed" size={12} />
           <span>{vecStatusLabel}</span>
           {(embStatus === 'loading' || embStatus === 'indexing') && <Typing color="currentColor" />}
@@ -220,7 +220,7 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
           href={STORYBOOK_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold border border-white/20 bg-white/10 text-white/80 hover:bg-[#FF4785]/20 hover:text-white hover:border-[#FF4785]/60 transition-all duration-200"
+          className="hidden sm:flex flex-shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-semibold border border-white/20 bg-white/10 text-white/80 hover:bg-[#FF4785]/20 hover:text-white hover:border-[#FF4785]/60 transition-all duration-200"
           aria-label="Storybook を新しいタブで開く"
         >
           <span className="w-2 h-2 rounded-full bg-[#FF4785] flex-shrink-0" aria-hidden="true" />
@@ -229,7 +229,7 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
         </a>
       </Tooltip>
       <Tooltip label="ログインユーザー: 木村 研一" placement="left">
-      <div className="w-8 h-8 rounded-full bg-white/20 border-[1.5px] border-white/40 flex items-center justify-center text-[11px] font-bold text-white" aria-label="ログインユーザー">
+      <div className="flex-shrink-0 w-8 h-8 rounded-full bg-white/20 border-[1.5px] border-white/40 flex items-center justify-center text-[11px] font-bold text-white" aria-label="ログインユーザー">
         KK
       </div>
       </Tooltip>

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,20 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-10-notifications',
+    date: '2026-04-10',
+    type: 'feature',
+    title: 'アプリ内お知らせ機能を追加',
+    body: 'トップバー右側の鈴アイコン、ヘッダー下バナー、右下サポートボタンに未読バッジ付きで通知を表示するようになりました。「お知らせ」タブから過去の更新履歴もまとめて確認できます。',
+  },
+  {
+    id: '2026-04-10-storybook',
+    date: '2026-04-10',
+    type: 'info',
+    title: 'Storybook でデザインシステムを公開中',
+    body: 'Matlens の UI コンポーネント・デザイントークン・パターンを Storybook で参照できます。トップバー右側の「Storybook」リンク、またはサポートパネル内のリンクから開けます。',
+  },
+  {
     id: '2026-04-10-maiml',
     date: '2026-04-10',
     type: 'feature',

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -1,0 +1,47 @@
+// アプリケーション内お知らせ（更新履歴・運用情報）のデータソース。
+//
+// エントリは「発表日降順」で上から並べる。id は不変のユニーク文字列で、
+// 既読管理の localStorage キーとして使われるため、リリース後は変更しない。
+// type はバナーのアイコン色に使用される。
+
+export type AnnouncementType = 'feature' | 'fix' | 'info' | 'warn';
+
+export interface Announcement {
+  id: string;
+  date: string; // YYYY-MM-DD
+  type: AnnouncementType;
+  title: string;
+  body: string; // 1-3文。長文は含めない
+}
+
+// 新しいお知らせは配列の先頭に追加する。
+export const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: '2026-04-10-maiml',
+    date: '2026-04-10',
+    type: 'feature',
+    title: 'MaiML (JIS K 0200:2024) エクスポート/インポートに対応',
+    body: '材料データを MaiML 形式で書き出し・読み込みできるようになりました。材料一覧の「インポート」「エクスポート」、詳細ページの「MaiML」ボタンからご利用ください。',
+  },
+  {
+    id: '2026-04-10-rag-streaming',
+    date: '2026-04-10',
+    type: 'feature',
+    title: 'AI チャットにストリーミング応答を導入',
+    body: 'RAG チャットで回答が少しずつ流れてくるようになり、体感速度が改善しました。参照材料データも折りたたみで確認できます。',
+  },
+  {
+    id: '2026-04-09-ui-polish',
+    date: '2026-04-09',
+    type: 'fix',
+    title: '細部UIの改善 — チェックボックス・検索ハイライト・テキスト選択色',
+    body: 'ライト/ダーク両モードで見やすくなるよう、チェックボックスの配色、検索キーワードのハイライト、テキスト選択色を調整しました。',
+  },
+];
+
+/**
+ * 最新のお知らせを取得。ANNOUNCEMENTS が空の場合は undefined。
+ */
+export function getLatestAnnouncement(): Announcement | undefined {
+  return ANNOUNCEMENTS[0];
+}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -61,6 +61,7 @@ export const FAQ_ITEMS: { q: string; a: string }[] = [
 
 export const SUPPORT_TABS: { id: string; label: string; icon: string }[] = [
   { id: 'help', label: 'ヘルプ', icon: 'help' },
+  { id: 'news', label: 'お知らせ', icon: 'spark' },
   { id: 'faq',  label: 'Q&A',   icon: 'info' },
   { id: 'ai',   label: 'AI設定', icon: 'ai' },
 ];

--- a/src/hooks/useAnnouncements/index.ts
+++ b/src/hooks/useAnnouncements/index.ts
@@ -1,0 +1,2 @@
+export { useAnnouncements } from './useAnnouncements';
+export type { AnnouncementsState } from './useAnnouncements';

--- a/src/hooks/useAnnouncements/useAnnouncements.ts
+++ b/src/hooks/useAnnouncements/useAnnouncements.ts
@@ -1,0 +1,78 @@
+// Unread-state tracking for in-app announcements.
+//
+// We deliberately keep this on localStorage rather than a user account so
+// the banner doesn't reappear after each reload for returning users, while
+// staying anonymous for first-time visitors. The stored value is the id of
+// the most-recent announcement the user has acknowledged; anything newer
+// than that id (by array position) is treated as unread.
+
+import { useState, useEffect, useCallback } from 'react';
+import { ANNOUNCEMENTS, type Announcement } from '../../data/announcements';
+
+const STORAGE_KEY = 'matlens:lastSeenAnnouncementId';
+
+function loadLastSeenId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveLastSeenId(id: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    /* ignore quota / disabled storage */
+  }
+}
+
+export interface AnnouncementsState {
+  /** すべてのお知らせ（降順） */
+  all: Announcement[];
+  /** 未読のお知らせ（最新→古い順） */
+  unread: Announcement[];
+  /** 一番最新の未読お知らせ。なければ null */
+  latestUnread: Announcement | null;
+  /** 未読件数 */
+  unreadCount: number;
+  /** 指定IDまでを既読にする（デフォルトは全件既読） */
+  markAsSeen: (id?: string) => void;
+}
+
+export function useAnnouncements(): AnnouncementsState {
+  const [lastSeenId, setLastSeenId] = useState<string | null>(() =>
+    typeof window === 'undefined' ? null : loadLastSeenId()
+  );
+
+  // 別タブでの更新を反映（複数タブ起動時の体験を揃える）
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setLastSeenId(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const unreadIndex = lastSeenId
+    ? ANNOUNCEMENTS.findIndex(a => a.id === lastSeenId)
+    : ANNOUNCEMENTS.length;
+  // lastSeen が見つからない場合（旧ID を消した等）は全件未読扱い
+  const cutoff = unreadIndex < 0 ? ANNOUNCEMENTS.length : unreadIndex;
+  const unread = ANNOUNCEMENTS.slice(0, cutoff);
+
+  const markAsSeen = useCallback((id?: string) => {
+    const target = id ?? ANNOUNCEMENTS[0]?.id;
+    if (!target) return;
+    saveLastSeenId(target);
+    setLastSeenId(target);
+  }, []);
+
+  return {
+    all: ANNOUNCEMENTS,
+    unread,
+    latestUnread: unread[0] ?? null,
+    unreadCount: unread.length,
+    markAsSeen,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,17 +9,23 @@
   --bg-base:#eef0f3; --bg-surface:#ffffff; --bg-raised:#f5f6f8;
   --bg-sunken:#e4e6ea; --bg-hover:#e8eef7; --bg-active:#d4e2f4;
   --border-faint:rgba(0,30,80,.07); --border-default:rgba(0,30,80,.13);
-  --border-strong:rgba(0,30,80,.22); --border-focus:#0050AA;
+  --border-strong:rgba(0,30,80,.22); --border-focus:#0a5fcc;
   --text-hi:#0d1520; --text-md:#3a4554; --text-lo:#6b7a8d;
-  --accent:#004590; --accent-hover:#003070;
-  --accent-dim:#dce8f7; --accent-mid:#1a6bc0;
-  --accent-glow:rgba(0,69,144,.12);
-  --ai-col:#3b35a0; --ai-dim:#ebebfa; --ai-mid:#5c56cc;
-  --ai-glow:rgba(59,53,160,.1);
-  --vec:#0a6657; --vec-dim:#d8f0eb; --vec-mid:#0f8f78;
-  --ok:#1e6b0f; --ok-dim:#e4f3de;
-  --warn:#7a4b00; --warn-dim:#fdf0d8;
-  --err:#8b1a1a; --err-dim:#fdeaea;
+  /* Accent — sapphire. 6.5:1 on white, visibly richer than previous navy */
+  --accent:#0d5dc7; --accent-hover:#094ba3;
+  --accent-dim:#e2ecfa; --accent-mid:#2c78db;
+  --accent-glow:rgba(13,93,199,.14);
+  /* AI — vibrant indigo, still WCAG AA on white */
+  --ai-col:#524acc; --ai-dim:#ececfb; --ai-mid:#6c65e0;
+  --ai-glow:rgba(82,74,204,.14);
+  /* Vec — fresh teal. 4.7:1 on white */
+  --vec:#0e8c72; --vec-dim:#d6f1ea; --vec-mid:#14a585;
+  /* OK — slightly brighter forest green */
+  --ok:#2a8418; --ok-dim:#e3f3db;
+  /* Warn — amber. Shifts from brown toward warmer amber for clarity */
+  --warn:#a05d00; --warn-dim:#fdefd5;
+  /* Err — vivid red */
+  --err:#b52424; --err-dim:#fde8e8;
   --tag-surface:#e8ebef;
   --shadow-xs:0 1px 2px rgba(0,20,60,.06);
   --shadow-sm:0 2px 6px rgba(0,20,60,.08);
@@ -122,9 +128,13 @@ body{
 :focus-visible{outline:2px solid var(--border-focus);outline-offset:2px;border-radius:var(--radius-sm)}
 :focus:not(:focus-visible){outline:none}
 
+/* Utility — hide scrollbar but keep horizontal scrolling enabled (topbar on mobile) */
+.no-scrollbar{scrollbar-width:none;-ms-overflow-style:none}
+.no-scrollbar::-webkit-scrollbar{display:none}
+
 /* Text selection — theme-aware, avoids muddy OS defaults on dark cards */
-[data-theme="light"] ::selection{background:#b6d4f5;color:#0d1520}
-[data-theme="light"] ::-moz-selection{background:#b6d4f5;color:#0d1520}
+[data-theme="light"] ::selection{background:#c2dcf8;color:#0d1520}
+[data-theme="light"] ::-moz-selection{background:#c2dcf8;color:#0d1520}
 [data-theme="dark"] ::selection{background:#3560a0;color:#f2f8ff}
 [data-theme="dark"] ::-moz-selection{background:#3560a0;color:#f2f8ff}
 [data-theme="eng"] ::selection{background:#0d4a3c;color:#e8f0f5}

--- a/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/pages/Dashboard/DashboardPage.tsx
@@ -100,21 +100,21 @@ export const DashboardPage = ({ db, onNav, claude }: DashboardPageProps) => {
       ]}>
         {!insightLoading && <div className="md-preview" dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(insight) }} />}
       </AIInsightCard>
-      <div className="grid grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <KpiCard label="総データ件数" value={db.length} delta="▲ 12件（今月）" deltaUp={true} />
         <KpiCard label="実験バッチ数" value={38} delta="▲ 3バッチ" deltaUp={true} />
         <KpiCard label="レビュー待ち" value={db.filter(r=>r.status==='レビュー待').length} delta="▼ 要対応" deltaUp={false} />
         <KpiCard label="AI 検出" value={db.filter(r=>r.ai).length} delta="異常値候補あり" color="var(--ai-col)" />
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <SectionCard title="月次登録件数トレンド（12ヶ月）"><div className="chart-container"><canvas ref={chartRefs.trend} /></div></SectionCard>
         <SectionCard title="カテゴリ別件数構成"><div className="chart-container"><canvas ref={chartRefs.donut} /></div></SectionCard>
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <SectionCard title="バッチ別ステータス内訳"><div className="chart-container"><canvas ref={chartRefs.status} /></div></SectionCard>
         <SectionCard title="硬度 vs 引張強さ 散布図"><div className="chart-container"><canvas ref={chartRefs.scatter} /></div></SectionCard>
       </div>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <SectionCard title="最近登録されたデータ" action={<Button variant="ghost" size="xs" onClick={() => onNav('list')}>一覧へ <Icon name="chevronRight" size={10} /></Button>}>
           {db.slice(0,5).map((r, i) => (
             <div key={r.id} className="flex items-center gap-2.5 py-1.5 border-b border-[var(--border-faint)] last:border-b-0 cursor-pointer hover:bg-hover rounded px-1 transition-colors">

--- a/src/pages/MaterialList/MaterialListPage.tsx
+++ b/src/pages/MaterialList/MaterialListPage.tsx
@@ -246,7 +246,7 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
 
         {/* === Card view === */}
         {viewMode === 'card' && (
-          <div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 p-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 p-3">
             {slice.length === 0 ? (
               <div className="col-span-full text-center py-10 text-text-lo"><Icon name="info" size={24} className="mx-auto mb-2 opacity-30" /><div>該当データなし</div></div>
             ) : slice.map(r => (

--- a/src/pages/UxDesign/UxDesignPage.tsx
+++ b/src/pages/UxDesign/UxDesignPage.tsx
@@ -20,7 +20,7 @@ export const UxDesignPage = () => {
   const CONTENT = {
     'info-arch': <>
       <AIInsightCard loading={false} chips={[]}><strong>情報設計</strong>は「どこに何があるか」をユーザーが直感的に理解できる構造を作るプロセス。BtoBではユーザーのメンタルモデル（業務フロー）と画面構成を合致させることが最重要です。</AIInsightCard>
-      <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+      <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         <SectionCard title="Matlens の IA 原則">
           {[['ユーザーゴール優先','「何をしたいか」から設計。材料検索→詳細→編集をワンアクションで辿れる。'],['段階的開示','最初は重要情報のみ。詳細条件は「詳細」展開で。認知負荷を段階的に。'],['コンテキスト維持','一覧→詳細→編集の遷移でフィルタ状態を維持。作業文脈を失わない。'],['エラー防止','削除確認ダイアログ。AI異常値検出による事前警告。リアルタイムバリデーション。']].map(([t,d])=>(
             <div key={t} className="flex gap-2.5 py-2 border-b border-[var(--border-faint)] last:border-b-0"><Icon name="check" size={13} className="text-ok flex-shrink-0 mt-0.5"/><div><div className="text-[13px] font-bold text-text-hi">{t}</div><div className="text-[12px] text-text-md mt-0.5">{d}</div></div></div>
@@ -51,7 +51,7 @@ export const UxDesignPage = () => {
       </div>
     </>,
     'nav-design': <>
-      <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+      <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         <SectionCard title="ナビゲーション設計原則">
           {[['現在地の明示','アクティブアイテムを左ボーダー+背景色で強調。詳細画面ではbreadcrumb + prev/next ナビ。'],['折り畳みによる空間確保','サイドバートグルで作業領域を最大化。アイコン+ツールチップで折り畳み時も操作可能。'],['グローバル検索','トップバー中央に検索バー。Enter で材料一覧にフィルタ適用して遷移。IME対応済み。'],['セクション分け','概要/データ入力/AI分析/ヘルプ/開発者向け/設定の6セクションで機能の文脈を伝える。']].map(([t,d])=>(
             <div key={t} className="bg-raised border border-[var(--border-faint)] rounded p-3 mb-2 last:mb-0"><div className="text-[13px] font-bold text-text-hi mb-1">{t}</div><div className="text-[12px] text-text-md">{d}</div></div>
@@ -66,7 +66,7 @@ export const UxDesignPage = () => {
       </div>
     </>,
     'form-design': <>
-      <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+      <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         <SectionCard title="フォーム設計7原則">
           {[['ラベルは常に表示','プレースホルダーだけでなく、常時表示のラベルを必ず配置。'],['必須・任意を明示','* で必須を示し、任意には（任意）と記載。'],['リアルタイムバリデーション','onBlur時にその場でエラー表示。送信まで待たない。'],['インラインエラー','フィールド直下に赤色+アイコン+説明文でエラーを表示。'],['適切なinput種別','数値はnumber+単位。選択肢はselect or radio。'],['グルーピング','関連フィールドを視覚的にまとめる（枠・見出し）。'],['AIアシスト','組成入力で物性値を自動提案。入力工数を大幅削減。']].map(([t,d])=>(
             <div key={t} className="flex gap-2 py-1.5 border-b border-[var(--border-faint)] last:border-b-0 text-[12px]"><Icon name="check" size={12} className="text-ok flex-shrink-0 mt-0.5"/><div><strong className="text-text-hi">{t}</strong> — {d}</div></div>
@@ -87,7 +87,7 @@ export const UxDesignPage = () => {
     </>,
     'list-design': <>
       <SectionCard title="一覧・フィルタ設計パターン">
-        <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr 1fr'}}>
+        <div className="grid gap-3" style={{gridTemplateColumns:"repeat(auto-fit,minmax(220px,1fr))"}}>
           {[['全文検索','名称・ID・組成・備考を横断検索。デバウンスで入力遅延防止。'],['ファセットフィルタ','カテゴリ・ステータス・バッチのドロップダウン。AND絞り込み。'],['数値範囲フィルタ','最小〜最大の範囲指定。詳細パネルに隠して初期表示簡潔化。'],['アクティブタグ','有効なフィルタをタグ表示。個別・一括解除対応。'],['ソート','列単位の昇降順。現在ソートを視覚的に表示。'],['ページネーション','大量データを分割表示。件数/ページも変更可能。']].map(([t,d])=>(
             <div key={t} className="bg-raised border border-[var(--border-faint)] rounded p-3"><div className="text-[13px] font-bold text-text-hi mb-1">{t}</div><div className="text-[12px] text-text-md">{d}</div></div>
           ))}
@@ -102,7 +102,7 @@ export const UxDesignPage = () => {
     </>,
     'feedback': <>
       <SectionCard title="フィードバック設計の4層">
-        <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+        <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
           {[['即時 (<100ms)','ボタン押下のvisual feedback。hover/focus状態。','accent'],['短期 (〜2s)','ローディング・Typing インジケーター（AI応答待ち）。','ai'],['操作完了','Toast通知（登録・更新・削除）。3秒後自動消去。','ok'],['エラー・警告','モーダル（削除確認）。インラインエラー。バナー。','warn']].map(([t,d,c])=>(
             <div key={t} className={`bg-[var(--${c}-dim)] border border-[var(--${c})] rounded p-3`}><div className="text-[13px] font-bold text-text-hi mb-1.5">{t}</div><div className="text-[12px] text-text-md">{d}</div></div>
           ))}
@@ -110,7 +110,7 @@ export const UxDesignPage = () => {
       </SectionCard>
     </>,
     'a11y': <>
-      <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+      <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         <SectionCard title="WCAG 2.1 AA チェックリスト">
           {[['コントラスト比 4.5:1以上'],['focus-visible フォーカスリング'],['キーボード完全操作'],['aria-label / role / aria-current'],['スキップナビゲーション'],['最小フォントサイズ 12px'],['色+アイコン+テキストのセット'],['ラベルのフォームコントロール関連付け']].map(([t])=>(
             <div key={t} className="flex gap-2 py-1.5 border-b border-[var(--border-faint)] last:border-b-0 text-[12px]"><Icon name="check" size={12} className="text-ok flex-shrink-0 mt-0.5"/><span className="text-text-hi">{t}</span></div>
@@ -143,7 +143,7 @@ export const UxDesignPage = () => {
     </>,
     'btob': <>
       <SectionCard title="BtoB業務システム設計の固有原則">
-        <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr 1fr'}}>
+        <div className="grid gap-3" style={{gridTemplateColumns:"repeat(auto-fit,minmax(220px,1fr))"}}>
           {[['情報密度','BtoBは高密度が正義。1画面で多くのデータを見渡せることを優先。余白はBtoCほど取らない。','about'],['操作効率','繰り返し操作（一括処理・ショートカット）を重視。熟練者の生産性を最大化。','filter'],['エラー耐性','データ損失・誤操作の影響が大きい。削除確認・下書き・変更履歴を必ず設計。','warning'],['権限管理','閲覧・編集・承認のロール分離。ステータスワークフロー設計。','check'],['バルク操作','複数レコードへの一括操作（承認・削除・CSV出力）はBtoB必須機能。','list'],['監査ログ','いつ・誰が・何を変更したかの証跡。コンプライアンス要件への対応。','info']].map(([t,d,ico])=>(
             <div key={t} className="bg-raised border border-[var(--border-faint)] rounded p-3"><div className="flex items-center gap-2 mb-1.5"><Icon name={ico as IconName} size={13} className="text-accent"/><div className="text-[13px] font-bold text-text-hi">{t}</div></div><div className="text-[12px] text-text-md">{d}</div></div>
           ))}
@@ -162,7 +162,7 @@ export const UxDesignPage = () => {
           ))}
         </div>
       </SectionCard>
-      <div className="grid gap-3" style={{gridTemplateColumns:'1fr 1fr'}}>
+      <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
         <SectionCard title="タイポグラフィ スケール">
           {[['10px','補助ラベル・バッジ'],['11px','表ヘッダー・メタ'],['12px','ボディ小・補足'],['13px','ボディ標準・フォーム'],['14px','ボディ大・インプット'],['17px','ページタイトル小'],['19px','セクションタイトル']].map(([size,usage])=>(
             <div key={size} className="flex items-baseline gap-3 mb-1.5"><span className="w-10 font-mono text-[11px] text-text-lo">{size}</span><span style={{fontSize:size}} className="text-text-hi">あAaBb 123</span><span className="text-[11px] text-text-lo">{usage}</span></div>
@@ -182,15 +182,15 @@ export const UxDesignPage = () => {
   return (
     <div className="flex flex-col gap-4">
       <div><h1 className="ptitle text-[19px] font-bold tracking-tight">UX 設計ガイド</h1><p className="text-[12px] text-text-lo mt-0.5">BtoB業務システムにおける情報設計・ナビゲーション・フォーム・A11y のベストプラクティス</p></div>
-      <div className="grid gap-4" style={{gridTemplateColumns:'180px 1fr'}}>
-        <div className="flex flex-col gap-0.5">
+      <div className="flex flex-col md:grid gap-4 md:[grid-template-columns:180px_1fr]">
+        <div className="flex md:flex-col gap-0.5 overflow-x-auto no-scrollbar md:overflow-visible">
           {SECTIONS.map(s=>(
-            <button key={s.id} onClick={()=>setSection(s.id)} className={`flex items-center gap-2 px-3 py-2 rounded text-[13px] text-left transition-colors font-ui border-l-2 ${section===s.id?'bg-accent-dim text-accent border-accent font-semibold':'text-text-md border-transparent hover:bg-hover'}`}>
+            <button key={s.id} onClick={()=>setSection(s.id)} className={`flex items-center gap-2 px-3 py-2 rounded text-[13px] text-left transition-colors font-ui border-b-2 md:border-b-0 md:border-l-2 whitespace-nowrap md:whitespace-normal flex-shrink-0 ${section===s.id?'bg-accent-dim text-accent border-accent font-semibold':'text-text-md border-transparent hover:bg-hover'}`}>
               <Icon name={s.icon as IconName} size={12} className="flex-shrink-0 opacity-70"/><span className="leading-tight">{s.title}</span>
             </button>
           ))}
         </div>
-        <div className="flex flex-col gap-3">{(CONTENT as Record<string, React.ReactNode>)[section]}</div>
+        <div className="flex flex-col gap-3 min-w-0">{(CONTENT as Record<string, React.ReactNode>)[section]}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

ユーザーがアプリを開いたときに最新の更新・運用情報に気づけるよう、ミニマムな「お知らせ」導線を3つ追加します。

- **トップバー下のスリムなバナー** — 最新の未読お知らせを1行表示。× で dismiss、「すべて見る」でサポートパネルの お知らせ タブへ
- **サポートパネルに「お知らせ」タブ** — 全履歴を新しい順に表示。未読は赤バッジと accent-dim の背景で区別、タブを開くと自動で既読化
- **右下サポートボタンに未読カウント** — 赤丸 + 件数表示（9+ で打ち切り）

## Technical details

- `src/data/announcements.ts` — 静的な更新履歴配列（id / date / type / title / body）
- `src/hooks/useAnnouncements` — `matlens:lastSeenAnnouncementId` を localStorage に保存、`storage` イベントでマルチタブ同期
- 未読判定は配列の先頭から lastSeen の手前までを「未読」とする（順序安定）
- バナー・タブバッジ・ボタンバッジはすべて同じ unreadCount を参照するため、どこで dismiss しても即時に同期

## Test plan

- [ ] 初回ロード時にバナーが表示される
- [ ] × を押すとバナーが消え、リロード後も再表示されないことを確認
- [ ] 「すべて見る」で サポートパネル > お知らせ タブが開く
- [ ] お知らせタブを開いた瞬間、右下ボタンとタブの赤バッジが消える
- [ ] announcements.ts に新しいエントリを先頭追加すると、次回ロードで再びバナーが表示される
- [ ] ライト/ダーク/eng/cae 全テーマでバナーの色が自然に見える
- [ ] モバイル幅でバナーのタイトルが切り詰められ、日付が非表示になる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプリ内お知らせ機能を追加。ユーザーは最新の公知をバナーで確認できます
  * トップバーに通知ボタンを追加。未読公知数をバッジで表示します
  * サポートパネルに「お知らせ」タブを追加。全公知の履歴を閲覧可能になりました
  * 複数ウィンドウ間で未読状態を自動同期します

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
