### PR TITLE
feat(download): 全ダウンロード箇所にプレビュー確認モーダルを適用

### DIFF
--- a/src/components/molecules/molecules.tsx
+++ b/src/components/molecules/molecules.tsx
@@ -11,6 +11,8 @@ import { Tooltip } from '../Tooltip';
 import { Button, Badge, Card, Input, SectionCard } from '../atoms';
 import { AppCtx } from '../../context/AppContext';
 import { Material, AppContextValue } from '../../types';
+import { DownloadPreviewModal, type DownloadPreviewLanguage } from './DownloadPreviewModal';
+import { downloadTextFile } from '../../services/downloadFile';
 
 interface ModalProps {
   open: boolean;
@@ -186,6 +188,7 @@ export const FilterChip = ({ label, onRemove }: FilterChipProps) => (
 // is enough — no custom equality function needed.
 export const MarkdownBubble = memo(function MarkdownBubble({ text, onSpeak }: MarkdownBubbleProps) {
   const [copied, setCopied] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
   const html = useMemo(() => renderSafeMarkdown(text), [text]);
 
   const handleCopy = async () => {
@@ -193,10 +196,10 @@ export const MarkdownBubble = memo(function MarkdownBubble({ text, onSpeak }: Ma
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
-  const handleDownload = () => {
-    const a = document.createElement('a');
-    a.href = 'data:text/plain;charset=utf-8,' + encodeURIComponent(text);
-    a.download = `matlens-ai-${Date.now()}.txt`; a.click();
+  const openDownloadPreview = () => setPreviewOpen(true);
+  const handleConfirmDownload = () => {
+    downloadTextFile(text, `matlens-ai-${Date.now()}.txt`, 'text/plain');
+    setPreviewOpen(false);
   };
 
   return (
@@ -214,28 +217,74 @@ export const MarkdownBubble = memo(function MarkdownBubble({ text, onSpeak }: Ma
           </Tooltip>
         )}
         <Tooltip label="テキストをファイルに保存" placement="top">
-          <button onClick={handleDownload} className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[12px] border border-[var(--border-faint)] text-text-lo hover:text-text-hi hover:bg-hover transition-all duration-150 font-ui">
+          <button onClick={openDownloadPreview} className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[12px] border border-[var(--border-faint)] text-text-lo hover:text-text-hi hover:bg-hover transition-all duration-150 font-ui">
             <Icon name="download" size={11} />保存
           </button>
         </Tooltip>
       </div>
+      <DownloadPreviewModal
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        onConfirm={handleConfirmDownload}
+        title="AI テキスト保存 プレビュー"
+        filename={`matlens-ai-${Date.now()}.txt`}
+        content={text}
+        language="text"
+        description="AI の回答テキストをプレーンテキストファイルとして保存します。"
+      />
     </div>
   );
 });
 
+/**
+ * ExportModal 内のダウンロードプレビュー状態。各「開く」アクションがこれを埋め、
+ * DownloadPreviewModal を介してユーザーが確認した後に実際のダウンロードを行う。
+ */
+interface ExportPreviewState {
+  title: string;
+  filename: string;
+  content: string;
+  language: DownloadPreviewLanguage;
+  mime: string;
+  description: string;
+  /** MaiML は既存 downloadMaimlFile() を経由させたいのでフック可能にする */
+  downloader?: (content: string, filename: string) => void;
+}
+
 export const ExportModal = ({ open, onClose, db, filtered }: ExportModalProps) => {
-  const exportCSV = () => {
+  const [preview, setPreview] = useState<ExportPreviewState | null>(null);
+  const today = new Date().toISOString().slice(0, 10);
+  const targetRows = filtered.length > 0 ? filtered : db;
+
+  // ─── プレビュー内容の生成 ───
+  const buildCSV = (): string => {
     const h = ['ID','名称','カテゴリ','硬度HV','引張MPa','弾性GPa','組成','バッチ','登録日','ステータス','備考'];
     const rows = filtered.map(r => [r.id,`"${r.name}"`,r.cat,r.hv,r.ts,r.el,`"${r.comp}"`,r.batch,r.date,r.status,`"${r.memo||''}"`]);
-    const csv = [h,...rows].map(r => r.join(',')).join('\n');
-    const a = document.createElement('a'); a.href = 'data:text/csv;charset=utf-8,\uFEFF'+encodeURIComponent(csv);
-    a.download = `matdb_${new Date().toISOString().slice(0,10)}.csv`; a.click(); onClose();
+    return [h,...rows].map(r => r.join(',')).join('\n');
   };
-  const exportJSON = () => {
-    const a = document.createElement('a');
-    a.href = 'data:application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify({exported:new Date().toISOString(),count:db.length,data:db},null,2));
-    a.download = `matdb_${new Date().toISOString().slice(0,10)}.json`; a.click(); onClose();
-  };
+  const buildJSON = (): string => JSON.stringify({
+    exported: new Date().toISOString(),
+    count: db.length,
+    data: db,
+  }, null, 2);
+
+  // ─── 各「開く」アクション ───
+  const exportCSV = () => setPreview({
+    title: 'CSV エクスポート プレビュー',
+    filename: `matdb_${today}.csv`,
+    content: buildCSV(),
+    language: 'csv',
+    mime: 'text/csv',
+    description: `Excel で開ける CSV 形式。${filtered.length} 件を出力します。`,
+  });
+  const exportJSON = () => setPreview({
+    title: 'JSON エクスポート プレビュー',
+    filename: `matdb_${today}.json`,
+    content: buildJSON(),
+    language: 'json',
+    mime: 'application/json',
+    description: `システム連携用の JSON 形式。DB 全 ${db.length} 件を出力します。`,
+  });
   const exportPDF = () => {
     const rows = db.map(r => `<tr><td>${r.id}</td><td>${r.name}</td><td>${r.cat}</td><td>${r.hv}</td><td>${r.ts}</td><td>${r.status}</td></tr>`).join('');
     const win = window.open('','_blank');
@@ -243,22 +292,47 @@ export const ExportModal = ({ open, onClose, db, filtered }: ExportModalProps) =
     win.document.write(`<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><title>Matlens レポート</title><style>body{font-family:sans-serif;font-size:11px;padding:20px}h1{font-size:16px;margin-bottom:4px}.meta{color:#666;font-size:11px;margin-bottom:16px}table{width:100%;border-collapse:collapse}th{background:#1e3050;color:#fff;padding:6px 8px;text-align:left;font-size:10px}td{padding:5px 8px;border-bottom:1px solid #e0e0e0;font-size:10px}tr:nth-child(even) td{background:#f7f7f5}</style></head><body><h1>Matlens 材料データレポート</h1><div class="meta">出力: ${new Date().toLocaleString('ja-JP')} ／ 総件数: ${db.length}件</div><table><thead><tr><th>ID</th><th>名称</th><th>カテゴリ</th><th>硬度HV</th><th>引張MPa</th><th>ステータス</th></tr></thead><tbody>${rows}</tbody></table></body></html>`);
     win.document.close(); setTimeout(() => win.print(), 400); onClose();
   };
-  const exportMaiML = () => {
-    const xml = serializeMaterialsToMaiml(filtered.length > 0 ? filtered : db);
-    downloadMaimlFile(xml, defaultMaimlFilename('matlens'));
-    onClose();
-  };
-  const exportMaiMLAll = () => {
-    const xml = serializeMaterialsToMaiml(db);
-    downloadMaimlFile(xml, `matlens_all_${new Date().toISOString().slice(0, 10)}.maiml`);
-    onClose();
-  };
+  const exportMaiML = () => setPreview({
+    title: 'MaiML エクスポート プレビュー（推奨）',
+    filename: defaultMaimlFilename('matlens'),
+    content: serializeMaterialsToMaiml(targetRows),
+    language: 'xml',
+    mime: 'application/xml',
+    description: `JIS K 0200:2024 準拠の MaiML XML。${targetRows.length} 件を出力します。`,
+    downloader: downloadMaimlFile,
+  });
+  const exportMaiMLAll = () => setPreview({
+    title: 'MaiML エクスポート プレビュー（全件）',
+    filename: `matlens_all_${today}.maiml`,
+    content: serializeMaterialsToMaiml(db),
+    language: 'xml',
+    mime: 'application/xml',
+    description: `JIS K 0200:2024 準拠の MaiML XML。DB 全 ${db.length} 件を出力します。`,
+    downloader: downloadMaimlFile,
+  });
   const exportMarkdown = () => {
     const rows = filtered.map(r => `| ${r.id} | ${r.name} | ${r.cat} | ${r.hv} | ${r.ts} | ${r.comp} | ${r.status} |`).join('\n');
     const md = `# Matlens 材料データ\n\n出力日時: ${new Date().toLocaleString('ja-JP')}  \n件数: ${filtered.length}件\n\n| ID | 名称 | カテゴリ | 硬度HV | 引張MPa | 組成 | ステータス |\n| --- | --- | --- | --- | --- | --- | --- |\n${rows}\n`;
-    const a = document.createElement('a');
-    a.href = 'data:text/markdown;charset=utf-8,' + encodeURIComponent(md);
-    a.download = `matdb_${new Date().toISOString().slice(0, 10)}.md`; a.click(); onClose();
+    setPreview({
+      title: 'Markdown エクスポート プレビュー',
+      filename: `matdb_${today}.md`,
+      content: md,
+      language: 'markdown',
+      mime: 'text/markdown',
+      description: `ドキュメント共有用の Markdown テーブル形式。${filtered.length} 件を出力します。`,
+    });
+  };
+
+  // プレビュー「ダウンロード実行」押下時の処理
+  const handleConfirmDownload = () => {
+    if (!preview) return;
+    if (preview.downloader) {
+      preview.downloader(preview.content, preview.filename);
+    } else {
+      downloadTextFile(preview.content, preview.filename, preview.mime);
+    }
+    setPreview(null);
+    onClose();
   };
 
   // MaiML is the platform's primary data format (JIS K 0200:2024), so it is
@@ -278,36 +352,51 @@ export const ExportModal = ({ open, onClose, db, filtered }: ExportModalProps) =
   ];
 
   return (
-    <Modal open={open} onClose={onClose} title="データエクスポート" footer={<Button variant="default" onClick={onClose}>閉じる</Button>}>
-      <div className="flex flex-col gap-3">
-        <button
-          onClick={primary.action}
-          className="flex items-center gap-3 p-4 rounded-md border-2 border-accent bg-accent-dim hover:bg-hover transition-all duration-150 text-left font-ui"
-        >
-          <div className="w-10 h-10 rounded-md bg-accent text-white flex items-center justify-center flex-shrink-0">
-            <Icon name="embed" size={18} />
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
-              <div className="text-[14px] font-bold text-text-hi">{primary.label}</div>
-              <Badge variant="blue" className="text-[10px]">PRIMARY</Badge>
+    <>
+      <Modal open={open} onClose={onClose} title="データエクスポート" footer={<Button variant="default" onClick={onClose}>閉じる</Button>}>
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={primary.action}
+            className="flex items-center gap-3 p-4 rounded-md border-2 border-accent bg-accent-dim hover:bg-hover transition-all duration-150 text-left font-ui"
+          >
+            <div className="w-10 h-10 rounded-md bg-accent text-white flex items-center justify-center flex-shrink-0">
+              <Icon name="embed" size={18} />
             </div>
-            <div className="text-[12px] text-text-md mt-0.5">{primary.desc}</div>
-          </div>
-        </button>
-        <div className="grid grid-cols-2 gap-2.5">
-          {secondary.map(item => (
-            <button key={item.label} onClick={item.action} className="flex flex-col items-center gap-2 p-3 bg-raised border border-[var(--border-default)] rounded-md cursor-pointer hover:border-accent hover:bg-hover transition-all duration-150 text-center font-ui">
-              <Icon name={item.icon} size={20} className="text-text-md" />
-              <div>
-                <div className="text-[12px] font-bold text-text-hi">{item.label}</div>
-                <div className="text-[11px] text-text-lo mt-0.5">{item.desc}</div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <div className="text-[14px] font-bold text-text-hi">{primary.label}</div>
+                <Badge variant="blue" className="text-[10px]">PRIMARY</Badge>
               </div>
-            </button>
-          ))}
+              <div className="text-[12px] text-text-md mt-0.5">{primary.desc}</div>
+            </div>
+          </button>
+          <div className="grid grid-cols-2 gap-2.5">
+            {secondary.map(item => (
+              <button key={item.label} onClick={item.action} className="flex flex-col items-center gap-2 p-3 bg-raised border border-[var(--border-default)] rounded-md cursor-pointer hover:border-accent hover:bg-hover transition-all duration-150 text-center font-ui">
+                <Icon name={item.icon} size={20} className="text-text-md" />
+                <div>
+                  <div className="text-[12px] font-bold text-text-hi">{item.label}</div>
+                  <div className="text-[11px] text-text-lo mt-0.5">{item.desc}</div>
+                </div>
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+      {/* Download Preview — 全フォーマット共通 */}
+      {preview && (
+        <DownloadPreviewModal
+          open={!!preview}
+          onClose={() => setPreview(null)}
+          onConfirm={handleConfirmDownload}
+          title={preview.title}
+          filename={preview.filename}
+          content={preview.content}
+          language={preview.language}
+          description={preview.description}
+        />
+      )}
+    </>
   );
 };
 

--- a/src/components/ui/ChatSupport/ChatSupport.tsx
+++ b/src/components/ui/ChatSupport/ChatSupport.tsx
@@ -8,7 +8,7 @@
 // localStorage so the user's preference survives page reloads and
 // story switches. When `closed`, only the FAB is visible.
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import type { StoryContext } from './chatSupportTypes'
 import { getStoryGuide } from './storyGuideMap'
 import { useChat } from './hooks/useChat'
@@ -22,6 +22,8 @@ import { ChatInput } from './components/ChatInput'
 import { ChatSettings } from './components/ChatSettings'
 import { ChatPanel } from './components/ChatPanel'
 import { ChatSidebar } from './components/ChatSidebar'
+import { DownloadPreviewModal } from '../../molecules/DownloadPreviewModal'
+import { downloadTextFile } from '../../../services/downloadFile'
 
 interface ChatSupportProps {
   currentStory: StoryContext | null
@@ -47,6 +49,24 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
   const chat = useChat()
   const [input, setInput] = useState('')
   const [showSettings, setShowSettings] = useState(false)
+  const [downloadPreviewOpen, setDownloadPreviewOpen] = useState(false)
+
+  // プレビュー表示用のエクスポートペイロードを memoize
+  // （モーダルが開いている間だけ生成して再計算を抑える）
+  const exportPayload = useMemo(
+    () => (downloadPreviewOpen ? chat.getExportPayload() : null),
+    [downloadPreviewOpen, chat],
+  )
+
+  const handleDownloadPreview = useCallback(() => {
+    setDownloadPreviewOpen(true)
+  }, [])
+
+  const handleConfirmDownload = useCallback(() => {
+    if (!exportPayload) return
+    downloadTextFile(exportPayload.content, exportPayload.filename, 'application/json')
+    setDownloadPreviewOpen(false)
+  }, [exportPayload])
 
   const message = useChatMessage({
     provider: config.provider,
@@ -114,7 +134,7 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
         layoutMode={config.layoutMode === 'sidebar' ? 'sidebar' : 'floating'}
         onToggleLayout={handleToggleLayout}
         onOpenSettings={() => setShowSettings(true)}
-        onDownload={chat.downloadMessages}
+        onDownload={handleDownloadPreview}
         onClear={chat.clearMessages}
         onClose={handleClose}
         showSettings={showSettings}
@@ -151,12 +171,12 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
     </>
   )
 
+  // 現在のレイアウトモードに対応する本体要素
+  let layoutEl: React.ReactNode
   if (config.layoutMode === 'closed') {
-    return <ChatFab onOpen={handleOpen} />
-  }
-
-  if (config.layoutMode === 'sidebar') {
-    return (
+    layoutEl = <ChatFab onOpen={handleOpen} />
+  } else if (config.layoutMode === 'sidebar') {
+    layoutEl = (
       <ChatSidebar
         width={config.sidebarWidth}
         onResizeStart={sidebarResize.handleSidebarResize}
@@ -164,14 +184,33 @@ export const ChatSupport = ({ currentStory }: ChatSupportProps) => {
         {body}
       </ChatSidebar>
     )
+  } else {
+    layoutEl = (
+      <ChatPanel
+        size={widgetResize.widgetSize}
+        onResizeStart={widgetResize.handleResizeStart}
+      >
+        {body}
+      </ChatPanel>
+    )
   }
 
   return (
-    <ChatPanel
-      size={widgetResize.widgetSize}
-      onResizeStart={widgetResize.handleResizeStart}
-    >
-      {body}
-    </ChatPanel>
+    <>
+      {layoutEl}
+      {/* 会話履歴ダウンロードはプレビューを挟んでから実行 */}
+      {exportPayload && (
+        <DownloadPreviewModal
+          open={downloadPreviewOpen}
+          onClose={() => setDownloadPreviewOpen(false)}
+          onConfirm={handleConfirmDownload}
+          title="会話履歴エクスポート プレビュー"
+          filename={exportPayload.filename}
+          content={exportPayload.content}
+          language="json"
+          description={`Storybook チャットの会話履歴を JSON でダウンロードします（${chat.messages.length} 件のメッセージ）。`}
+        />
+      )}
+    </>
   )
 }

--- a/src/components/ui/ChatSupport/hooks/useChat.ts
+++ b/src/components/ui/ChatSupport/hooks/useChat.ts
@@ -54,7 +54,13 @@ export interface UseChatResult {
     source?: ChatMessage['source'],
   ) => void
   clearMessages: () => void
+  /** 会話履歴を即ダウンロード (内部 API — 通常は getExportPayload + DownloadPreviewModal を使う) */
   downloadMessages: () => void
+  /**
+   * エクスポート内容とファイル名を生成して返す (ダウンロードはしない)。
+   * 呼出側でプレビューモーダルに渡してから実ダウンロードへ繋げる用途。
+   */
+  getExportPayload: () => { content: string; filename: string }
   hasMessages: boolean
 }
 
@@ -107,33 +113,45 @@ export function useChat(): UseChatResult {
     }
   }, [])
 
-  const downloadMessages = useCallback(() => {
+  /** エクスポートペイロード生成（ダウンロードはしない） */
+  const getExportPayload = useCallback(() => {
     const snapshot = {
       exportedAt: new Date().toISOString(),
       source: 'matlens-storybook-chatsupport',
       messages: messagesRef.current,
     }
-    const blob = new Blob([JSON.stringify(snapshot, null, 2)], {
-      type: 'application/json',
-    })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
     // ISO date in filename for easy sorting. Colons are illegal on
     // Windows filenames, so strip them.
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    a.download = `matlens-chat-${timestamp}.json`
+    return {
+      content: JSON.stringify(snapshot, null, 2),
+      filename: `matlens-chat-${timestamp}.json`,
+    }
+  }, [])
+
+  /**
+   * 下位互換用: 即ダウンロード (プレビューなし)。
+   * 新しい呼出側は getExportPayload + DownloadPreviewModal を使うことを推奨。
+   */
+  const downloadMessages = useCallback(() => {
+    const { content, filename } = getExportPayload()
+    const blob = new Blob([content], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }, [])
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }, [getExportPayload])
 
   return {
     messages,
     addMessage,
     clearMessages,
     downloadMessages,
+    getExportPayload,
     hasMessages: messages.length > 0,
   }
 }

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../services/maiml';
 import { Icon } from '../../components/Icon';
 import { Button, Badge, Card, SectionCard } from '../../components/atoms';
-import { Modal, AIInsightCard, VecCard } from '../../components/molecules';
+import { Modal, AIInsightCard, VecCard, DownloadPreviewModal } from '../../components/molecules';
 import { MaterialVisual } from '../../components/MaterialVisual';
 import { DataDisclaimer } from '../../components/DataDisclaimer';
 import { AppCtx } from '../../context/AppContext';
@@ -29,7 +29,21 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
   const [aiLoading, setAiLoading] = useState(true);
   const [vecNear, setVecNear] = useState<MaterialWithScore[]>([]);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [maimlPreviewOpen, setMaimlPreviewOpen] = useState(false);
   const { addToast } = useContext(AppCtx) as AppContextValue;
+
+  // 単一材料の MaiML プレビュー内容を memoize（モーダルを閉じるまで再計算しない）
+  const singleMaimlXml = useMemo(
+    () => (maimlPreviewOpen && r ? serializeMaterialToMaiml(r) : ''),
+    [maimlPreviewOpen, r],
+  );
+
+  const handleMaimlDownloadConfirm = () => {
+    if (!r) return;
+    downloadMaimlFile(singleMaimlXml, `${r.id}.maiml`);
+    addToast('MaiML ファイルをダウンロードしました');
+    setMaimlPreviewOpen(false);
+  };
 
   // Prev/Next navigation (via on-screen buttons only — no global arrow-key shortcut)
   const currentIndex = useMemo(() => db.findIndex(x => x.id === recordId), [db, recordId]);
@@ -64,6 +78,18 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
       }>
         <p><strong>{r.name}</strong>（{r.id}）を削除します。この操作は元に戻せません。</p>
       </Modal>
+
+      <DownloadPreviewModal
+        open={maimlPreviewOpen}
+        onClose={() => setMaimlPreviewOpen(false)}
+        onConfirm={handleMaimlDownloadConfirm}
+        title="MaiML エクスポート プレビュー（単一材料）"
+        filename={`${r.id}.maiml`}
+        content={singleMaimlXml}
+        language="xml"
+        description={`${r.name}（${r.id}）を JIS K 0200:2024 準拠の MaiML 形式で書き出します。`}
+      />
+
 
       {/* Breadcrumb + prev/next navigation */}
       <div className="flex items-center gap-1.5 text-[12px] text-text-lo">
@@ -106,11 +132,7 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
             <Button
               variant="default"
               size="sm"
-              onClick={() => {
-                const xml = serializeMaterialToMaiml(r);
-                downloadMaimlFile(xml, `${r.id}.maiml`);
-                addToast('MaiML ファイルをダウンロードしました');
-              }}
+              onClick={() => setMaimlPreviewOpen(true)}
               title="この材料を MaiML (JIS K 0200:2024) で書き出す"
             >
               <Icon name="download" size={12} />MaiML

--- a/src/services/downloadFile.ts
+++ b/src/services/downloadFile.ts
@@ -1,0 +1,31 @@
+/**
+ * downloadFile — ブラウザで文字列をファイルとしてダウンロードする共通ユーティリティ
+ *
+ * 各所にコピペされていた Blob / createObjectURL / 隠し `<a>` click パターンを集約。
+ * Firefox 互換性 (DOM append 必須) と URL.revokeObjectURL の遅延 revoke を統一する。
+ *
+ * 既存の downloadPnml / downloadMaimlFile も将来この関数に集約可能だが、本 PR では
+ * 新規呼出側のみ利用し、既存 API の破壊は行わない。
+ */
+
+const REVOKE_DELAY_MS = 1000
+
+/**
+ * 文字列を Blob 化して MIME 型指定でダウンロードさせる。
+ * @param content  ファイル内容
+ * @param filename 保存名（拡張子込み）
+ * @param mime     MIME 型（例: 'text/csv', 'application/json', 'application/xml'）
+ */
+export function downloadTextFile(content: string, filename: string, mime: string): void {
+  const blob = new Blob([content], { type: `${mime};charset=utf-8` })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  // Firefox は <a> が DOM にないと click() を無視する
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  // ダウンロード開始前に revoke するとブラウザが失敗することがあるため遅延
+  setTimeout(() => URL.revokeObjectURL(url), REVOKE_DELAY_MS)
+}


### PR DESCRIPTION
## 概要

issue #19 の実装。PR #18 で導入した `DownloadPreviewModal` を残りの全ダウンロード箇所に適用する。
ユーザー方針「全ての Data ダウンロードは Preview を一度挟んでから実行」を全域で実現。

## 変更内容

### 新規
- `src/services/downloadFile.ts` — `downloadTextFile()` 共通ユーティリティ。Blob + DOM append + 遅延 revoke の Firefox 互換パターンを一元化

### 適用箇所
| # | 場所 | フォーマット |
|---|---|---|
| 1 | `ExportModal` | CSV / JSON / Markdown / MaiML（フィルタ） / MaiML（全件） |
| 2 | `DetailPage` | 単一材料 MaiML |
| 3 | `MarkdownBubble` | AI テキスト (.txt) |
| 4 | `ChatSupport` | 会話履歴 JSON |

`useChat` フックに `getExportPayload()` を追加してダウンロード実処理と分離。既存 `downloadMessages` は下位互換のため残置。

## スコープ外

- PDF エクスポート — ブラウザ印刷ダイアログを開くためファイル書き出しではない

## テスト

- 515 件通過 (回帰なし)
- TypeScript strict 通過

## テスト計画

- [ ] ExportModal: 各フォーマット → プレビュー表示 → ダウンロード実行
- [ ] DetailPage: 単一 MaiML ボタン → プレビュー表示
- [ ] MarkdownBubble: 保存ボタン → プレビュー表示
- [ ] ChatSupport: 履歴 DL ボタン → プレビュー表示

closes #19