### PR TITLE
feat(security): フェーズ1 — 入力バリデーション・CSPヘッダー・テーマ永続化

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Matlens はプロトタイプ段階のプロダクトですが、セキュリティの問題は真剣に取り扱います。脆弱性を発見した場合は、**公開 Issue を作成せず**、メンテナーに直接ご連絡ください。
+
+- 連絡先: リポジトリオーナー ([@BoxPistols](https://github.com/BoxPistols))
+- 返答 SLA:
+  - 受領の確認: **48時間以内**
+  - 修正方針の共有: **7日以内**
+  - 重大度（High/Critical）のパッチリリース: **14日以内**
+
+公開リポジトリのため、報告内容には再現手順と影響範囲を含めてください。可能であれば CVSS v3.1 スコアも添えていただけると助かります。
+
+## Supported Versions
+
+`main` ブランチが唯一のサポート対象です。過去の git tag / 古いデプロイでの問題は、`main` でもまだ再現するかを確認してから報告してください。
+
+## セキュリティ実装状況
+
+現時点で Matlens が講じている主な対策を以下にまとめます。詳細は該当ファイルをご参照ください。
+
+### Input Validation
+- `api/lib/validation.js` にすべての API 入力の検証ロジックを集約
+- すべての文字列入力は NFKC 正規化 + null byte 拒否
+- `provider`, `category` はアローリスト、`topK` は数値範囲チェック
+- `application/json` 以外の Content-Type は 415 で拒否（CSRF の simple request 対策）
+- 材料インジェストは 1 リクエスト最大 500 件、1 フィールド最大 2000 文字
+
+### XML / MaiML
+- `src/services/maiml.ts` で `MAIML_MAX_BYTES = 10MB` の上限
+- `<!DOCTYPE>` を明示的に拒否（XXE / Billion Laughs 対策）
+- ブラウザ標準 `DOMParser` を使用（外部エンティティをデフォルトで解決しない）
+
+### Markdown / HTML サニタイゼーション
+- `src/services/safeMarkdown.ts` で `marked` + `isomorphic-dompurify`
+- `<script>`, `<iframe>`, `<object>`, `on*` 属性、`javascript:` URI はすべて除去
+- LLM 出力を innerHTML にレンダリングする全箇所でこの関数を経由
+
+### HTTP Security Headers (`vercel.json`)
+- `Content-Security-Policy` (self + 明示的な connect-src アローリスト)
+- `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` (クリックジャッキング対策)
+- `X-Content-Type-Options: nosniff`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Strict-Transport-Security` (HSTS, 1 年)
+- `Permissions-Policy` でカメラ・マイク・位置情報等を無効化
+
+### Rate Limiting
+- `api/lib/ratelimit.js` で Upstash Redis + in-memory fallback
+- 1 IP あたり `DAILY_LIMIT`（デフォルト 30 回/日）
+
+### 秘密情報管理
+- `.env.local` は `.gitignore` 済み
+- ユーザー自身の API キーは `sessionStorage` ベースで一時保持
+- サーバーログに API キーを出力しない（`console.error` は stack のみ）
+
+### エラー情報漏洩防止
+- サーバー側は `console.error` で詳細を記録
+- クライアントには一般化したメッセージのみ返す（stack / 内部パスを含めない）
+
+### Error Boundary
+- `src/components/ErrorBoundary` で各 AI メッセージを個別にラップ
+- 壊れた Markdown がチャット全体のレンダリングをクラッシュさせないように
+
+## 既知の未対応項目 / 今後の計画
+
+- [ ] CORS を Matlens の本番 Origin に限定（現状は `*`）
+- [ ] CSP に nonce ベースの `script-src` (現状は `'unsafe-inline'`)
+- [ ] Vercel BotID / Vercel Firewall の導入検討
+- [ ] 依存関係の自動監査 (Dependabot / Renovate)
+- [ ] MaiML 来歴データの SHA-256 ハッシュ保持
+- [ ] プライバシーポリシーの整備
+
+優先度の高い順に PR で対応していきます。

--- a/api/ai.js
+++ b/api/ai.js
@@ -16,6 +16,13 @@ import { openai } from '@ai-sdk/openai';
 import { google } from '@ai-sdk/google';
 import { checkRateLimit, getRemainingQuota } from './lib/ratelimit.js';
 import { classifyAIError } from './lib/aiErrors.js';
+import {
+  ValidationError,
+  validatePrompt,
+  validateOptionalSystem,
+  validateProvider,
+  assertJsonContentType,
+} from './lib/validation.js';
 
 // @ai-sdk/google reads from GOOGLE_GENERATIVE_AI_API_KEY; accept GEMINI_API_KEY
 // as an alias since that's what the rest of the Matlens codebase uses.
@@ -60,9 +67,24 @@ export default async function handler(req, res) {
     return errorResponse(res, 405, { code: 'UNKNOWN', message: 'Method not allowed' });
   }
 
-  const { provider, prompt, system } = req.body || {};
-  if (!prompt) {
-    return errorResponse(res, 400, { code: 'UNKNOWN', message: 'prompt is required' });
+  // Input validation — reject bad content-type, unknown providers, and
+  // oversized / empty / null-byte-infested prompts before touching the
+  // rate limiter or the upstream model. Everything from req.body is
+  // treated as untrusted.
+  let provider;
+  let prompt;
+  let system;
+  try {
+    assertJsonContentType(req);
+    const body = req.body || {};
+    provider = validateProvider(body.provider);
+    prompt = validatePrompt(body.prompt);
+    system = validateOptionalSystem(body.system);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      return errorResponse(res, e.status || 400, { code: 'BAD_REQUEST', message: e.message });
+    }
+    throw e;
   }
 
   // Provider key presence check (friendlier than downstream auth error)

--- a/api/ingest.js
+++ b/api/ingest.js
@@ -2,6 +2,11 @@
 // POST /api/ingest { materials: Material[] }
 
 import { ingestMaterials } from './lib/rag.js';
+import {
+  ValidationError,
+  validateIngestMaterials,
+  assertJsonContentType,
+} from './lib/validation.js';
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -13,15 +18,26 @@ export default async function handler(req, res) {
   if (!process.env.OPENAI_API_KEY) return res.status(500).json({ error: 'OPENAI_API_KEY が未設定です' });
   if (!process.env.UPSTASH_VECTOR_REST_URL) return res.status(500).json({ error: 'UPSTASH_VECTOR_REST_URL が未設定です' });
 
-  const { materials } = req.body || {};
-  if (!materials || !Array.isArray(materials) || materials.length === 0) {
-    return res.status(400).json({ error: 'materials (array) is required' });
+  // Input validation — enforce JSON content type, array shape, per-record
+  // string / numeric types, and the hard max of N materials per request.
+  let materials;
+  try {
+    assertJsonContentType(req);
+    materials = validateIngestMaterials(req.body?.materials);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      return res.status(e.status || 400).json({ error: e.message });
+    }
+    throw e;
   }
 
   try {
     const count = await ingestMaterials(materials);
     return res.status(200).json({ ok: true, count });
   } catch (e) {
-    return res.status(500).json({ error: `インジェストエラー: ${e.message}` });
+    // Log the full error server-side but hand the client a generic message
+    // so stack traces / provider internals never hit the wire.
+    console.error('[api/ingest]', e);
+    return res.status(500).json({ error: 'インジェスト中にエラーが発生しました' });
   }
 }

--- a/api/lib/validation.js
+++ b/api/lib/validation.js
@@ -1,0 +1,193 @@
+// Shared input validation helpers for Matlens API routes.
+//
+// These run on the server before any business logic or outbound call
+// executes, so downstream providers never see bad input and an attacker
+// cannot coerce large / malformed / null-byte-infested payloads into the
+// pipeline. Every validator throws a ValidationError with a short user-
+// facing message on failure — the route handler converts that to an HTTP
+// 400 response.
+
+export class ValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ValidationError';
+    this.status = 400;
+  }
+}
+
+// Absolute maximums. These are deliberately generous but bounded.
+const MAX_PROMPT_LENGTH = 4000;
+const MAX_SYSTEM_LENGTH = 4000;
+const MAX_QUERY_LENGTH = 500;
+const MAX_TOPK = 20;
+const MIN_TOPK = 1;
+const MAX_MATERIALS_PER_INGEST = 500;
+const MAX_INGEST_STRING_FIELD = 2000;
+
+const ALLOWED_PROVIDERS = new Set(['openai-nano', 'openai-mini', 'gemini']);
+const ALLOWED_CATEGORIES = new Set([
+  'METAL',
+  'CERAMIC',
+  'POLYMER',
+  'COMPOSITE',
+  'OTHER',
+]);
+
+// Reject null bytes — some downstream providers choke on them, and they
+// are a common smuggling primitive. Applies everywhere we take free-form
+// text.
+function assertNoNullBytes(value, fieldName) {
+  if (value.includes('\x00')) {
+    throw new ValidationError(`${fieldName} contains a null byte`);
+  }
+}
+
+/**
+ * Validate a prompt / system message coming from a client. Normalizes
+ * Unicode to NFKC so zero-width characters and visually-identical tricks
+ * resolve to a canonical form before length checks.
+ */
+export function validatePrompt(prompt, { field = 'prompt', max = MAX_PROMPT_LENGTH } = {}) {
+  if (typeof prompt !== 'string') {
+    throw new ValidationError(`${field} must be a string`);
+  }
+  assertNoNullBytes(prompt, field);
+  const normalized = prompt.normalize('NFKC');
+  if (normalized.length === 0) {
+    throw new ValidationError(`${field} is empty`);
+  }
+  if (normalized.length > max) {
+    throw new ValidationError(`${field} is too long (max ${max} chars)`);
+  }
+  return normalized;
+}
+
+export function validateOptionalSystem(system) {
+  if (system === undefined || system === null) return undefined;
+  return validatePrompt(system, { field: 'system', max: MAX_SYSTEM_LENGTH });
+}
+
+/**
+ * Reject anything not on the provider allowlist so a malicious client
+ * cannot trick the router into calling an unexpected upstream.
+ */
+export function validateProvider(provider) {
+  if (typeof provider !== 'string') {
+    throw new ValidationError('provider must be a string');
+  }
+  if (!ALLOWED_PROVIDERS.has(provider)) {
+    throw new ValidationError(`invalid provider: ${provider}`);
+  }
+  return provider;
+}
+
+export function validateSearchQuery(query) {
+  return validatePrompt(query, { field: 'query', max: MAX_QUERY_LENGTH });
+}
+
+/**
+ * topK for vector search — must be a positive integer within sane bounds.
+ */
+export function validateTopK(k, fallback = 6) {
+  if (k === undefined || k === null) return fallback;
+  if (typeof k !== 'number' || !Number.isInteger(k)) {
+    throw new ValidationError('k must be an integer');
+  }
+  if (k < MIN_TOPK || k > MAX_TOPK) {
+    throw new ValidationError(`k must be between ${MIN_TOPK} and ${MAX_TOPK}`);
+  }
+  return k;
+}
+
+export function validateCategoryFilter(category) {
+  if (category === undefined || category === null || category === '') return undefined;
+  if (typeof category !== 'string') {
+    throw new ValidationError('category must be a string');
+  }
+  if (!ALLOWED_CATEGORIES.has(category)) {
+    throw new ValidationError(`invalid category: ${category}`);
+  }
+  return category;
+}
+
+function assertString(value, field, max = MAX_INGEST_STRING_FIELD) {
+  if (value === undefined || value === null) return '';
+  if (typeof value !== 'string') {
+    throw new ValidationError(`${field} must be a string`);
+  }
+  assertNoNullBytes(value, field);
+  const normalized = value.normalize('NFKC');
+  if (normalized.length > max) {
+    throw new ValidationError(`${field} is too long (max ${max} chars)`);
+  }
+  return normalized;
+}
+
+function assertFiniteNumber(value, field) {
+  if (value === undefined || value === null) return 0;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ValidationError(`${field} must be a finite number`);
+  }
+  return value;
+}
+
+/**
+ * Validate the shape of a materials array for /api/ingest. Returns a
+ * fresh array of sanitised records so downstream code never touches the
+ * raw request body.
+ */
+export function validateIngestMaterials(materials) {
+  if (!Array.isArray(materials)) {
+    throw new ValidationError('materials must be an array');
+  }
+  if (materials.length === 0) {
+    throw new ValidationError('materials is empty');
+  }
+  if (materials.length > MAX_MATERIALS_PER_INGEST) {
+    throw new ValidationError(
+      `too many materials (max ${MAX_MATERIALS_PER_INGEST} per request)`
+    );
+  }
+  return materials.map((mat, i) => {
+    if (!mat || typeof mat !== 'object') {
+      throw new ValidationError(`materials[${i}] must be an object`);
+    }
+    const id = assertString(mat.id, `materials[${i}].id`, 64);
+    if (!id) throw new ValidationError(`materials[${i}].id is required`);
+    return {
+      id,
+      name: assertString(mat.name, `materials[${i}].name`),
+      cat: assertString(mat.cat, `materials[${i}].cat`, 64),
+      comp: assertString(mat.comp, `materials[${i}].comp`),
+      memo: assertString(mat.memo, `materials[${i}].memo`),
+      hv: assertFiniteNumber(mat.hv, `materials[${i}].hv`),
+      ts: assertFiniteNumber(mat.ts, `materials[${i}].ts`),
+      el: assertFiniteNumber(mat.el, `materials[${i}].el`),
+      dn: assertFiniteNumber(mat.dn, `materials[${i}].dn`),
+    };
+  });
+}
+
+/**
+ * Enforce Content-Type: application/json on POST endpoints so CSRF-style
+ * "simple request" form submissions from another origin cannot hit them.
+ */
+export function assertJsonContentType(req) {
+  const ct = req.headers?.['content-type'] ?? '';
+  if (!ct.toLowerCase().includes('application/json')) {
+    const err = new ValidationError('Unsupported Media Type — expected application/json');
+    err.status = 415;
+    throw err;
+  }
+}
+
+// Shared limits re-exported so tests / other modules can reference them.
+export const LIMITS = {
+  MAX_PROMPT_LENGTH,
+  MAX_SYSTEM_LENGTH,
+  MAX_QUERY_LENGTH,
+  MAX_TOPK,
+  MIN_TOPK,
+  MAX_MATERIALS_PER_INGEST,
+  MAX_INGEST_STRING_FIELD,
+};

--- a/api/lib/validation.test.js
+++ b/api/lib/validation.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ValidationError,
+  validatePrompt,
+  validateOptionalSystem,
+  validateProvider,
+  validateSearchQuery,
+  validateTopK,
+  validateCategoryFilter,
+  validateIngestMaterials,
+  assertJsonContentType,
+  LIMITS,
+} from './validation.js';
+
+describe('validatePrompt', () => {
+  it('accepts a short valid prompt', () => {
+    expect(validatePrompt('hello')).toBe('hello');
+  });
+
+  it('normalizes Unicode to NFKC', () => {
+    // Full-width digits should fold to ASCII
+    expect(validatePrompt('１２３')).toBe('123');
+  });
+
+  it('rejects non-string input', () => {
+    expect(() => validatePrompt(42)).toThrow(ValidationError);
+    expect(() => validatePrompt(null)).toThrow(ValidationError);
+    expect(() => validatePrompt(undefined)).toThrow(ValidationError);
+  });
+
+  it('rejects empty string', () => {
+    expect(() => validatePrompt('')).toThrow(/empty/);
+  });
+
+  it('rejects null bytes', () => {
+    expect(() => validatePrompt('hello\x00world')).toThrow(/null byte/);
+  });
+
+  it('rejects prompts over MAX_PROMPT_LENGTH', () => {
+    const huge = 'a'.repeat(LIMITS.MAX_PROMPT_LENGTH + 1);
+    expect(() => validatePrompt(huge)).toThrow(/too long/);
+  });
+});
+
+describe('validateOptionalSystem', () => {
+  it('returns undefined for missing input', () => {
+    expect(validateOptionalSystem(undefined)).toBeUndefined();
+    expect(validateOptionalSystem(null)).toBeUndefined();
+  });
+  it('validates like a prompt when provided', () => {
+    expect(validateOptionalSystem('sys')).toBe('sys');
+    expect(() => validateOptionalSystem('x\x00')).toThrow(/null byte/);
+  });
+});
+
+describe('validateProvider', () => {
+  it('accepts allowlisted providers', () => {
+    expect(validateProvider('openai-nano')).toBe('openai-nano');
+    expect(validateProvider('openai-mini')).toBe('openai-mini');
+    expect(validateProvider('gemini')).toBe('gemini');
+  });
+  it('rejects unknown providers', () => {
+    expect(() => validateProvider('openai-gpt4')).toThrow(/invalid provider/);
+    expect(() => validateProvider('claude')).toThrow(/invalid provider/);
+    expect(() => validateProvider('')).toThrow(/invalid provider/);
+  });
+  it('rejects non-string input', () => {
+    expect(() => validateProvider(42)).toThrow(/string/);
+  });
+});
+
+describe('validateSearchQuery', () => {
+  it('accepts valid queries', () => {
+    expect(validateSearchQuery('耐熱合金')).toBe('耐熱合金');
+  });
+  it('rejects queries over MAX_QUERY_LENGTH', () => {
+    expect(() => validateSearchQuery('a'.repeat(LIMITS.MAX_QUERY_LENGTH + 1))).toThrow(/too long/);
+  });
+});
+
+describe('validateTopK', () => {
+  it('defaults to fallback when undefined', () => {
+    expect(validateTopK(undefined)).toBe(6);
+    expect(validateTopK(undefined, 10)).toBe(10);
+  });
+  it('accepts integers in range', () => {
+    expect(validateTopK(1)).toBe(1);
+    expect(validateTopK(20)).toBe(20);
+  });
+  it('rejects non-integer or out-of-range values', () => {
+    expect(() => validateTopK(0)).toThrow(/between/);
+    expect(() => validateTopK(21)).toThrow(/between/);
+    expect(() => validateTopK(1.5)).toThrow(/integer/);
+    expect(() => validateTopK('5')).toThrow(/integer/);
+  });
+});
+
+describe('validateCategoryFilter', () => {
+  it('accepts allowlisted categories', () => {
+    expect(validateCategoryFilter('METAL')).toBe('METAL');
+    expect(validateCategoryFilter('CERAMIC')).toBe('CERAMIC');
+  });
+  it('returns undefined for empty', () => {
+    expect(validateCategoryFilter(undefined)).toBeUndefined();
+    expect(validateCategoryFilter('')).toBeUndefined();
+  });
+  it('rejects unknown categories', () => {
+    expect(() => validateCategoryFilter('WOOD')).toThrow(/invalid category/);
+  });
+});
+
+describe('validateIngestMaterials', () => {
+  const valid = {
+    id: 'MAT-0001',
+    name: 'SUS316L',
+    cat: '金属合金',
+    comp: 'Fe-17Cr-12Ni',
+    memo: '',
+    hv: 186,
+    ts: 520,
+    el: 193,
+    dn: 7.98,
+  };
+
+  it('accepts and normalizes a single valid material', () => {
+    const result = validateIngestMaterials([valid]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('MAT-0001');
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => validateIngestMaterials('nope')).toThrow(/array/);
+    expect(() => validateIngestMaterials({})).toThrow(/array/);
+  });
+
+  it('rejects empty array', () => {
+    expect(() => validateIngestMaterials([])).toThrow(/empty/);
+  });
+
+  it('rejects arrays over the ingest limit', () => {
+    const many = Array.from({ length: LIMITS.MAX_MATERIALS_PER_INGEST + 1 }, (_, i) => ({
+      ...valid,
+      id: `MAT-${i}`,
+    }));
+    expect(() => validateIngestMaterials(many)).toThrow(/too many/);
+  });
+
+  it('rejects materials missing an id', () => {
+    expect(() => validateIngestMaterials([{ ...valid, id: '' }])).toThrow(/required/);
+  });
+
+  it('rejects non-finite numeric fields', () => {
+    expect(() => validateIngestMaterials([{ ...valid, hv: NaN }])).toThrow(/finite number/);
+    expect(() => validateIngestMaterials([{ ...valid, ts: Infinity }])).toThrow(/finite number/);
+  });
+
+  it('rejects null bytes in string fields', () => {
+    expect(() => validateIngestMaterials([{ ...valid, name: 'x\x00y' }])).toThrow(/null byte/);
+  });
+});
+
+describe('assertJsonContentType', () => {
+  it('accepts application/json', () => {
+    expect(() => assertJsonContentType({ headers: { 'content-type': 'application/json' } })).not.toThrow();
+  });
+  it('accepts application/json with charset', () => {
+    expect(() =>
+      assertJsonContentType({ headers: { 'content-type': 'application/json; charset=utf-8' } })
+    ).not.toThrow();
+  });
+  it('rejects form-urlencoded', () => {
+    expect(() =>
+      assertJsonContentType({ headers: { 'content-type': 'application/x-www-form-urlencoded' } })
+    ).toThrow(/Unsupported Media Type/);
+  });
+  it('rejects missing content-type', () => {
+    expect(() => assertJsonContentType({ headers: {} })).toThrow();
+  });
+});

--- a/api/search.js
+++ b/api/search.js
@@ -2,6 +2,13 @@
 // POST /api/search { query, k?, category? }
 
 import { search, keywordSearch } from './lib/rag.js';
+import {
+  ValidationError,
+  validateSearchQuery,
+  validateTopK,
+  validateCategoryFilter,
+  assertJsonContentType,
+} from './lib/validation.js';
 
 export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -10,8 +17,28 @@ export default async function handler(req, res) {
   if (req.method === 'OPTIONS') return res.status(200).end();
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
 
-  const { query, k = 6, category, db } = req.body || {};
-  if (!query) return res.status(400).json({ error: 'query is required' });
+  // Input validation — reject non-JSON bodies, oversized queries, and
+  // out-of-range topK before any expensive work.
+  let query;
+  let k;
+  let category;
+  try {
+    assertJsonContentType(req);
+    const body = req.body || {};
+    query = validateSearchQuery(body.query);
+    k = validateTopK(body.k, 6);
+    category = validateCategoryFilter(body.category);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      return res.status(e.status || 400).json({ error: e.message });
+    }
+    throw e;
+  }
+
+  // `db` is an optional client-side fallback used in dev when Upstash isn't
+  // configured; don't validate every row, just bound the array size so a
+  // malicious client can't force us to scan a huge list.
+  const db = Array.isArray(req.body?.db) ? req.body.db.slice(0, 1000) : null;
 
   const hasUpstash = process.env.UPSTASH_VECTOR_REST_URL && process.env.UPSTASH_VECTOR_REST_TOKEN;
 
@@ -22,13 +49,16 @@ export default async function handler(req, res) {
     }
 
     // Fallback: keyword search (requires db from client)
-    if (db && Array.isArray(db)) {
+    if (db) {
       const results = keywordSearch(db, query, k);
       return res.status(200).json({ results, engine: 'keyword' });
     }
 
     return res.status(200).json({ results: [], engine: 'none', message: 'UPSTASH_VECTOR未設定。キーワード検索にはdbパラメータが必要です。' });
   } catch (e) {
-    return res.status(500).json({ error: `検索エラー: ${e.message}` });
+    // Log internal errors server-side but return a generic message to the
+    // client so we don't leak stack traces or provider internals.
+    console.error('[api/search]', e);
+    return res.status(500).json({ error: '検索中にエラーが発生しました' });
   }
 }

--- a/src/hooks/useTheme/useTheme.test.ts
+++ b/src/hooks/useTheme/useTheme.test.ts
@@ -1,48 +1,105 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useTheme } from './useTheme';
+
+const STORAGE_KEY = 'matlens:theme';
+
+// Local in-memory storage shim. The browser-mode vitest environment provided
+// by @storybook/addon-vitest does not expose a fully-functional localStorage
+// global, so each test swaps in its own Storage-shaped object via defineProperty.
+function createLocalStorageStub() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
 
 describe('useTheme', () => {
   beforeEach(() => {
     document.documentElement.removeAttribute('data-theme');
+    Object.defineProperty(window, 'localStorage', {
+      value: createLocalStorageStub(),
+      writable: true,
+      configurable: true,
+    });
   });
 
-  it('initial theme is light', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults to light when no theme is stored and no prefers-color-scheme match', () => {
+    // Stub matchMedia → no match (light mode)
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
     const { result } = renderHook(() => useTheme());
     expect(result.current.theme).toBe('light');
   });
 
-  it('setTheme changes the theme state', () => {
+  it('respects prefers-color-scheme: dark on first visit', () => {
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((q: string) => ({ matches: q.includes('dark') }))
+    );
     const { result } = renderHook(() => useTheme());
-    act(() => {
-      result.current.setTheme('dark');
-    });
     expect(result.current.theme).toBe('dark');
   });
 
-  it('setTheme updates document.documentElement data-theme attribute', () => {
+  it('restores the theme from localStorage on mount', () => {
+    localStorage.setItem(STORAGE_KEY, 'dark');
     const { result } = renderHook(() => useTheme());
-    act(() => {
-      result.current.setTheme('dark');
-    });
+    expect(result.current.theme).toBe('dark');
     expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
   });
 
-  it('can switch themes multiple times', () => {
+  it('ignores invalid stored values and falls back to the default', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-a-real-theme');
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({ matches: false }));
     const { result } = renderHook(() => useTheme());
-    act(() => { result.current.setTheme('dark'); });
-    expect(result.current.theme).toBe('dark');
-
-    act(() => { result.current.setTheme('engineering'); });
-    expect(result.current.theme).toBe('engineering');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('engineering');
-
-    act(() => { result.current.setTheme('light'); });
     expect(result.current.theme).toBe('light');
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('returns a stable setTheme function across renders', () => {
+  it('setTheme persists the new value to localStorage', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme('dark');
+    });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('dark');
+  });
+
+  it('setTheme updates data-theme attribute on the html element', () => {
+    const { result } = renderHook(() => useTheme());
+    act(() => {
+      result.current.setTheme('eng');
+    });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('eng');
+  });
+
+  it('can switch between all four valid themes', () => {
+    const { result } = renderHook(() => useTheme());
+    for (const theme of ['dark', 'eng', 'cae', 'light']) {
+      act(() => {
+        result.current.setTheme(theme);
+      });
+      expect(result.current.theme).toBe(theme);
+      expect(document.documentElement.getAttribute('data-theme')).toBe(theme);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(theme);
+    }
+  });
+
+  it('returns a stable setTheme function across re-renders', () => {
     const { result, rerender } = renderHook(() => useTheme());
     const firstSetTheme = result.current.setTheme;
     rerender();

--- a/src/hooks/useTheme/useTheme.ts
+++ b/src/hooks/useTheme/useTheme.ts
@@ -1,10 +1,62 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+
+// localStorage key used to persist the user's theme selection across
+// sessions. Kept in a constant so tests and migrations can reference it.
+const STORAGE_KEY = 'matlens:theme';
+const VALID_THEMES = ['light', 'dark', 'eng', 'cae'] as const;
+type ValidTheme = (typeof VALID_THEMES)[number];
+
+function isValidTheme(t: string | null): t is ValidTheme {
+  return !!t && (VALID_THEMES as readonly string[]).includes(t);
+}
+
+function loadInitialTheme(): string {
+  if (typeof window === 'undefined') return 'light';
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (isValidTheme(stored)) return stored;
+  } catch {
+    /* localStorage may be disabled (private mode, quota full, etc.) */
+  }
+  // Fall back to the OS preference so first-time visitors get a sensible
+  // default instead of always being dropped into light mode.
+  if (typeof window.matchMedia === 'function') {
+    if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+  }
+  return 'light';
+}
 
 export function useTheme(): { theme: string; setTheme: (t: string) => void } {
-  const [theme, setThemeState] = useState<string>('light');
+  const [theme, setThemeState] = useState<string>(loadInitialTheme);
+
+  // Keep <html data-theme="..."> and localStorage in sync with state. Running
+  // this as a layout-agnostic effect (rather than inside setTheme) means the
+  // attribute is applied on initial mount too, including when the user
+  // restored from localStorage or prefers-color-scheme.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* ignore quota / disabled storage */
+    }
+  }, [theme]);
+
+  // Sync across browser tabs — if the user changes the theme in another
+  // tab the storage event lets us mirror that here without waiting for a
+  // reload.
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return;
+      if (isValidTheme(e.newValue)) setThemeState(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
   const setTheme = useCallback((t: string) => {
     setThemeState(t);
-    document.documentElement.setAttribute('data-theme', t);
   }, []);
+
   return { theme, setTheme };
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,37 @@
-{}
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.openai.com https://generativelanguage.googleapis.com https://*.upstash.io https://*.vercel.app https://vercel.live; media-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "on"
+        }
+      ]
+    }
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
     css: true,
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'api/**/*.test.{js,ts}'],
   },
 });


### PR DESCRIPTION
## 概要

ピアレビューで受けたセキュリティ監査のフェーズ1対応と、小さな無関係の UX 改善 (テーマ設定のリロード時永続化) をまとめた PR。

## 入力バリデーション (`api/lib/validation.js`)

API リクエストがレートリミッターや外部プロバイダーに触れる前に、**すべての** リクエストで共通バリデーターを実行する。

- すべての自由文字列に **NFKC 正規化** を適用。ゼロ幅・紛らわしい Unicode を長さチェック前に正規化する
- すべての文字列入力で **ヌルバイトを拒否** (ダウンストリームのパーサーに対する smuggling 対策)
- `provider` (openai-nano / openai-mini / gemini) と `category` (METAL / CERAMIC / POLYMER / COMPOSITE / OTHER) の **許可リスト**
- **上限値**: prompt ≤4000, system ≤4000, query ≤500, topK ∈ [1,20], ingest 配列 ≤500行, 各フィールド ≤2000文字
- `assertJsonContentType()` で POST に `application/json` を強制し、form-urlencoded / text/plain の simple request を拒否 (CSRF 対策)
- **30本のユニットテスト** で正常系・異常系を全カバー

## エンドポイント堅牢化 (`api/ai.js`, `api/search.js`, `api/ingest.js`)

- 3 エンドポイントすべてが新しいバリデーターを呼ぶ
- `ValidationError` は HTTP 400 / 415 にマップされ、バリデーターの短いメッセージを返す
- 予期しない 500 では内部情報を `console.error` にログし、クライアントには汎用メッセージのみを返す。**スタックトレースやプロバイダー内部情報はワイヤー上に出さない**

## HTTP セキュリティヘッダー (`vercel.json`)

| ヘッダー | 値 |
|---|---|
| `Content-Security-Policy` | `self` + `connect-src` 明示許可 (OpenAI / Google GenAI / Upstash / vercel.live) |
| `X-Frame-Options` | `DENY` + CSP `frame-ancestors 'none'` (クリックジャッキング対策) |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (HSTS) |

## テーマ永続化

`useTheme` が localStorage からテーマ設定を読み込み・保存するよう修正。ブラウザリロードで設定が消える問題を解消。

## テスト計画

- [ ] `pnpm test` — 新しい validation スイート (30件) とテーマテストがパス
- [ ] `pnpm build` — クリーンビルド、型エラーなし
- [ ] ローカルで全エンドポイントに正常系・異常系リクエストを送って動作確認