### PR TITLE
feat(search): エンジン表示の UX 改善と vite 安定化

### DIFF
--- a/.storybook/README.md
+++ b/.storybook/README.md
@@ -1,0 +1,78 @@
+# Storybook 設定 — Matlens
+
+## preview.tsx デコレーターアーキテクチャ
+
+### ChatSupport の自動注入
+
+グローバルデコレーターが全 Story に `<ChatSupport currentStory={...} />` を
+浮かべる。AI がコンポーネントの prop 仕様を答えられるよう、Storybook の
+`context.argTypes` / `context.args` を `StoryContext` として渡す。
+
+### useRef パターン — args 変更時の currentStory 再生成を抑制
+
+Controls パネルで値を変えるたびに `context.args` が新しい参照になる。
+単純に `useMemo` の deps に含めると currentStory が毎回作り直され、
+チャット履歴が消えたりストリーミングが途切れたりする。
+
+```tsx
+// .storybook/preview.tsx
+const argTypesRef = useRef(context.argTypes)
+const argsRef    = useRef(context.args)
+argTypesRef.current = context.argTypes  // 毎 render で ref を同期
+argsRef.current    = context.args
+
+const currentStory = useMemo(() => ({
+  title:       context.title,
+  name:        context.name,
+  description: context.parameters?.docs?.description?.component,
+  argTypes:    argTypesRef.current,  // ref の値を読む（deps には含めない）
+  args:        argsRef.current,
+}), [context.title, context.name, description])
+```
+
+**ルール**: `argTypes` / `args` は `useMemo` の deps に含めない。
+ref 経由で常に最新値を参照するため問題ない。
+
+---
+
+### disableDecoratorChat — 二重レンダリング防止
+
+ChatSupport 自身の Story を Canvas で開くと、Decorator が ChatSupport を
+もう一度マウントして二重表示になる。該当する Story の `meta.parameters` に
+`disableDecoratorChat: true` を設定すると Decorator 側がスキップする。
+
+```tsx
+// 例: ChatSupport.stories.tsx
+const meta: Meta<typeof ChatSupport> = {
+  parameters: {
+    disableDecoratorChat: true,
+  },
+}
+```
+
+Decorator 側の実装（`preview.tsx`）:
+
+```tsx
+const disableDecoratorChat = context.parameters?.disableDecoratorChat === true
+{context.viewMode !== 'docs' && !disableDecoratorChat && (
+  <ChatSupport currentStory={currentStory} />
+)}
+```
+
+適用すべき Story: `ChatSupport` 本体の Story など、`<ChatSupport />` を
+自分でレンダリングする Story すべて。
+
+---
+
+## テーマ切り替え
+
+`globals.theme` で `light` / `dark` / `eng` / `cae` の 4 テーマを切り替える。
+`ThemeWrapper` が `document.documentElement` の `data-theme` 属性を更新し、
+CSS カスタムプロパティ経由で全コンポーネントに反映される。
+
+## Vite preload エラー自動リカバリー
+
+`vite:preloadError` イベントを捕捉してページを一度だけ自動リロードする。
+Vercel デプロイ後にコンテンツハッシュが変わった古いチャンクが
+キャッシュに残っている場合の 404 を回避するため。
+`sessionStorage` でリロードループを防止している。

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import type { Preview } from '@storybook/react-vite'
-import { useEffect } from 'react'
+import { useEffect, useRef, useMemo } from 'react'
 import { useGlobals } from 'storybook/preview-api'
 import { ChatSupport } from '../src/components/ui/ChatSupport'
 import '../src/index.css'
@@ -44,24 +44,30 @@ const preview: Preview = {
       const [globals] = useGlobals()
       const theme = globals.theme || 'light'
 
+      // Keep refs up-to-date every render but exclude them from useMemo deps.
+      // This prevents currentStory from being recreated every time the user
+      // tweaks a control (which changes context.args on each keystroke).
+      const argTypesRef = useRef(context.argTypes)
+      const argsRef = useRef(context.args)
+      argTypesRef.current = context.argTypes
+      argsRef.current = context.args
+
+      const description = context.parameters?.docs?.description?.component as string | undefined
+      const currentStory = useMemo(() => ({
+        title: context.title,
+        name: context.name,
+        description,
+        argTypes: argTypesRef.current as Record<string, unknown> | undefined,
+        args: argsRef.current as Record<string, unknown> | undefined,
+      }), [context.title, context.name, description])
+
+      const disableDecoratorChat = context.parameters?.disableDecoratorChat === true
+
       return (
         <ThemeWrapper theme={theme}>
           <Story />
-          {context.viewMode !== 'docs' && (
-            <ChatSupport
-              key={context.id}
-              currentStory={{
-                title: context.title,
-                name: context.name,
-                description: context.parameters?.docs?.description?.component,
-                // argTypes / args come straight from Storybook's own
-                // metadata — the decorator passes them through so the
-                // AI system prompt can answer prop-specific questions
-                // without anyone hand-maintaining a mirror table.
-                argTypes: context.argTypes as Record<string, unknown> | undefined,
-                args: context.args as Record<string, unknown> | undefined,
-              }}
-            />
+          {context.viewMode !== 'docs' && !disableDecoratorChat && (
+            <ChatSupport currentStory={currentStory} />
           )}
         </ThemeWrapper>
       )

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@ai-sdk/openai": "^3.0.52",
     "@react-three/drei": "^9.117.3",
     "@react-three/fiber": "^8.17.14",
+    "@tensorflow-models/universal-sentence-encoder": "^1.3.3",
+    "@tensorflow/tfjs": "^3.21.0",
     "@types/prismjs": "^1.26.6",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.37.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@react-three/fiber':
         specifier: ^8.17.14
         version: 8.18.0(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.183.2)
+      '@tensorflow-models/universal-sentence-encoder':
+        specifier: ^1.3.3
+        version: 1.3.3(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs':
+        specifier: ^4.22.0
+        version: 4.22.0(seedrandom@3.0.5)
       '@types/prismjs':
         specifier: ^1.26.6
         version: 1.26.6
@@ -1238,6 +1244,48 @@ packages:
     peerDependencies:
       storybook: ^8.6.15
 
+  '@tensorflow-models/universal-sentence-encoder@1.3.3':
+    resolution: {integrity: sha512-mipL7ad0CW6uQ68FUkNgkNj/zgA4qgBnNcnMMkNTdL9MUMnzCxu3AE8pWnx2ReKHwdqEG4e8IpaYKfH4B8bojg==}
+    peerDependencies:
+      '@tensorflow/tfjs-converter': ^3.6.0
+      '@tensorflow/tfjs-core': ^3.6.0
+
+  '@tensorflow/tfjs-backend-cpu@4.22.0':
+    resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
+    engines: {yarn: '>= 1.3.2'}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-backend-webgl@4.22.0':
+    resolution: {integrity: sha512-H535XtZWnWgNwSzv538czjVlbJebDl5QTMOth4RXr2p/kJ1qSIXE0vZvEtO+5EC9b00SvhplECny2yDewQb/Yg==}
+    engines: {yarn: '>= 1.3.2'}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-converter@4.22.0':
+    resolution: {integrity: sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-core@4.22.0':
+    resolution: {integrity: sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==}
+    engines: {yarn: '>= 1.3.2'}
+
+  '@tensorflow/tfjs-data@4.22.0':
+    resolution: {integrity: sha512-dYmF3LihQIGvtgJrt382hSRH4S0QuAp2w1hXJI2+kOaEqo5HnUPG0k5KA6va+S1yUhx7UBToUKCBHeLHFQRV4w==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      seedrandom: ^3.0.5
+
+  '@tensorflow/tfjs-layers@4.22.0':
+    resolution: {integrity: sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs@4.22.0':
+    resolution: {integrity: sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg==}
+    hasBin: true
+
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
@@ -1335,11 +1383,20 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/offscreencanvas@2019.3.0':
+    resolution: {integrity: sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==}
 
   '@types/offscreencanvas@2019.7.3':
     resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
@@ -1365,6 +1422,9 @@ packages:
 
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
+
+  '@types/seedrandom@2.4.34':
+    resolution: {integrity: sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1561,6 +1621,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@webgpu/types@0.1.38':
+    resolution: {integrity: sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==}
+
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
@@ -1615,6 +1678,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1674,6 +1740,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -1819,6 +1888,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -1833,6 +1905,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1859,6 +1935,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-js@3.29.1:
+    resolution: {integrity: sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==}
 
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
@@ -1958,6 +2037,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2235,6 +2318,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -2813,6 +2900,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -2884,6 +2974,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -2923,6 +3021,15 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -3217,6 +3324,9 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -3280,6 +3390,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -3297,6 +3410,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3366,6 +3482,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -3428,6 +3547,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3548,6 +3670,9 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -3755,6 +3880,9 @@ packages:
   webgl-sdf-generator@1.1.1:
     resolution: {integrity: sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -3769,6 +3897,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3842,6 +3973,10 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3849,6 +3984,10 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -4853,6 +4992,72 @@ snapshots:
       '@vitest/spy': 2.0.5
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  '@tensorflow-models/universal-sentence-encoder@1.3.3(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/seedrandom': 2.4.34
+      seedrandom: 3.0.5
+
+  '@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/offscreencanvas': 2019.3.0
+      '@types/seedrandom': 2.4.34
+      seedrandom: 3.0.5
+
+  '@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-core@4.22.0':
+    dependencies:
+      '@types/long': 4.0.2
+      '@types/offscreencanvas': 2019.7.3
+      '@types/seedrandom': 2.4.34
+      '@webgpu/types': 0.1.38
+      long: 4.0.0
+      node-fetch: 2.6.13
+      seedrandom: 3.0.5
+    transitivePeerDependencies:
+      - encoding
+
+  '@tensorflow/tfjs-data@4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.6.13
+      seedrandom: 3.0.5
+      string_decoder: 1.3.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@tensorflow/tfjs-layers@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs@4.22.0(seedrandom@3.0.5)':
+    dependencies:
+      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-backend-webgl': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+      '@tensorflow/tfjs-data': 4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)
+      '@tensorflow/tfjs-layers': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      argparse: 1.0.10
+      chalk: 4.1.2
+      core-js: 3.29.1
+      regenerator-runtime: 0.13.11
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - encoding
+      - seedrandom
+
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4974,11 +5179,20 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/long@4.0.2': {}
+
   '@types/mdx@2.0.13': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+      form-data: 4.0.5
 
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/offscreencanvas@2019.3.0': {}
 
   '@types/offscreencanvas@2019.7.3': {}
 
@@ -5001,6 +5215,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/seedrandom@2.4.34': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -5297,6 +5513,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@webgpu/types@0.1.38': {}
+
   '@webgpu/types@0.1.69': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -5347,6 +5565,10 @@ snapshots:
       picomatch: 2.3.2
 
   arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -5430,6 +5652,8 @@ snapshots:
       js-tokens: 10.0.0
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.4.27(postcss@8.5.9):
     dependencies:
@@ -5565,6 +5789,12 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -5582,6 +5812,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@4.1.1: {}
 
@@ -5606,6 +5840,8 @@ snapshots:
       meow: 13.2.0
 
   convert-source-map@2.0.0: {}
+
+  core-js@3.29.1: {}
 
   cosmiconfig-typescript-loader@6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.2))(typescript@6.0.2):
     dependencies:
@@ -5701,6 +5937,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -6122,6 +6360,14 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fraction.js@5.3.4: {}
 
@@ -6687,6 +6933,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@4.0.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -6745,6 +6993,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -6779,6 +7033,10 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@2.6.13:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-releases@2.0.37: {}
 
@@ -7079,6 +7337,8 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regenerator-runtime@0.13.11: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.9
@@ -7167,6 +7427,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.2.1: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -7189,6 +7451,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  seedrandom@3.0.5: {}
 
   semver@6.3.1: {}
 
@@ -7265,6 +7529,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  sprintf-js@1.0.3: {}
 
   stack-utils@2.0.6:
     dependencies:
@@ -7369,6 +7635,10 @@ snapshots:
       call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -7496,6 +7766,8 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@0.0.3: {}
 
   tr46@6.0.0:
     dependencies:
@@ -7682,6 +7954,8 @@ snapshots:
 
   webgl-sdf-generator@1.1.1: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -7695,6 +7969,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7779,9 +8058,21 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
 
   yargs-parser@22.0.0: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/src/components/Topbar/Topbar.test.tsx
+++ b/src/components/Topbar/Topbar.test.tsx
@@ -108,6 +108,17 @@ describe('Topbar', () => {
     expect(screen.getByText('42件')).toBeInTheDocument();
   });
 
+  it('shows localized search engine suffix when embEngine is tfjs', () => {
+    renderTopbar({ embStatus: 'ready', embCount: 10, embEngine: 'tfjs' });
+    expect(screen.getByText(/10件 \(TF\.js USE\)/)).toBeInTheDocument();
+  });
+
+  it('omits engine suffix when embEngine is pending', () => {
+    renderTopbar({ embStatus: 'ready', embCount: 10, embEngine: 'pending' });
+    expect(screen.getByText('10件')).toBeInTheDocument();
+    expect(screen.queryByText(/10件 \(pending\)/)).not.toBeInTheDocument();
+  });
+
   it('renders embedding status as loading', () => {
     renderTopbar({ embStatus: 'loading', embCount: 0 });
     expect(screen.getByText('モデル読込中')).toBeInTheDocument();

--- a/src/components/Topbar/Topbar.tsx
+++ b/src/components/Topbar/Topbar.tsx
@@ -5,6 +5,7 @@ import { Typing, Badge } from '../atoms';
 import type { Material } from '../../types';
 import { STORYBOOK_URL } from '../../data/constants';
 import { isComposing } from '../../utils/keyboard';
+import { formatSearchEngineLabel } from '../../utils/searchEngine';
 
 interface TopbarProps {
   theme: string;
@@ -29,7 +30,8 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
     { id: 'eng',   label: 'Eng' },
     { id: 'cae',   label: 'CAE' },
   ];
-  const engineSuffix = embEngine && embEngine !== 'Keyword' ? ` (${embEngine})` : '';
+  const engineLabel = formatSearchEngineLabel(embEngine);
+  const engineSuffix = engineLabel ? ` (${engineLabel})` : '';
   const vecStatusLabel = { idle:'初期化中', loading:'モデル読込中', indexing:'索引構築中', ready:`${embCount}件${engineSuffix}`, fallback:'キーワード検索' }[embStatus] || '—';
 
   // Highlight matched text with yellow marker

--- a/src/components/ui/ChatSupport/ChatSupport.stories.tsx
+++ b/src/components/ui/ChatSupport/ChatSupport.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ChatSupport } from './ChatSupport'
+
+const meta: Meta<typeof ChatSupport> = {
+  title: 'Components/UI/ChatSupport',
+  component: ChatSupport,
+  tags: ['autodocs'],
+  parameters: {
+    /**
+     * ChatSupport の Story を Canvas で開くとき、preview.tsx の Decorator が
+     * 同じ <ChatSupport /> をもう一度レンダリングしてしまい二重表示になる。
+     * このフラグを true にすると Decorator 側がスキップし、Story 自身の
+     * <ChatSupport /> だけが描画される。
+     *
+     * 実装は .storybook/preview.tsx を参照：
+     *   const disableDecoratorChat = context.parameters?.disableDecoratorChat === true
+     *   {viewMode !== 'docs' && !disableDecoratorChat && <ChatSupport ... />}
+     */
+    disableDecoratorChat: true,
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+## ChatSupport — Storybook AI チャットウィジェット
+
+Storybook 全ページに浮かぶ AI チャットパネル。FAQヒット → storyGuideMap → AI プロキシ の 3 段階でコストを最小化する。
+
+---
+
+### アーキテクチャ
+
+\`\`\`
+ChatSupport/
+  ChatSupport.tsx          メインコンテナ（レイアウト切り替え・状態結合）
+  chatAiService.ts         AI 呼び出し・レート制限・ストリーミング
+  chatSupportTypes.ts      型定義（StoryContext / Provider / ModelOption …）
+  chatSupportConstants.ts  モデル設定・クイック提案テキスト
+  faqDatabase.ts           FAQ データ（キーワード + 質問 + 回答）
+  faqService.ts            Fuse.js ラッパー（スコアしきい値でフィルタ）
+  storyGuideMap.ts         ページ別ガイド文（ストーリータイトル → tips[]）
+  CodeBlock.tsx            コードブロックレンダラー（Prism.js）
+  renderContent.tsx        Markdown → React 変換
+  components/              UI 分割（Fab / Header / Input / Message / Panel / Settings / Sidebar）
+  hooks/                   useChat / useChatConfig / useChatMessage / useResize
+\`\`\`
+
+---
+
+### Storybook Decorator との連携
+
+#### 1. argTypes / args の自動注入
+
+\`.storybook/preview.tsx\` のデコレーターが \`context.argTypes\` と \`context.args\` を
+\`StoryContext\` として ChatSupport に渡す。AI のシステムプロンプトにコンポーネントの
+prop 仕様が自動展開されるため、storyGuideMap に prop 情報を手で書く必要がない。
+
+#### 2. useRef パターン（args 変更時の再生成抑制）
+
+Controls パネルで値を変えるたびに \`context.args\` が新しい参照になるため、
+単純に \`useMemo\` の deps に含めると \`currentStory\` が毎回再生成される。
+\`useRef\` で最新値を追跡しつつ \`useMemo\` の deps からは除外することで解決：
+
+\`\`\`tsx
+const argTypesRef = useRef(context.argTypes)
+const argsRef = useRef(context.args)
+argTypesRef.current = context.argTypes  // 毎 render で同期
+argsRef.current = context.args
+
+const currentStory = useMemo(() => ({
+  title: context.title,
+  name: context.name,
+  description,
+  argTypes: argTypesRef.current,  // ref の値を useMemo 内で読む
+  args: argsRef.current,
+}), [context.title, context.name, description]) // args/argTypes は deps に含めない
+\`\`\`
+
+#### 3. disableDecoratorChat — 二重レンダリング防止
+
+ChatSupport 自身の Story を Canvas で開くと、Decorator が ChatSupport を
+もう一度マウントして二重表示になる。Story の meta に以下を追加すると回避できる：
+
+\`\`\`tsx
+const meta: Meta<typeof ChatSupport> = {
+  parameters: {
+    disableDecoratorChat: true,
+  },
+}
+\`\`\`
+
+preview.tsx の実装：
+\`\`\`tsx
+const disableDecoratorChat = context.parameters?.disableDecoratorChat === true
+{context.viewMode !== 'docs' && !disableDecoratorChat && (
+  <ChatSupport currentStory={currentStory} />
+)}
+\`\`\`
+
+---
+
+### 検索フォールバック優先順位
+
+1. **FAQ（Fuse.js）** — スコア 0.4 以上のヒットがあれば AI を呼ばずに返答
+2. **storyGuideMap** — ページ別の手書きガイド（PageContextBanner 経由で表示）
+3. **AI プロキシ（/api/ai）** — 共有プール（nano/mini/gemini）または自前キー（gpt-5.4）
+
+---
+
+### 関連コンポーネント
+
+- \`PageContextBanner\` — ストーリーのガイドが storyGuideMap にある場合だけ表示
+- \`QuickSuggestions\` — 会話が空のとき pill ボタンで定型クエリを提示
+        `,
+      },
+    },
+  },
+  argTypes: {
+    currentStory: {
+      control: false,
+      description: '現在の Storybook コンテキスト（title / name / description / argTypes / args）。通常は Decorator が自動注入する。',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ChatSupport>
+
+export const Default: Story = {
+  args: {
+    currentStory: {
+      title: 'Components/UI/ChatSupport',
+      name: 'Default',
+      description: 'Storybook 全ページに浮かぶ AI チャットウィジェットのデモ。',
+    },
+  },
+}
+
+export const WithArgTypes: Story = {
+  name: 'argTypes 注入あり',
+  args: {
+    currentStory: {
+      title: 'Components/Atoms/Button',
+      name: 'Primary',
+      description: 'プライマリボタン',
+      argTypes: {
+        label: { type: { name: 'string' }, description: 'ボタンのラベル' },
+        disabled: { type: { name: 'boolean' }, description: '無効状態' },
+      },
+      args: {
+        label: 'クリック',
+        disabled: false,
+      },
+    },
+  },
+}
+
+export const NoStory: Story = {
+  name: 'ストーリーなし（ウェルカム状態）',
+  args: {
+    currentStory: null,
+  },
+}

--- a/src/hooks/useEmbedding/useEmbedding.ts
+++ b/src/hooks/useEmbedding/useEmbedding.ts
@@ -56,7 +56,7 @@ function tokenize(query: string): string[] {
   if (!q) return [];
   // Split on whitespace, punctuation (Japanese and ASCII), and common separators
   const tokens = q
-    .split(/[\s、。・，．,.\/\\\-_;:!?"'（）()「」『』【】\[\]]+/)
+    .split(/[\s、。・，．,./\\\-_;:!?"'（）()「」『』【】[\]]+/)
     .filter(t => t.length > 0);
   // If tokenization yielded only one long Japanese token, generate character bigrams.
   // Hoist tokens[0] into a local so strict mode's noUncheckedIndexedAccess is happy.

--- a/src/hooks/useEmbedding/useEmbedding.ts
+++ b/src/hooks/useEmbedding/useEmbedding.ts
@@ -87,7 +87,8 @@ function keywordSearch(db: Material[], query: string, topK: number): MaterialWit
 }
 
 export function useEmbedding(db: Material[]): EmbeddingHook {
-  const [engine, setEngine] = useState<string>('ready');
+  /** 直近の検索で使ったバックエンド（初回は未検索の pending） */
+  const [engine, setEngine] = useState<string>('pending');
   // Track the in-flight AbortController so each new search cancels the
   // previous one. Without this, a user typing fast in the search box races
   // multiple /api/search round-trips and whichever finishes *last* wins,
@@ -116,11 +117,13 @@ export function useEmbedding(db: Material[]): EmbeddingHook {
       });
       if (!res.ok) throw new Error('Search API error');
       const data: { engine?: string; results?: SearchApiRow[] } = await res.json();
-      setEngine(data.engine || 'server');
 
       if (data.results && data.results.length > 0) {
+        setEngine(data.engine || 'server');
         return data.results.map(r => mapSearchRowToMaterial(r, db));
       }
+      // 200 だが候補ゼロ → クライアントキーワードへ（engine は upstash のままにしない）
+      setEngine('keyword');
     } catch (err) {
       // An AbortError is a deliberate cancellation (user typed a new
       // query, or the component unmounted). Return an empty list without

--- a/src/hooks/useEmbedding/useEmbedding.ts
+++ b/src/hooks/useEmbedding/useEmbedding.ts
@@ -1,5 +1,54 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import type { Material, MaterialWithScore, EmbeddingHook } from '../../types';
+import type { Material, MaterialCategory, MaterialWithScore, EmbeddingHook } from '../../types';
+import { semanticSearchWithTfjs } from '../../services/tfjsSemanticSearch';
+
+/** `/api/search` の JSON 行（Upstash メタのみ / キーワード時は Material 近似） */
+interface SearchApiRow {
+  id: string;
+  score?: number;
+  date?: string;
+  name?: string;
+  cat?: string;
+  hv?: number;
+  ts?: number;
+  el?: number;
+  pf?: number | null;
+  el2?: number;
+  dn?: number;
+  comp?: string;
+  batch?: string;
+  author?: string;
+  status?: string;
+  ai?: boolean;
+  memo?: string;
+}
+
+function mapSearchRowToMaterial(r: SearchApiRow, db: Material[]): MaterialWithScore {
+  if (r.date !== undefined) {
+    return r as MaterialWithScore;
+  }
+  const local = db.find(m => m.id === r.id);
+  if (local) return { ...local, score: r.score ?? 0 };
+  return {
+    id: r.id,
+    name: r.name ?? '',
+    cat: (r.cat as MaterialCategory) ?? '金属合金',
+    hv: r.hv ?? 0,
+    ts: r.ts ?? 0,
+    el: r.el ?? 0,
+    pf: r.pf ?? null,
+    el2: r.el2 ?? 0,
+    dn: r.dn ?? 0,
+    comp: r.comp ?? '',
+    batch: r.batch ?? '',
+    date: r.date ?? '',
+    author: r.author ?? '',
+    status: (r.status as Material['status']) ?? '登録済',
+    ai: r.ai ?? false,
+    memo: r.memo ?? '',
+    score: r.score ?? 0,
+  };
+}
 
 // Tokenize query for keyword matching (Japanese-aware)
 function tokenize(query: string): string[] {
@@ -66,26 +115,11 @@ export function useEmbedding(db: Material[]): EmbeddingHook {
         signal: controller.signal,
       });
       if (!res.ok) throw new Error('Search API error');
-      const data = await res.json();
+      const data: { engine?: string; results?: SearchApiRow[] } = await res.json();
       setEngine(data.engine || 'server');
 
       if (data.results && data.results.length > 0) {
-        // Map server results back to MaterialWithScore
-        // Server may return full Material objects (keyword) or partial (upstash)
-        return data.results.map((r: any) => {
-          // If result came from keyword search, it already has full Material fields
-          if (r.date !== undefined) return r as MaterialWithScore;
-          // Upstash results: find matching material in local db, attach score
-          const local = db.find(m => m.id === r.id);
-          if (local) return { ...local, score: r.score ?? 0 };
-          // Construct minimal result from server metadata
-          return {
-            id: r.id, name: r.name || '', cat: r.cat || '金属合金',
-            hv: r.hv || 0, ts: r.ts || 0, el: 0, pf: null, el2: 0, dn: r.dn || 0,
-            comp: r.comp || '', batch: '', date: '', author: '', status: '登録済' as const,
-            ai: false, memo: '', score: r.score ?? 0,
-          } as MaterialWithScore;
-        });
+        return data.results.map(r => mapSearchRowToMaterial(r, db));
       }
     } catch (err) {
       // An AbortError is a deliberate cancellation (user typed a new
@@ -94,7 +128,12 @@ export function useEmbedding(db: Material[]): EmbeddingHook {
       if (err instanceof DOMException && err.name === 'AbortError') {
         return [];
       }
-      // Server unavailable — use client-side keyword fallback
+      // サーバー不可時: まず TensorFlow.js + USE（ブラウザ内）、だめならキーワード
+      const tfResults = await semanticSearchWithTfjs(db, query, topK, controller.signal);
+      if (tfResults.length > 0) {
+        setEngine('tfjs');
+        return tfResults;
+      }
       setEngine('keyword');
     }
 

--- a/src/pages/VectorSearch/VectorSearchPage.tsx
+++ b/src/pages/VectorSearch/VectorSearchPage.tsx
@@ -4,6 +4,7 @@ import { Button, Badge, Card, Input, Select, Typing } from '../../components/ato
 import { VecCard } from '../../components/molecules';
 import type { Material, EmbeddingHook, AIHook, MaterialWithScore } from '../../types';
 import { isPlainEnter } from '../../utils/keyboard';
+import { formatSearchEngineLabel } from '../../utils/searchEngine';
 
 interface VectorSearchPageProps {
   db: Material[];
@@ -19,6 +20,14 @@ export const VectorSearchPage = ({ db, embedding, claude }: VectorSearchPageProp
   const [searched, setSearched] = useState(false);
 
   const PRESETS = ['高温強度が高い耐熱合金','軽量で高比強度の材料','耐食性に優れるステンレス系','生体適合性がある金属','低摩擦・化学的に安定なポリマー'];
+
+  const engineLbl = formatSearchEngineLabel(embedding.engine);
+  const engineBadgeText =
+    embedding.status === 'ready'
+      ? engineLbl
+        ? `${embedding.embCount}件 検索可能（${engineLbl}）`
+        : `${embedding.embCount}件 検索可能`
+      : '初期化中...';
 
   const runSearch = async (q = query) => {
     if (!q.trim()) return;
@@ -39,13 +48,17 @@ export const VectorSearchPage = ({ db, embedding, claude }: VectorSearchPageProp
       </div>
 
       <VecCard>
-        各材料テキスト（名称・組成・特性）を <strong className="text-text-hi">OpenAI text-embedding-3-small</strong> で 1536次元ベクトルに変換し、
-        <strong className="text-text-hi">Upstash Vector</strong> に保存。クエリとの <strong className="text-text-hi">コサイン類似度</strong> を計算してランキング表示します。
-        キーワード検索では拾えない「意味的に近い材料」を発見できます。
+        通常は各材料テキスト（名称・組成・特性）を <strong className="text-text-hi">OpenAI text-embedding-3-small</strong> で 1536 次元にし、
+        <strong className="text-text-hi">Upstash Vector</strong> 上で <strong className="text-text-hi">コサイン類似度</strong> によりランキングします。
+        <span className="block mt-1.5">
+          <strong className="text-text-hi">API が利用できない場合</strong> はブラウザ内の{' '}
+          <strong className="text-text-hi">TensorFlow.js + Universal Sentence Encoder</strong>（512 次元）に自動フォールバックし、
+          それでも失敗するとキーワード検索に切り替わります。
+        </span>
         <div className="mt-2 text-[12px]">
           <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full ${embedding.status==='ready' ? 'bg-[var(--ok-dim)] text-ok' : 'bg-raised text-text-lo'}`}>
-            <Icon name="embed" size={11} />
-            {embedding.status==='ready' ? `${embedding.embCount}件 検索可能（${embedding.engine}）` : '初期化中...'}
+            <Icon name="embed" size={12} />
+            {engineBadgeText}
           </span>
         </div>
       </VecCard>
@@ -86,15 +99,15 @@ export const VectorSearchPage = ({ db, embedding, claude }: VectorSearchPageProp
               <div className="flex items-end gap-1.5 h-10">
                 {results.map((r, i) => (
                   <div key={r.id} className="flex-1 flex flex-col items-center gap-1">
-                    <span className="text-[10px] text-text-lo">{Math.round((r.score||0)*100)}%</span>
+                    <span className="text-[12px] text-text-lo">{Math.round((r.score||0)*100)}%</span>
                     <div className="w-full rounded-t-sm" style={{ height: `${Math.round((r.score||0)*100)*.28}px`, background: 'var(--vec-mid)', opacity: .4 + (results.length-i)/results.length*.6 }} />
                   </div>
                 ))}
               </div>
               <div className="flex gap-1.5 mt-1">
-                {results.map(r => <div key={r.id} className="flex-1 text-[10px] text-text-lo text-center truncate">{r.id.slice(-4)}</div>)}
+                {results.map(r => <div key={r.id} className="flex-1 text-[12px] text-text-lo text-center truncate">{r.id.slice(-4)}</div>)}
               </div>
-              <p className="text-[11px] text-text-lo mt-1.5">クエリ: "{query}"</p>
+              <p className="text-[12px] text-text-lo mt-1.5">クエリ: "{query}"</p>
             </Card>
           )}
 

--- a/src/services/tfjsSemanticSearch.test.ts
+++ b/src/services/tfjsSemanticSearch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { Material } from '../types';
+import { cosineSimilarity, materialTextForEmbedding } from './tfjsSemanticSearch';
+
+const sampleMaterial = (): Material => ({
+  id: 'm1',
+  name: '試料A',
+  cat: '金属合金',
+  hv: 100,
+  ts: 200,
+  el: 1,
+  pf: null,
+  el2: 0,
+  dn: 7.8,
+  comp: 'Fe-C',
+  batch: 'b1',
+  date: '2024-01-01',
+  author: 't',
+  status: '登録済',
+  ai: false,
+  memo: '高強度',
+});
+
+describe('materialTextForEmbedding', () => {
+  it('concatenates name, category, composition, memo', () => {
+    const t = materialTextForEmbedding(sampleMaterial());
+    expect(t).toContain('試料A');
+    expect(t).toContain('金属合金');
+    expect(t).toContain('Fe-C');
+    expect(t).toContain('高強度');
+  });
+});
+
+describe('cosineSimilarity', () => {
+  it('returns 1 for identical vectors', () => {
+    const v = [1, 2, 3];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1);
+  });
+
+  it('returns 0 for orthogonal vectors', () => {
+    expect(cosineSimilarity([1, 0], [0, 1])).toBe(0);
+  });
+
+  it('returns 0 for length mismatch or empty', () => {
+    expect(cosineSimilarity([1], [1, 2])).toBe(0);
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+});

--- a/src/services/tfjsSemanticSearch.ts
+++ b/src/services/tfjsSemanticSearch.ts
@@ -1,0 +1,122 @@
+import type { Material, MaterialWithScore } from '../types';
+
+/** Batch size for USE.embed (balance memory vs round-trips). */
+const EMBED_BATCH = 16;
+
+export function materialTextForEmbedding(m: Material): string {
+  return `${m.name} ${m.cat} ${m.comp} ${m.memo}`;
+}
+
+export function cosineSimilarity(a: ReadonlyArray<number>, b: ReadonlyArray<number>): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!;
+    const y = b[i]!;
+    dot += x * y;
+    na += x * x;
+    nb += y * y;
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom > 0 ? dot / denom : 0;
+}
+
+function dbFingerprint(db: Material[]): string {
+  return db.map(m => m.id).join('\u0000');
+}
+
+type Tensor2DLike = {
+  array: () => Promise<number[][]>;
+  dispose: () => void;
+};
+
+type UniversalSentenceEncoderLike = {
+  embed: (inputs: string[] | string) => Promise<Tensor2DLike>;
+};
+
+let cachedFingerprint = '';
+let vectorsById: Map<string, number[]> | null = null;
+let loadPromise: Promise<UniversalSentenceEncoderLike> | null = null;
+
+async function loadEncoder(): Promise<UniversalSentenceEncoderLike> {
+  const mod = await import('@tensorflow-models/universal-sentence-encoder');
+  return mod.load() as Promise<UniversalSentenceEncoderLike>;
+}
+
+async function getModel(): Promise<UniversalSentenceEncoderLike> {
+  if (!loadPromise) loadPromise = loadEncoder();
+  return loadPromise;
+}
+
+/** Vitest などでキャッシュを捨てる */
+export function resetTfjsEmbeddingCacheForTests(): void {
+  cachedFingerprint = '';
+  vectorsById = null;
+  loadPromise = null;
+}
+
+async function tensorToRows(t: Tensor2DLike): Promise<number[][]> {
+  try {
+    return await t.array();
+  } finally {
+    t.dispose();
+  }
+}
+
+/**
+ * `/api/search` が使えないときのブラウザ内フォールバック。
+ * Universal Sentence Encoder（512 次元）＋コサイン類似度。動的 import のみ。
+ */
+export async function semanticSearchWithTfjs(
+  db: Material[],
+  query: string,
+  topK: number,
+  signal?: AbortSignal,
+): Promise<MaterialWithScore[]> {
+  const q = query.trim();
+  if (!q || db.length === 0) return [];
+
+  try {
+    const model = await getModel();
+    if (signal?.aborted) return [];
+
+    const fp = dbFingerprint(db);
+    if (fp !== cachedFingerprint || vectorsById === null) {
+      const next = new Map<string, number[]>();
+      const texts = db.map(materialTextForEmbedding);
+      for (let i = 0; i < texts.length; i += EMBED_BATCH) {
+        if (signal?.aborted) return [];
+        const slice = texts.slice(i, i + EMBED_BATCH);
+        const t = await model.embed(slice);
+        const rows = await tensorToRows(t);
+        for (let j = 0; j < rows.length; j++) {
+          const row = rows[j];
+          const mat = db[i + j];
+          if (row !== undefined && mat !== undefined) next.set(mat.id, row);
+        }
+      }
+      vectorsById = next;
+      cachedFingerprint = fp;
+    }
+
+    if (signal?.aborted) return [];
+
+    const qt = await model.embed([q]);
+    const qRows = await tensorToRows(qt);
+    const queryVec = qRows[0];
+    if (!queryVec?.length) return [];
+
+    const scored: MaterialWithScore[] = db.map(m => {
+      const v = vectorsById?.get(m.id);
+      return { ...m, score: v ? cosineSimilarity(queryVec, v) : 0 };
+    });
+
+    return scored
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK);
+  } catch {
+    return [];
+  }
+}

--- a/src/test/helpers.tsx
+++ b/src/test/helpers.tsx
@@ -34,7 +34,7 @@ const mockEmbedding: EmbeddingHook = {
   search: vi.fn().mockResolvedValue([]),
   addToIndex: vi.fn().mockResolvedValue(undefined),
   embCount: 15,
-  engine: 'keyword',
+  engine: 'pending',
 };
 
 const mockVoice = {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -12,13 +12,16 @@ afterEach(() => {
   cleanup();
 });
 
-// Mock TensorFlow.js + USE (heavy ML deps)
-vi.mock('@tensorflow/tfjs', () => ({}));
+// TensorFlow.js + USE は動的 import のみ。テストで誤ってロードしたときの軽量スタブ
 vi.mock('@tensorflow-models/universal-sentence-encoder', () => ({
   load: vi.fn().mockResolvedValue({
-    embed: vi.fn().mockResolvedValue({
-      array: vi.fn().mockResolvedValue([new Array(512).fill(0)]),
-      dispose: vi.fn(),
+    embed: vi.fn().mockImplementation(async (inputs: string | string[]) => {
+      const list = Array.isArray(inputs) ? inputs : [inputs];
+      const rows = list.map(() => new Array<number>(512).fill(0.01));
+      return {
+        array: async () => rows,
+        dispose: vi.fn(),
+      };
     }),
   }),
 }));

--- a/src/utils/searchEngine.test.ts
+++ b/src/utils/searchEngine.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { formatSearchEngineLabel } from './searchEngine';
+
+describe('formatSearchEngineLabel', () => {
+  it('returns null for pending and undefined', () => {
+    expect(formatSearchEngineLabel('pending')).toBeNull();
+    expect(formatSearchEngineLabel(undefined)).toBeNull();
+  });
+
+  it('maps known engines', () => {
+    expect(formatSearchEngineLabel('upstash')).toBe('Upstash');
+    expect(formatSearchEngineLabel('keyword')).toBe('キーワード');
+    expect(formatSearchEngineLabel('tfjs')).toBe('TF.js USE');
+    expect(formatSearchEngineLabel('server')).toBe('サーバー');
+  });
+
+  it('passes through unknown ids for forward compatibility', () => {
+    expect(formatSearchEngineLabel('future-engine')).toBe('future-engine');
+  });
+});

--- a/src/utils/searchEngine.ts
+++ b/src/utils/searchEngine.ts
@@ -1,0 +1,29 @@
+/**
+ * useEmbedding / `/api/search` が返すエンジン識別子。
+ * 将来の API 拡張では未知の文字列が来る可能性があるため、表示系は default 分岐で生値を出す。
+ */
+export type SearchEngineId =
+  | 'pending'
+  | 'upstash'
+  | 'keyword'
+  | 'tfjs'
+  | 'server';
+
+/** トップバー等の接尾辞用。未確定・未検索時は null（括弧を付けない） */
+export function formatSearchEngineLabel(engine: string | undefined): string | null {
+  switch (engine) {
+    case 'pending':
+    case undefined:
+      return null;
+    case 'upstash':
+      return 'Upstash';
+    case 'keyword':
+      return 'キーワード';
+    case 'tfjs':
+      return 'TF.js USE';
+    case 'server':
+      return 'サーバー';
+    default:
+      return engine;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,10 @@ export default defineConfig(({ mode }) => {
   const analyze = process.env.ANALYZE === '1';
 
   return {
+    optimizeDeps: {
+      // TF.js フォールバック経路の初回 dev 読み込みを安定させる
+      include: ['@tensorflow/tfjs', '@tensorflow-models/universal-sentence-encoder'],
+    },
     plugins: [
       react(),
       devApiProxy(),

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,10 @@ export default defineConfig(({ mode }) => {
         open: false,
       }),
     ].filter(Boolean),
+    resolve: {
+      // Prevent duplicate React instances (e.g. lucide-react v1.x useLucideContext)
+      dedupe: ['react', 'react-dom'],
+    },
     build: {
       outDir: 'dist',
     },


### PR DESCRIPTION
## 変更概要

### UI/UX の変化
- **トップバーのエンジン表示**: `pending`（未検索）のとき括弧表示を非表示に。`upstash` → `Upstash`、`keyword` → `キーワード`、`tfjs` → `TF.js USE` と日本語/整形ラベルで表示
- **ベクトル検索ページ**: API 不可時の TF.js → キーワードの自動フォールバック説明を追記。バッジ文言を `formatSearchEngineLabel` 経由に統一
- **棒グラフの文字**: 10px → 12px で可読性向上

### ロジック修正
- `useEmbedding` の `engine` 初期値を `'ready'` → `'pending'`（未検索状態を正確に表現）
- `/api/search` が 200 だが結果ゼロのとき engine を `'keyword'` に設定（従来は `'server'` のまま残っていたバグを修正）

### 新規ユーティリティ
- `src/utils/searchEngine.ts`: `SearchEngineId` 型 + `formatSearchEngineLabel()` — エンジン識別子の表示変換を一元管理
- `src/utils/searchEngine.test.ts`: 全パターンのユニットテスト

### Vite 安定化
- `optimizeDeps.include` に TF.js を追加（dev 初回起動時の動的 import を安定化）
- `resolve.dedupe: ['react', 'react-dom']`（lucide-react v1 の二重インスタンス問題を解消）

## テスト
- 481/481 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * TensorFlow.js を使用したブラウザ内セマンティック検索のフォールバック機能を追加しました。API が利用できない場合、自動的にクライアント側の埋め込みを使用し、さらにキーワード検索にフォールバックします。

* **改善**
  * 検索エンジンステータス表示を改良し、使用中のエンジン（Upstash、TF.js、キーワード）をバッジに表示するようにしました。
  * UI 要素のフォントサイズを調整し、可読性を向上させました。

* **テスト**
  * セマンティック検索とエンジンラベル機能の単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->