### PR TITLE
feat(bayes): ガウス過程回帰によるベイズ最適化 MVP (1D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # Matlens
 
-材料研究者・実験担当者向けのデータ管理システム。材料特性値の登録・検索・比較に加え、AIベクトル検索とRAGチャットで意思決定を支援する。
+金属試験データの管理プラットフォーム。**MaiML (JIS K 0200:2024) ネイティブ**の材料特性データ CRUD、
+**Petri net ワークフロー可視化**、**ベイズ最適化**（次実験候補の自動提案）、
+AI ベクトル検索と RAG チャットを統合した研究支援システム。
+
+対象ドメイン: 金属材料の組成・加工・試験・レポートのライフサイクル管理。
+類似サービス: IIC-HQ 等の試験ラボが提供する材料特性データ配信。
 
 ## Tech Stack
 
 | カテゴリ | 技術 |
 |---------|------|
-| ランタイム | React 19 + TypeScript |
-| ビルド | Vite 5 |
+| ランタイム | React 19 + TypeScript (strict + `noUncheckedIndexedAccess`) |
+| ビルド | Vite 6 |
 | スタイリング | Tailwind CSS 3 + CSS Variables (4テーマ) |
-| AI (LLM) | OpenAI GPT-5.4 nano/mini, Google Gemini 2.5 Flash |
-| ベクトル検索 | TensorFlow.js + Universal Sentence Encoder (ブラウザ内) |
+| AI (LLM) | AI SDK v6 + Vercel AI Gateway / OpenAI GPT-5.4 nano/mini / Google Gemini 2.5 Flash |
+| ベクトル検索 | Upstash Vector (サーバー) / TensorFlow.js + Universal Sentence Encoder (ブラウザフォールバック) |
+| データフォーマット | MaiML (JIS K 0200:2024), PNML (ISO/IEC 15909-2), CSV/JSON/Markdown |
+| 数値最適化 | ガウス過程回帰 + Expected Improvement (純 TypeScript 実装、依存なし) |
 | グラフ | Chart.js 4 |
 | アイコン | Lucide React |
-| Markdown | marked.js |
-| テスト | Vitest + Testing Library |
+| Markdown | marked.js + isomorphic-dompurify |
+| テスト | Vitest + Testing Library + jest-axe (a11y スモーク) |
 | コンポーネントカタログ | Storybook 10 (addon-a11y, addon-docs, addon-vitest) |
 | デザイントークン連携 | Figma Variables (カスタムプラグイン経由) |
-| デプロイ | Vercel (静的 + Serverless Functions) |
+| コード品質 | husky + commitlint (Conventional Commits) |
+| デプロイ | Vercel (Fluid Compute Functions + 静的ホスティング) |
 
 ## Getting Started
 
@@ -86,13 +94,15 @@ Matlens/
 │   │   ├── MaterialVisual/       材料ビジュアル (CSS/SVG)
 │   │   └── DataDisclaimer/       データ免責バナー
 │   │
-│   ├── pages/                    15ページ (各フォルダにコロケーション)
+│   ├── pages/                    17ページ (各フォルダにコロケーション)
 │   │   ├── Dashboard/            ダッシュボード (KPI + Chart.js)
 │   │   ├── MaterialList/         材料一覧 (テーブル/カード/コンパクト)
 │   │   ├── MaterialForm/         新規登録 / 編集フォーム
 │   │   ├── Detail/               材料詳細 (prev/next ナビ付き)
 │   │   ├── Catalog/              材料カタログ (CSSビジュアル)
-│   │   ├── VectorSearch/         意味検索 (TF.js Embedding)
+│   │   ├── PetriNet/             金属試験ワークフロー可視化 (P/T ネット + PNML)
+│   │   ├── BayesianOpt/          ベイズ最適化 (GP 回帰 + EI 獲得関数)
+│   │   ├── VectorSearch/         意味検索 (Upstash / TF.js)
 │   │   ├── RAGChat/              AIチャット (RAG)
 │   │   ├── Similar/              類似材料比較
 │   │   ├── ApiDebug/             API テスト (Mock REST)
@@ -117,7 +127,13 @@ Matlens/
 │   │   └── initialDb.ts          サンプル材料データ (68件)
 │   │
 │   ├── services/
-│   │   └── mockApi.ts            fetch インターセプター (Mock REST API)
+│   │   ├── mockApi.ts            fetch インターセプター (Mock REST API)
+│   │   ├── maiml.ts              MaiML (JIS K 0200:2024) シリアライザ/パーサ
+│   │   ├── pnml.ts               PNML (ISO/IEC 15909-2) エクスポーター
+│   │   ├── bayesianOpt.ts        ガウス過程回帰 + EI 獲得関数 (1D)
+│   │   ├── tfjsSemanticSearch.ts TF.js USE によるブラウザ内ベクトル検索
+│   │   ├── downloadFile.ts       Blob ダウンロード共通ユーティリティ
+│   │   └── safeMarkdown.ts       marked + DOMPurify (XSS 対策)
 │   │
 │   └── stories/                  Storybook ガイド・パターン
 │

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const UxDesignPage = lazy(() => import('./pages/UxDesign').then(m => ({ default:
 const TestSuitePage = lazy(() => import('./pages/TestSuite').then(m => ({ default: m.TestSuitePage })));
 const CatalogPage = lazy(() => import('./pages/Catalog/CatalogPage').then(m => ({ default: m.CatalogPage })));
 const PetriNetPage = lazy(() => import('./pages/PetriNet').then(m => ({ default: m.PetriNetPage })));
+const BayesianOptPage = lazy(() => import('./pages/BayesianOpt').then(m => ({ default: m.BayesianOptPage })));
 
 const LazyFallback = ({ label = 'ページを読み込み中...' }: { label?: string }) => (
   <div className="flex items-center justify-center h-64 text-text-lo">
@@ -204,6 +205,7 @@ export function App() {
       case 'sim':     return <SimilarPage {...commonProps} initialBase={simInitialBase} clearInitialBase={() => setSimInitialBase('')} />;
       case 'catalog': return lazyPage(<CatalogPage db={db} onNav={navTo} onDetail={showDetail} />);
       case 'petri':   return lazyPage(<PetriNetPage />);
+      case 'bayes':   return lazyPage(<BayesianOptPage db={db} />);
       case 'voice':   return lazyPage(<VoicePage />);
       case 'api':     return lazyPage(<ApiDebugPage db={db} dispatch={dispatch} />);
       case 'tests':   return lazyPage(<TestSuitePage />);

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,27 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-12-bayes-opt',
+    date: '2026-04-12',
+    type: 'feature',
+    title: 'ベイズ最適化ページを追加 — 次実験候補の自動提案',
+    body: 'ガウス過程回帰 + Expected Improvement 獲得関数で「次に試すべき実験点」を提案する新ページを追加しました。「ベイズ最適化」メニューから特徴変数と目的変数を選んで探索できます。',
+  },
+  {
+    id: '2026-04-12-download-preview',
+    date: '2026-04-12',
+    type: 'feature',
+    title: '全ダウンロードにプレビュー確認モーダルを導入',
+    body: 'CSV / JSON / Markdown / MaiML / PNML / AI テキスト / 会話履歴 の全データダウンロードで、ファイル内容・サイズ・行数を確認してから「ダウンロード実行」を押す 2 段階フローに変更しました。',
+  },
+  {
+    id: '2026-04-12-petri-net',
+    date: '2026-04-12',
+    type: 'feature',
+    title: '金属試験ワークフローのペトリネット可視化を追加',
+    body: '11 工程の金属試験ライフサイクルを Petri net で可視化する新ページを追加しました。トークンを発火させて工程を進められ、再加工フィードバックループや長時間試験の並行ステーション制約にも対応。PNML 形式で外部ツール (PIPE/GreatSPN) にエクスポート可能です。',
+  },
+  {
     id: '2026-04-10-notifications',
     date: '2026-04-10',
     type: 'feature',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -25,6 +25,7 @@ export const NAV_ITEMS: NavItem[] = [
   { id:'new',     label:'新規登録',         icon:'plus' },
   { section: 'ワークフロー' },
   { id:'petri',   label:'試験フロー可視化', icon:'workflow' },
+  { id:'bayes',   label:'ベイズ最適化',    icon:'spark',   badgeLabel:'AI', badgeVariant:'ai', cls:'ai-nav' },
   { section: 'AI 分析・検索' },
   { id:'vsearch', label:'意味検索',         icon:'vecSearch', badgeLabel:'AI', badgeVariant:'vec', cls:'vec-nav' },
   { id:'rag',     label:'AI チャット',      icon:'rag',     badgeLabel:'AI',  badgeVariant:'ai',  cls:'ai-nav' },

--- a/src/pages/BayesianOpt/BayesianOptPage.tsx
+++ b/src/pages/BayesianOpt/BayesianOptPage.tsx
@@ -1,0 +1,319 @@
+/**
+ * BayesianOptPage — 1D ガウス過程回帰によるベイズ最適化
+ *
+ * 金属材料 DB から特徴量 (x) と目的変数 (y) を選び、次の実験候補点を提案する。
+ * GP で予測平均と不確実性を推定し、Expected Improvement 獲得関数を最大化する点を
+ * "次に試すべき実験" として提示する。
+ */
+
+import { useMemo, useRef, useEffect, useState } from 'react'
+import { Chart, registerables } from 'chart.js'
+import { Badge, Card, Select, SectionCard } from '../../components/atoms'
+import { Icon } from '../../components/Icon'
+import type { Material } from '../../types'
+import {
+  fitGP,
+  suggestNext,
+  normalize,
+  denormalize,
+  DEFAULT_HYPER,
+} from '../../services/bayesianOpt'
+
+Chart.register(...registerables)
+
+interface BayesianOptPageProps {
+  db: Material[]
+}
+
+type FeatureKey = 'hv' | 'ts' | 'el' | 'dn'
+
+const FEATURE_LABELS: Record<FeatureKey, { label: string; unit: string }> = {
+  hv: { label: '硬度',     unit: 'HV' },
+  ts: { label: '引張強さ', unit: 'MPa' },
+  el: { label: '弾性率',   unit: 'GPa' },
+  dn: { label: '密度',     unit: 'g/cm³' },
+}
+
+const N_GRID = 100
+
+export const BayesianOptPage = ({ db }: BayesianOptPageProps) => {
+  const [xFeature, setXFeature] = useState<FeatureKey>('el')
+  const [yFeature, setYFeature] = useState<FeatureKey>('ts')
+
+  // ─── データ抽出 + 正規化 + GP fit ───
+  const analysis = useMemo(() => {
+    if (xFeature === yFeature) return null
+    const points = db
+      .map(m => ({ x: m[xFeature] ?? 0, y: m[yFeature] ?? 0, id: m.id, name: m.name }))
+      .filter(p => Number.isFinite(p.x) && Number.isFinite(p.y))
+
+    if (points.length < 3) return null
+
+    const rawX = points.map(p => p.x)
+    const rawY = points.map(p => p.y)
+    const { normalized: normX, min: xMin, max: xMax } = normalize(rawX)
+    const { normalized: normY, min: yMin, max: yMax } = normalize(rawY)
+
+    // ハイパーパラメータは正規化済み空間 [0, 1] で妥当な値を選ぶ
+    const hyper = { ...DEFAULT_HYPER, lengthScale: 0.15, variance: 0.3, noise: 0.02 }
+    const model = fitGP(normX, normY, hyper)
+
+    // グリッドスキャン (正規化空間)
+    const { best, grid } = suggestNext(model, 0, 1, N_GRID)
+
+    return {
+      points,
+      rawX, rawY,
+      xMin, xMax, yMin, yMax,
+      model, grid, best,
+    }
+  }, [db, xFeature, yFeature])
+
+  // ─── Chart.js 描画 ───
+  const chartRef = useRef<HTMLCanvasElement | null>(null)
+  const chartInstance = useRef<Chart | null>(null)
+
+  useEffect(() => {
+    if (!chartRef.current || !analysis) return
+    if (chartInstance.current) {
+      chartInstance.current.destroy()
+      chartInstance.current = null
+    }
+
+    const cssVal = (n: string) => getComputedStyle(document.documentElement).getPropertyValue(n).trim()
+    const accent = cssVal('--accent') || '#0a6657'
+    const warn = cssVal('--warn') || '#c38000'
+    const textLo = cssVal('--text-lo') || '#888'
+    const borderFaint = cssVal('--border-faint') || '#ccc'
+
+    // グリッドを実スケールに戻す
+    const gridX = analysis.grid.map(g => denormalize(g.x, analysis.xMin, analysis.xMax))
+    const meanY = analysis.grid.map(g => denormalize(g.mean, analysis.yMin, analysis.yMax))
+    // 不確実性バンド (±2σ)
+    const yRange = analysis.yMax - analysis.yMin
+    const upperY = analysis.grid.map(g => denormalize(g.mean + 2 * g.std, analysis.yMin, analysis.yMax))
+    const lowerY = analysis.grid.map(g => denormalize(Math.max(g.mean - 2 * g.std, 0), analysis.yMin, analysis.yMax))
+
+    const bestXReal = denormalize(analysis.best.x, analysis.xMin, analysis.xMax)
+    const bestYReal = denormalize(analysis.best.mean, analysis.yMin, analysis.yMax)
+
+    chartInstance.current = new Chart(chartRef.current, {
+      type: 'scatter',
+      data: {
+        datasets: [
+          {
+            label: '不確実性 +2σ',
+            data: gridX.map((x, i) => ({ x, y: upperY[i]! })),
+            borderColor: accent + '40',
+            backgroundColor: accent + '20',
+            pointRadius: 0,
+            showLine: true,
+            fill: '+1',
+            tension: 0.3,
+            order: 3,
+          },
+          {
+            label: '不確実性 -2σ',
+            data: gridX.map((x, i) => ({ x, y: lowerY[i]! })),
+            borderColor: accent + '40',
+            backgroundColor: accent + '20',
+            pointRadius: 0,
+            showLine: true,
+            fill: false,
+            tension: 0.3,
+            order: 3,
+          },
+          {
+            label: 'GP 平均',
+            data: gridX.map((x, i) => ({ x, y: meanY[i]! })),
+            borderColor: accent,
+            backgroundColor: accent,
+            pointRadius: 0,
+            showLine: true,
+            tension: 0.3,
+            borderWidth: 2,
+            order: 2,
+          },
+          {
+            label: '観測データ',
+            data: analysis.points.map(p => ({ x: p.x, y: p.y })),
+            borderColor: accent,
+            backgroundColor: accent,
+            pointRadius: 4,
+            pointHoverRadius: 6,
+            showLine: false,
+            order: 1,
+          },
+          {
+            label: '提案点 (EI 最大)',
+            data: [{ x: bestXReal, y: bestYReal }],
+            borderColor: warn,
+            backgroundColor: warn,
+            pointRadius: 8,
+            pointStyle: 'rectRot',
+            showLine: false,
+            order: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            type: 'linear',
+            title: {
+              display: true,
+              text: `${FEATURE_LABELS[xFeature].label} (${FEATURE_LABELS[xFeature].unit})`,
+              color: textLo,
+            },
+            grid: { color: borderFaint },
+          },
+          y: {
+            title: {
+              display: true,
+              text: `${FEATURE_LABELS[yFeature].label} (${FEATURE_LABELS[yFeature].unit})`,
+              color: textLo,
+            },
+            grid: { color: borderFaint },
+          },
+        },
+        plugins: {
+          legend: {
+            labels: { color: textLo, font: { size: 11 } },
+          },
+          tooltip: {
+            callbacks: {
+              label: ctx => {
+                const px = ctx.parsed.x ?? 0
+                const py = ctx.parsed.y ?? 0
+                return `${ctx.dataset.label}: (${px.toFixed(2)}, ${py.toFixed(2)})`
+              },
+            },
+          },
+        },
+      },
+    })
+    // yRange が 0 の場合のみ参照警告を避けるために touch
+    void yRange
+
+    return () => {
+      chartInstance.current?.destroy()
+      chartInstance.current = null
+    }
+  }, [analysis, xFeature, yFeature])
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* ヘッダー */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-[16px] font-bold text-text-hi flex items-center gap-2">
+            <Icon name="spark" size={16} />
+            ベイズ最適化 — 次実験候補の提案
+          </h1>
+          <p className="text-[12px] text-text-lo mt-0.5">
+            ガウス過程回帰 (RBF カーネル) で目的変数をモデル化し、
+            Expected Improvement 獲得関数を最大化する点を「次に試すべき実験」として提案します。
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Badge variant="ai">EXPERIMENTAL</Badge>
+        </div>
+      </div>
+
+      {/* コントロール */}
+      <Card className="p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="text-[11px] font-bold text-text-lo uppercase tracking-[.05em] block mb-1">特徴変数 (X軸)</label>
+            <Select value={xFeature} onChange={e => setXFeature(e.target.value as FeatureKey)}>
+              {Object.entries(FEATURE_LABELS).map(([k, v]) => (
+                <option key={k} value={k}>{v.label} ({v.unit})</option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <label className="text-[11px] font-bold text-text-lo uppercase tracking-[.05em] block mb-1">目的変数 (Y軸 — 最大化)</label>
+            <Select value={yFeature} onChange={e => setYFeature(e.target.value as FeatureKey)}>
+              {Object.entries(FEATURE_LABELS).map(([k, v]) => (
+                <option key={k} value={k}>{v.label} ({v.unit})</option>
+              ))}
+            </Select>
+          </div>
+        </div>
+      </Card>
+
+      {/* グラフ or エラー */}
+      {!analysis ? (
+        <Card className="p-6 text-center">
+          <p className="text-[13px] text-text-md">
+            {xFeature === yFeature
+              ? 'X 軸と Y 軸に異なる変数を選択してください。'
+              : 'データ点が不足しています (3 点以上必要)。'}
+          </p>
+        </Card>
+      ) : (
+        <>
+          <Card className="p-4">
+            <div style={{ height: 420 }}>
+              <canvas ref={chartRef} />
+            </div>
+          </Card>
+
+          {/* 提案パネル */}
+          <SectionCard title="提案された次実験点">
+            <div className="grid grid-cols-1 sm:grid-cols-4 gap-3">
+              <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3">
+                <div className="text-[10px] font-bold text-text-lo uppercase tracking-[.05em] mb-1">{FEATURE_LABELS[xFeature].label}</div>
+                <div className="text-[15px] font-bold text-text-hi font-mono">
+                  {denormalize(analysis.best.x, analysis.xMin, analysis.xMax).toFixed(2)}
+                </div>
+                <div className="text-[10px] text-text-lo mt-0.5">{FEATURE_LABELS[xFeature].unit}</div>
+              </div>
+              <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3">
+                <div className="text-[10px] font-bold text-text-lo uppercase tracking-[.05em] mb-1">予測 {FEATURE_LABELS[yFeature].label}</div>
+                <div className="text-[15px] font-bold text-text-hi font-mono">
+                  {denormalize(analysis.best.mean, analysis.yMin, analysis.yMax).toFixed(2)}
+                </div>
+                <div className="text-[10px] text-text-lo mt-0.5">{FEATURE_LABELS[yFeature].unit}</div>
+              </div>
+              <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3">
+                <div className="text-[10px] font-bold text-text-lo uppercase tracking-[.05em] mb-1">不確実性 ±σ</div>
+                <div className="text-[15px] font-bold font-mono" style={{ color: 'var(--warn)' }}>
+                  ±{(analysis.best.std * (analysis.yMax - analysis.yMin)).toFixed(2)}
+                </div>
+                <div className="text-[10px] text-text-lo mt-0.5">{FEATURE_LABELS[yFeature].unit}</div>
+              </div>
+              <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3">
+                <div className="text-[10px] font-bold text-text-lo uppercase tracking-[.05em] mb-1">EI (獲得関数)</div>
+                <div className="text-[15px] font-bold font-mono" style={{ color: 'var(--accent)' }}>
+                  {analysis.best.ei.toFixed(4)}
+                </div>
+                <div className="text-[10px] text-text-lo mt-0.5">期待改善値</div>
+              </div>
+            </div>
+          </SectionCard>
+        </>
+      )}
+
+      {/* 技術ノート */}
+      <Card className="p-3 border-dashed" style={{ borderColor: 'var(--border-faint)' }}>
+        <p className="text-[11px] font-bold text-text-lo mb-1">アルゴリズム</p>
+        <p className="text-[11px] text-text-md leading-relaxed">
+          <strong>ガウス過程回帰 (GP)</strong>: RBF カーネル
+          <code className="font-mono text-[10px] px-1">k(x,x') = σ² exp(−(x−x')²/2ℓ²)</code> で
+          任意の 2 点間の相関を定義し、既知データから任意点の予測平均と分散を閉形式で求める。
+          内部では Cholesky 分解で <code className="font-mono text-[10px]">K⁻¹y</code> を安定的に計算。
+          <br />
+          <strong>Expected Improvement (EI)</strong>: 現在の最良値を更新する期待値
+          <code className="font-mono text-[10px] px-1">EI(x) = (μ−f*)·Φ(z) + σ·φ(z)</code> を最大化する点を選ぶ。
+          不確実性が高い領域 (探索) と平均が高い領域 (活用) のバランスを取る。
+          <br />
+          <strong>制限</strong>: 現状は 1D 版 MVP。ハイパーパラメータは固定値 (ℓ=0.15, σ²=0.3, noise=0.02)。
+          多次元最適化・Thompson Sampling・制約付き最適化は今後の課題。
+        </p>
+      </Card>
+    </div>
+  )
+}

--- a/src/pages/BayesianOpt/index.ts
+++ b/src/pages/BayesianOpt/index.ts
@@ -1,0 +1,1 @@
+export { BayesianOptPage } from './BayesianOptPage'

--- a/src/services/bayesianOpt.test.ts
+++ b/src/services/bayesianOpt.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import {
+  rbfKernel,
+  fitGP,
+  predictGP,
+  expectedImprovement,
+  suggestNext,
+  normalize,
+  denormalize,
+  DEFAULT_HYPER,
+} from './bayesianOpt'
+
+describe('rbfKernel', () => {
+  it('同じ点では variance に等しい', () => {
+    expect(rbfKernel(1.0, 1.0, DEFAULT_HYPER)).toBe(DEFAULT_HYPER.variance)
+  })
+
+  it('離れた点ほど値が小さくなる', () => {
+    const near = rbfKernel(0, 0.5, DEFAULT_HYPER)
+    const far = rbfKernel(0, 3.0, DEFAULT_HYPER)
+    expect(near).toBeGreaterThan(far)
+  })
+
+  it('対称性: k(x1,x2) = k(x2,x1)', () => {
+    expect(rbfKernel(0.3, 1.2, DEFAULT_HYPER)).toBeCloseTo(rbfKernel(1.2, 0.3, DEFAULT_HYPER))
+  })
+})
+
+describe('fitGP + predictGP', () => {
+  it('訓練点での予測は訓練値に近い (ノイズ項以内)', () => {
+    const xs = [0, 1, 2, 3, 4]
+    const ys = [0, 2, 1, 3, 2]
+    const model = fitGP(xs, ys)
+    for (let i = 0; i < xs.length; i++) {
+      const pred = predictGP(model, xs[i]!)
+      // ノイズ項 (0.05) 程度の誤差を許容
+      expect(pred.mean).toBeCloseTo(ys[i]!, 0)
+    }
+  })
+
+  it('訓練点での分散は小さい (データが観測済みなので)', () => {
+    const xs = [0, 1, 2]
+    const ys = [1, 2, 1.5]
+    const model = fitGP(xs, ys)
+    const pred = predictGP(model, 1)
+    // 観測ノイズ程度の不確実性
+    expect(pred.std).toBeLessThan(0.3)
+  })
+
+  it('訓練点から遠い点では分散が大きい', () => {
+    const xs = [0, 1, 2]
+    const ys = [1, 2, 1.5]
+    const model = fitGP(xs, ys)
+    const predNear = predictGP(model, 1.5)
+    const predFar  = predictGP(model, 10)
+    expect(predFar.std).toBeGreaterThan(predNear.std)
+  })
+
+  it('空データで fitGP は throw', () => {
+    expect(() => fitGP([], [])).toThrow()
+  })
+
+  it('xs/ys の長さ不一致で throw', () => {
+    expect(() => fitGP([1, 2, 3], [1, 2])).toThrow()
+  })
+})
+
+describe('expectedImprovement', () => {
+  it('std=0 なら EI=0 (改善の期待なし)', () => {
+    const ei = expectedImprovement({ mean: 1, std: 0 }, 0)
+    expect(ei).toBe(0)
+  })
+
+  it('mean > yBest かつ std>0 なら EI > 0', () => {
+    const ei = expectedImprovement({ mean: 2, std: 0.5 }, 1)
+    expect(ei).toBeGreaterThan(0)
+  })
+
+  it('同じ平均/std で yBest が小さいほど EI は大きい', () => {
+    const pred = { mean: 2, std: 0.5 }
+    const eiLow  = expectedImprovement(pred, 0)
+    const eiHigh = expectedImprovement(pred, 1.5)
+    expect(eiLow).toBeGreaterThan(eiHigh)
+  })
+})
+
+describe('suggestNext', () => {
+  it('提案点が探索範囲内', () => {
+    const xs = [0, 2, 4]
+    const ys = [1, 3, 2]
+    const model = fitGP(xs, ys)
+    const { best } = suggestNext(model, 0, 5, 50)
+    expect(best.x).toBeGreaterThanOrEqual(0)
+    expect(best.x).toBeLessThanOrEqual(5)
+  })
+
+  it('グリッド点数が正しい', () => {
+    const xs = [0, 1]
+    const ys = [0, 1]
+    const model = fitGP(xs, ys)
+    const { grid } = suggestNext(model, 0, 1, 25)
+    expect(grid).toHaveLength(25)
+  })
+
+  it('全グリッド点の EI が非負', () => {
+    const xs = [0, 1, 2]
+    const ys = [0, 2, 1]
+    const model = fitGP(xs, ys)
+    const { grid } = suggestNext(model, -1, 3)
+    for (const point of grid) {
+      expect(point.ei).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('nGrid < 2 で throw', () => {
+    const model = fitGP([0, 1], [0, 1])
+    expect(() => suggestNext(model, 0, 1, 1)).toThrow()
+  })
+})
+
+describe('normalize / denormalize', () => {
+  it('min-max 正規化で [0, 1] 区間になる', () => {
+    const { normalized, min, max } = normalize([10, 20, 30, 40, 50])
+    expect(min).toBe(10)
+    expect(max).toBe(50)
+    expect(normalized[0]).toBe(0)
+    expect(normalized[4]).toBe(1)
+    expect(normalized[2]).toBe(0.5)
+  })
+
+  it('全要素同値 → 0.5 で埋める', () => {
+    const { normalized } = normalize([5, 5, 5])
+    expect(normalized).toEqual([0.5, 0.5, 0.5])
+  })
+
+  it('空配列 → 空配列', () => {
+    const { normalized } = normalize([])
+    expect(normalized).toEqual([])
+  })
+
+  it('denormalize は normalize の逆', () => {
+    const { normalized, min, max } = normalize([10, 20, 30])
+    expect(denormalize(normalized[0]!, min, max)).toBe(10)
+    expect(denormalize(normalized[2]!, min, max)).toBe(30)
+  })
+})

--- a/src/services/bayesianOpt.ts
+++ b/src/services/bayesianOpt.ts
@@ -1,0 +1,274 @@
+/**
+ * ベイズ最適化 (1D) — ガウス過程回帰 + Expected Improvement 獲得関数
+ *
+ * 金属材料の物性探索で「次に何を実験すべきか」を提案する。
+ * 純 TypeScript 実装・外部依存なし。小規模データ (< 50 点) 向け。
+ *
+ * アルゴリズム:
+ *   1. RBF カーネル k(x1, x2) = σ²·exp(-(x1-x2)²/(2·ℓ²))
+ *   2. カーネル行列 K = k(xi, xj) + σ_n²·I (ノイズ項)
+ *   3. Cholesky 分解 K = L·L^T → K^(-1)·y を解く
+ *   4. 予測点 x* で平均 μ = k*^T · α、分散 σ² = k** - k*^T · K^(-1) · k*
+ *   5. Expected Improvement EI(x) を最大化する点を次実験候補として返す
+ *
+ * 参考: Rasmussen & Williams "Gaussian Processes for Machine Learning" (2006) §2.2, 5.4.2
+ */
+
+// ─── カーネル ────────────────────────────────────────────────────────────────
+export interface GPHyperParams {
+  /** RBF カーネルの長さスケール (大きいほど滑らか) */
+  lengthScale: number
+  /** カーネルの分散 (出力スケール) */
+  variance: number
+  /** 観測ノイズの分散 (対数尤度の正則化にも寄与) */
+  noise: number
+}
+
+export const DEFAULT_HYPER: GPHyperParams = {
+  lengthScale: 1.0,
+  variance: 1.0,
+  noise: 0.05,
+}
+
+/**
+ * RBF (squared exponential) カーネル。
+ * x1, x2 は正規化済みの 1D 特徴量を想定。
+ */
+export function rbfKernel(x1: number, x2: number, h: GPHyperParams): number {
+  const d = x1 - x2
+  return h.variance * Math.exp(-(d * d) / (2 * h.lengthScale * h.lengthScale))
+}
+
+// ─── 線形代数ヘルパー (小規模 Cholesky) ──────────────────────────────────────
+
+/**
+ * 対称正定値行列の Cholesky 分解 A = L·L^T を計算する。
+ * 返り値は下三角行列 L。
+ * 数値不安定性に備えて diagonal に jitter を加えて呼ぶこと。
+ */
+function cholesky(A: number[][]): number[][] {
+  const n = A.length
+  const L: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j <= i; j++) {
+      let sum = 0
+      for (let k = 0; k < j; k++) {
+        const lik = L[i]?.[k] ?? 0
+        const ljk = L[j]?.[k] ?? 0
+        sum += lik * ljk
+      }
+      const Li = L[i]!
+      const Lj = L[j]!
+      if (i === j) {
+        const diag = (A[i]?.[i] ?? 0) - sum
+        if (diag <= 0) {
+          // 数値誤差で負になる場合があるので小さい正の値にクリップ
+          Li[j] = Math.sqrt(Math.max(diag, 1e-10))
+        } else {
+          Li[j] = Math.sqrt(diag)
+        }
+      } else {
+        const Ljj = Lj[j] ?? 1e-10
+        Li[j] = ((A[i]?.[j] ?? 0) - sum) / Ljj
+      }
+    }
+  }
+  return L
+}
+
+/** L·x = b を x について解く (前進代入) */
+function forwardSolve(L: number[][], b: number[]): number[] {
+  const n = L.length
+  const x: number[] = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    let sum = b[i] ?? 0
+    const Li = L[i]!
+    for (let j = 0; j < i; j++) sum -= (Li[j] ?? 0) * (x[j] ?? 0)
+    x[i] = sum / (Li[i] ?? 1e-10)
+  }
+  return x
+}
+
+/** L^T·x = b を x について解く (後退代入) */
+function backwardSolve(L: number[][], b: number[]): number[] {
+  const n = L.length
+  const x: number[] = new Array(n).fill(0)
+  for (let i = n - 1; i >= 0; i--) {
+    let sum = b[i] ?? 0
+    for (let j = i + 1; j < n; j++) sum -= (L[j]?.[i] ?? 0) * (x[j] ?? 0)
+    x[i] = sum / (L[i]?.[i] ?? 1e-10)
+  }
+  return x
+}
+
+// ─── GP モデル ───────────────────────────────────────────────────────────────
+export interface GPModel {
+  xs: number[]
+  ys: number[]
+  h: GPHyperParams
+  /** 前計算した α = K^(-1)·y (予測の高速化用) */
+  alpha: number[]
+  /** Cholesky 分解結果 (分散計算用) */
+  L: number[][]
+}
+
+/**
+ * 訓練データから GP モデルを学習する。
+ *
+ * @param xs 訓練入力 (1D)
+ * @param ys 訓練出力
+ * @param h  カーネルハイパーパラメータ
+ */
+export function fitGP(xs: number[], ys: number[], h: GPHyperParams = DEFAULT_HYPER): GPModel {
+  const n = xs.length
+  if (n === 0) throw new Error('fitGP: empty training data')
+  if (xs.length !== ys.length) throw new Error('fitGP: xs/ys length mismatch')
+
+  // K + noise*I
+  const K: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const xi = xs[i] ?? 0
+      const xj = xs[j] ?? 0
+      const kij = rbfKernel(xi, xj, h)
+      K[i]![j] = i === j ? kij + h.noise : kij
+    }
+  }
+
+  const L = cholesky(K)
+  // α = K^(-1)·y = L^(-T)·L^(-1)·y
+  const z = forwardSolve(L, ys)
+  const alpha = backwardSolve(L, z)
+
+  return { xs: [...xs], ys: [...ys], h, alpha, L }
+}
+
+export interface GPPrediction {
+  mean: number
+  std: number
+}
+
+/**
+ * 学習済み GP モデルで点 x における予測平均と標準偏差を返す。
+ * 平均 μ(x*) = k*^T·α、分散 σ²(x*) = k(x*,x*) - v^T·v (v = L^(-1)·k*)
+ */
+export function predictGP(model: GPModel, x: number): GPPrediction {
+  const n = model.xs.length
+  const kStar: number[] = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    kStar[i] = rbfKernel(x, model.xs[i] ?? 0, model.h)
+  }
+
+  // mean = k*·α
+  let mean = 0
+  for (let i = 0; i < n; i++) mean += (kStar[i] ?? 0) * (model.alpha[i] ?? 0)
+
+  // var = k(x,x) - |L^(-1)·k*|²
+  const kxx = rbfKernel(x, x, model.h)
+  const v = forwardSolve(model.L, kStar)
+  let vv = 0
+  for (let i = 0; i < n; i++) vv += (v[i] ?? 0) * (v[i] ?? 0)
+  const variance = Math.max(kxx - vv, 0)
+  return { mean, std: Math.sqrt(variance) }
+}
+
+// ─── 獲得関数 (Expected Improvement) ─────────────────────────────────────────
+
+/** 標準正規分布の累積分布関数 (CDF) — Abramowitz & Stegun 7.1.26 近似 */
+function normCdf(x: number): number {
+  // erf 近似
+  const a1 =  0.254829592
+  const a2 = -0.284496736
+  const a3 =  1.421413741
+  const a4 = -1.453152027
+  const a5 =  1.061405429
+  const p  =  0.3275911
+  const sign = x < 0 ? -1 : 1
+  const ax = Math.abs(x) / Math.SQRT2
+  const t = 1 / (1 + p * ax)
+  const y = 1 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-ax * ax)
+  return 0.5 * (1 + sign * y)
+}
+
+/** 標準正規分布の確率密度関数 (PDF) */
+function normPdf(x: number): number {
+  return Math.exp(-0.5 * x * x) / Math.sqrt(2 * Math.PI)
+}
+
+/**
+ * Expected Improvement 獲得関数。
+ * 最大化問題として現在の最良値 `yBest` を更新する期待値を返す。
+ * `ξ` は exploration parameter (大きいほど探索寄り)。
+ */
+export function expectedImprovement(
+  pred: GPPrediction,
+  yBest: number,
+  xi = 0.01,
+): number {
+  if (pred.std < 1e-9) return 0
+  const improvement = pred.mean - yBest - xi
+  const z = improvement / pred.std
+  const ei = improvement * normCdf(z) + pred.std * normPdf(z)
+  // EI は理論上非負だが、改善が非常に小さい場合に浮動小数誤差で
+  // -1e-17 程度の値が出ることがあるためクランプする。
+  return Math.max(0, ei)
+}
+
+// ─── 候補提案 ────────────────────────────────────────────────────────────────
+
+export interface Suggestion {
+  x: number
+  mean: number
+  std: number
+  ei: number
+}
+
+/**
+ * 探索範囲を等間隔にスキャンして EI 最大点を返す。
+ * 可視化用に全グリッド点の予測値も同時に返す。
+ */
+export function suggestNext(
+  model: GPModel,
+  xMin: number,
+  xMax: number,
+  nGrid = 100,
+  xi = 0.01,
+): { best: Suggestion; grid: Suggestion[] } {
+  if (nGrid < 2) throw new Error('suggestNext: nGrid must be ≥ 2')
+  const yBest = Math.max(...model.ys)
+  const grid: Suggestion[] = []
+  let best: Suggestion | null = null
+  const step = (xMax - xMin) / (nGrid - 1)
+  for (let i = 0; i < nGrid; i++) {
+    const x = xMin + step * i
+    const pred = predictGP(model, x)
+    const ei = expectedImprovement(pred, yBest, xi)
+    const point: Suggestion = { x, mean: pred.mean, std: pred.std, ei }
+    grid.push(point)
+    if (best === null || ei > best.ei) best = point
+  }
+  // grid は必ず 1 点以上あるので best は non-null (TS 向けの assert)
+  if (!best) throw new Error('suggestNext: grid is empty')
+  return { best, grid }
+}
+
+// ─── 正規化ユーティリティ ──────────────────────────────────────────────────
+
+/** min-max 正規化 (配列 → [0, 1] 区間) */
+export function normalize(values: number[]): { normalized: number[]; min: number; max: number } {
+  if (values.length === 0) return { normalized: [], min: 0, max: 1 }
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min
+  if (range === 0) return { normalized: values.map(() => 0.5), min, max }
+  return {
+    normalized: values.map(v => (v - min) / range),
+    min,
+    max,
+  }
+}
+
+/** 正規化を元のスケールに戻す */
+export function denormalize(v: number, min: number, max: number): number {
+  return min + v * (max - min)
+}


### PR DESCRIPTION
## 概要

issue #21 の実装。親 issue #15 Phase E Tier 3 の初期実装として、金属材料 DB から次の実験候補点を提案するベイズ最適化ページを追加する。

## 新規機能

- 新ページ `#/bayes` 「ベイズ最適化」
- 1D ガウス過程回帰 + Expected Improvement 獲得関数
- 観測データ・GP 平均曲線・±2σ 不確実性バンド・提案点を Chart.js で重ね描き
- 提案点の実スケール値 / 予測値 / 不確実性 / EI を KPI カード表示
- アルゴリズム解説パネル（初学者向け）

## アルゴリズム

```
RBF カーネル: k(x,x') = σ²·exp(-(x-x')²/2ℓ²)
GP 予測: μ(x*) = k*^T·α,  σ²(x*) = k** - k*^T·K⁻¹·k*
EI 獲得関数: EI(x) = (μ-f*)·Φ(z) + σ·φ(z),  z = (μ-f*)/σ
```

- Cholesky 分解による数値安定な K⁻¹y 計算
- 純 TypeScript・外部依存なし (小規模 ≤ 50 点向け)
- 正規化 [0,1] 空間でハイパーパラメータ固定 (ℓ=0.15, σ²=0.3, noise=0.02)

## その他の変更

- **お知らせ**: 直近 3 機能 (Petri net / Download Preview / Bayes Opt) を `announcements.ts` 先頭に追加
- **README**: 対象ドメイン説明、Tech Stack 拡充 (AI SDK v6/Upstash Vector/GP 回帰等)、services 一覧更新、17 ページに更新

## テスト

- 553 件通過 (+19)
- `bayesianOpt.test.ts` 19 ケース
  - カーネル対称性 / 予測が訓練点で一致 / 遠点で分散増大
  - EI の非負性・単調性 / 空入力エラー
  - suggestNext の探索範囲・グリッド点数

## スコープ外 (follow-up)

- 多次元最適化（2+ 特徴量）
- ハイパーパラメータの自動最適化
- Thompson Sampling / UCB 獲得関数
- 離散変数 / 制約付き最適化
- バッチ提案

## 関連

- 親 issue: #15 Phase E Tier 3
- 前 PR: #18 (Petri net), #20 (Download Preview)

closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bayesian Optimization feature for intelligent next experiment point suggestions using Gaussian Process regression and Expected Improvement acquisition.
  * Updated platform branding to emphasize metal testing data management with enhanced workflow support.

* **Documentation**
  * Updated project description, tech stack, and supported data formats in documentation.

* **Navigation**
  * Added new "ベイズ最適化" (Bayesian Optimization) navigation menu item with AI badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->