### PR TITLE
feat(density): 密度トグル (コンパクト/標準/ゆったり)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import type { Toast, AppContextValue } from './types';
 import { AppCtx, dbReducer } from './context/AppContext';
 import { INITIAL_DB } from './data/initialDb';
 import { useTheme } from './hooks/useTheme';
+import { useDensity } from './hooks/useDensity';
 import { useEmbedding } from './hooks/useEmbedding';
 import { useAI } from './hooks/useAI';
 import { useVoice } from './hooks/useVoice';
@@ -80,6 +81,7 @@ export function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   const { theme, setTheme } = useTheme();
+  const { density, setDensity } = useDensity();
   const embedding = useEmbedding(db);
   const ai = useAI();
   const claude = ai;
@@ -223,6 +225,7 @@ export function App() {
       <div className="flex flex-col h-screen overflow-hidden" style={{ background: 'var(--bg-base)' }}>
         <Topbar
           theme={theme} setTheme={setTheme}
+          density={density} setDensity={setDensity}
           onToggleSidebar={() => setSidebarCollapsed(c=>!c)}
           embStatus={embedding.status} embCount={embedding.embCount} embEngine={embedding.engine}
           onGlobalSearch={handleGlobalSearch} globalQuery={globalQuery} setGlobalQuery={setGlobalQuery}

--- a/src/components/Topbar/Topbar.test.tsx
+++ b/src/components/Topbar/Topbar.test.tsx
@@ -6,6 +6,8 @@ import { Topbar } from './Topbar';
 const defaultProps = {
   theme: 'light',
   setTheme: vi.fn(),
+  density: 'regular' as const,
+  setDensity: vi.fn(),
   onToggleSidebar: vi.fn(),
   embStatus: 'ready',
   embCount: 42,

--- a/src/components/Topbar/Topbar.tsx
+++ b/src/components/Topbar/Topbar.tsx
@@ -6,10 +6,13 @@ import type { Material } from '../../types';
 import { STORYBOOK_URL } from '../../data/constants';
 import { isComposing } from '../../utils/keyboard';
 import { formatSearchEngineLabel } from '../../utils/searchEngine';
+import { DENSITY_META, VALID_DENSITIES, type Density } from '../../hooks/useDensity';
 
 interface TopbarProps {
   theme: string;
   setTheme: (t: string) => void;
+  density: Density;
+  setDensity: (d: Density) => void;
   onToggleSidebar: () => void;
   embStatus: string;
   embCount: number;
@@ -23,7 +26,7 @@ interface TopbarProps {
   onOpenNotifications?: () => void;
 }
 
-export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, embEngine, onGlobalSearch, globalQuery, setGlobalQuery, db, onDetail, unreadNotifications = 0, onOpenNotifications }: TopbarProps) => {
+export const Topbar = ({ theme, setTheme, density, setDensity, onToggleSidebar, embStatus, embCount, embEngine, onGlobalSearch, globalQuery, setGlobalQuery, db, onDetail, unreadNotifications = 0, onOpenNotifications }: TopbarProps) => {
   const THEMES = [
     { id: 'light', label: 'Light' },
     { id: 'dark',  label: 'Dark' },
@@ -191,6 +194,22 @@ export const Topbar = ({ theme, setTheme, onToggleSidebar, embStatus, embCount, 
           </button>
         ))}
       </div>
+
+      {/* UI 密度トグル */}
+      <Tooltip label="UI 密度 (行間隔)" placement="bottom">
+        <div className="hidden lg:flex gap-0.5 bg-black/25 p-0.5 rounded-md border border-white/10 flex-shrink-0" role="group" aria-label="UI 密度切替">
+          {VALID_DENSITIES.map(d => (
+            <button
+              key={d}
+              onClick={() => setDensity(d)}
+              aria-pressed={density === d}
+              className={`px-1.5 py-1 rounded text-[11px] font-medium transition-all duration-150 font-ui ${density === d ? 'bg-white/18 text-white' : 'text-white/50 hover:text-white/80'}`}
+            >
+              {DENSITY_META[d].label}
+            </button>
+          ))}
+        </div>
+      </Tooltip>
       <Tooltip label={unreadNotifications > 0 ? `お知らせ (未読 ${unreadNotifications} 件)` : 'お知らせ'} placement="bottom">
         <button
           type="button"

--- a/src/hooks/useDensity/index.ts
+++ b/src/hooks/useDensity/index.ts
@@ -1,0 +1,1 @@
+export { useDensity, VALID_DENSITIES, DENSITY_META, type Density } from './useDensity'

--- a/src/hooks/useDensity/useDensity.test.ts
+++ b/src/hooks/useDensity/useDensity.test.ts
@@ -1,0 +1,47 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useDensity, VALID_DENSITIES } from './useDensity'
+
+const STORAGE_KEY = 'matlens:density'
+
+// vitest 環境によっては localStorage が incomplete な場合がある
+const hasLocalStorage = (() => {
+  try { localStorage.setItem('__test__', '1'); localStorage.removeItem('__test__'); return true }
+  catch { return false }
+})()
+
+describe('useDensity', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-density')
+    if (hasLocalStorage) try { localStorage.clear() } catch { /* noop */ }
+  })
+
+  it('デフォルトは regular', () => {
+    const { result } = renderHook(() => useDensity())
+    expect(result.current.density).toBe('regular')
+    expect(document.documentElement.getAttribute('data-density')).toBe('regular')
+  })
+
+  it('setDensity で密度が変わり data-density 属性に反映される', () => {
+    const { result } = renderHook(() => useDensity())
+    act(() => result.current.setDensity('compact'))
+    expect(result.current.density).toBe('compact')
+    expect(document.documentElement.getAttribute('data-density')).toBe('compact')
+  })
+
+  it.skipIf(!hasLocalStorage)('localStorage から復元する', () => {
+    localStorage.setItem(STORAGE_KEY, 'relaxed')
+    const { result } = renderHook(() => useDensity())
+    expect(result.current.density).toBe('relaxed')
+  })
+
+  it.skipIf(!hasLocalStorage)('不正な localStorage 値は regular にフォールバック', () => {
+    localStorage.setItem(STORAGE_KEY, 'invalid-value')
+    const { result } = renderHook(() => useDensity())
+    expect(result.current.density).toBe('regular')
+  })
+
+  it('VALID_DENSITIES に 3 値が定義されている', () => {
+    expect(VALID_DENSITIES).toEqual(['compact', 'regular', 'relaxed'])
+  })
+})

--- a/src/hooks/useDensity/useDensity.ts
+++ b/src/hooks/useDensity/useDensity.ts
@@ -1,0 +1,62 @@
+/**
+ * useDensity — UI 密度 (行高さ / 余白) のトグルフック
+ *
+ * BtoB アプリでは情報密度の好みが人によって大きく異なる。
+ *   compact  — 36px 行。データ一覧を一画面で多く俯瞰したい熟練者向け。
+ *   regular  — 44px 行。標準。初見ユーザーにも読みやすいバランス。
+ *   relaxed  — 56px 行。視認性重視。大画面 or タッチ操作向け。
+ *
+ * <html data-density="..."> 属性で CSS 変数を切り替え、localStorage で永続化する。
+ * useTheme と同パターン。
+ */
+
+import { useState, useCallback, useEffect } from 'react'
+
+const STORAGE_KEY = 'matlens:density'
+export const VALID_DENSITIES = ['compact', 'regular', 'relaxed'] as const
+export type Density = (typeof VALID_DENSITIES)[number]
+
+export const DENSITY_META: Record<Density, { label: string; rowH: number }> = {
+  compact:  { label: 'コンパクト', rowH: 36 },
+  regular:  { label: '標準',       rowH: 44 },
+  relaxed:  { label: 'ゆったり',   rowH: 56 },
+}
+
+function isValidDensity(d: string | null): d is Density {
+  return !!d && (VALID_DENSITIES as readonly string[]).includes(d)
+}
+
+function loadInitial(): Density {
+  if (typeof window === 'undefined') return 'regular'
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (isValidDensity(stored)) return stored
+  } catch { /* ignore */ }
+  return 'regular'
+}
+
+export function useDensity(): { density: Density; setDensity: (d: Density) => void } {
+  const [density, setDensityState] = useState<Density>(loadInitial)
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-density', density)
+    try {
+      localStorage.setItem(STORAGE_KEY, density)
+    } catch { /* ignore */ }
+  }, [density])
+
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key !== STORAGE_KEY) return
+      if (isValidDensity(e.newValue)) setDensityState(e.newValue)
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [])
+
+  const setDensity = useCallback((d: Density) => {
+    if (isValidDensity(d)) setDensityState(d)
+  }, [])
+
+  return { density, setDensity }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -262,3 +262,20 @@ code[class*="language-"] .token,pre[class*="language-"] .token{
   right:100%;top:50%;transform:translateY(-50%);
   border-right-color:rgba(15,20,30,.92);
 }
+
+/* ─── UI 密度 (data-density) ───────────────────────────── */
+/* BtoB では行高さの好みが人によって異なる。
+   compact = 高密度、regular = 標準、relaxed = ゆったり。 */
+[data-density="compact"]{
+  --row-h:36px;--cell-py:4px;--card-py:12px;--table-fs:11px;
+}
+[data-density="regular"]{
+  --row-h:44px;--cell-py:8px;--card-py:16px;--table-fs:13px;
+}
+[data-density="relaxed"]{
+  --row-h:56px;--cell-py:12px;--card-py:24px;--table-fs:13px;
+}
+/* フォールバック (data-density 未設定時 = regular 相当) */
+:root{
+  --row-h:44px;--cell-py:8px;--card-py:16px;--table-fs:13px;
+}


### PR DESCRIPTION
## 概要

issue #23 A-1 の実装。BtoB アプリ向けに 3 段階の UI 密度設定を導入。

## 変更内容

- `src/hooks/useDensity/` — 密度トグルフック。useTheme と同パターン (localStorage 永続化 + `data-density` 属性 + タブ間同期)
- `src/index.css` — 密度ごとの CSS 変数 (`--row-h` / `--cell-py` / `--card-py` / `--table-fs`)
- `src/components/Topbar/Topbar.tsx` — テーマトグル横に密度ボタン 3 つ追加
- `src/App.tsx` — useDensity フックを統合、Topbar に props 追加

## 密度定義

| 密度 | 行高さ | セル余白 | カード余白 |
|---|---|---|---|
| compact | 36px | 4px | 12px |
| regular | 44px | 8px | 16px |
| relaxed | 56px | 12px | 24px |

## テスト

- 537 通過 + 2 スキップ (localStorage 不可環境)

## テスト計画

- [ ] トップバーで密度切り替えが動作すること
- [ ] リロード後に設定が復元されること
- [ ] CSS 変数 `--row-h` 等が適用されること

ref #23