### PR TITLE
feat(i18n): バイリンガル用語辞書 + ダークモードフォント視認性改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
 <meta name="theme-color" content="#1e3050">
 <meta name="color-scheme" content="light dark">
 <meta name="author" content="Asagiri">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <link rel="manifest" href="/site.webmanifest">

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,9 @@
+export {
+  MATERIAL_TERMS,
+  TEST_METHOD_TERMS,
+  WORKFLOW_TERMS,
+  UI_TERMS,
+  bilingual,
+  fullLabel,
+  type Term,
+} from './terms'

--- a/src/i18n/terms.test.ts
+++ b/src/i18n/terms.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MATERIAL_TERMS,
+  TEST_METHOD_TERMS,
+  WORKFLOW_TERMS,
+  UI_TERMS,
+  bilingual,
+  fullLabel,
+} from './terms'
+
+describe('MATERIAL_TERMS', () => {
+  it('全エントリに ja / en が定義されている', () => {
+    for (const [key, term] of Object.entries(MATERIAL_TERMS)) {
+      expect(term.ja, `${key}.ja が空`).toBeTruthy()
+      expect(term.en, `${key}.en が空`).toBeTruthy()
+    }
+  })
+
+  it('Material 型の主要フィールドがカバーされている', () => {
+    const required = ['hv', 'ts', 'el', 'dn', 'comp', 'name', 'cat', 'status', 'id']
+    for (const key of required) {
+      expect(MATERIAL_TERMS[key], `${key} が未定義`).toBeDefined()
+    }
+  })
+
+  it('物性値には unit が付いている', () => {
+    expect(MATERIAL_TERMS['hv']?.unit).toBe('HV')
+    expect(MATERIAL_TERMS['ts']?.unit).toBe('MPa')
+    expect(MATERIAL_TERMS['el']?.unit).toBe('GPa')
+  })
+})
+
+describe('TEST_METHOD_TERMS', () => {
+  it('主要な試験方法がカバーされている', () => {
+    expect(Object.keys(TEST_METHOD_TERMS).length).toBeGreaterThanOrEqual(5)
+  })
+})
+
+describe('WORKFLOW_TERMS', () => {
+  it('Petri net の 11 工程 + rework + reject をカバー', () => {
+    const required = [
+      'planning', 'material_select', 'raw_material',
+      'primary_process', 'post_process', 'specimen',
+      'evaluation', 'mechanical_test', 'environmental',
+      'fractography', 'report', 'rework', 'reject',
+    ]
+    for (const key of required) {
+      expect(WORKFLOW_TERMS[key], `${key} が未定義`).toBeDefined()
+    }
+  })
+})
+
+describe('UI_TERMS', () => {
+  it('主要ページの用語がカバーされている', () => {
+    const required = ['dashboard', 'material_list', 'petri_net', 'bayes_opt']
+    for (const key of required) {
+      expect(UI_TERMS[key], `${key} が未定義`).toBeDefined()
+    }
+  })
+})
+
+describe('bilingual', () => {
+  it('ja / en をスラッシュ区切りで結合する', () => {
+    const result = bilingual(MATERIAL_TERMS['ts']!)
+    expect(result).toBe('引張強さ / Tensile Strength')
+  })
+
+  it('カスタムセパレータを使える', () => {
+    const result = bilingual(MATERIAL_TERMS['hv']!, ' — ')
+    expect(result).toBe('硬度 — Hardness')
+  })
+})
+
+describe('fullLabel', () => {
+  it('unit がある場合は括弧付きで末尾に付く', () => {
+    const result = fullLabel(MATERIAL_TERMS['ts']!)
+    expect(result).toBe('引張強さ / Tensile Strength (MPa)')
+  })
+
+  it('unit がない場合は bilingual と同じ', () => {
+    const result = fullLabel(MATERIAL_TERMS['name']!)
+    expect(result).toBe('名称 / Name')
+  })
+})

--- a/src/i18n/terms.ts
+++ b/src/i18n/terms.ts
@@ -1,0 +1,115 @@
+/**
+ * バイリンガル用語辞書 — 材料工学 + システム UI
+ *
+ * 金属試験ドメインでは日英両方の表記が求められる場面が多い
+ * （論文引用・海外拠点との共有・JIS/ASTM 規格の二重表記）。
+ *
+ * 用途:
+ *   - UI ラベルで「引張強さ / Tensile Strength」のように日英併記
+ *   - ヘルプ / ツールチップでの補足
+ *   - 将来の言語切り替え (Phase D) の下地
+ *
+ * 構造:
+ *   key → { ja, en, unit?, abbr? }
+ *   key は Material 型のフィールド名またはドメイン用語を snake_case で統一。
+ */
+
+export interface Term {
+  ja: string
+  en: string
+  /** 物理単位 (表示用) */
+  unit?: string
+  /** 略称 (テーブルヘッダ等のコンパクト表示用) */
+  abbr?: string
+}
+
+// ─── 材料特性 ────────────────────────────────────────────────────────────
+export const MATERIAL_TERMS: Record<string, Term> = {
+  hv:   { ja: '硬度',       en: 'Hardness',          unit: 'HV',     abbr: '硬度HV' },
+  ts:   { ja: '引張強さ',   en: 'Tensile Strength',  unit: 'MPa',    abbr: '引張MPa' },
+  el:   { ja: '弾性率',     en: "Young's Modulus",    unit: 'GPa',    abbr: '弾性GPa' },
+  el2:  { ja: '伸び',       en: 'Elongation',         unit: '%',      abbr: '伸び%' },
+  dn:   { ja: '密度',       en: 'Density',            unit: 'g/cm³',  abbr: '密度' },
+  pf:   { ja: '疲労強度',   en: 'Fatigue Strength',   unit: 'MPa',    abbr: '疲労MPa' },
+  comp: { ja: '組成',       en: 'Composition',                        abbr: '組成' },
+  name: { ja: '名称',       en: 'Name',                               abbr: '名称' },
+  cat:  { ja: 'カテゴリ',   en: 'Category',                           abbr: 'カテゴリ' },
+  batch:{ ja: 'バッチ番号', en: 'Batch Number',                       abbr: 'バッチ' },
+  date: { ja: '登録日',     en: 'Registration Date',                  abbr: '登録日' },
+  author:{ ja: '登録者',    en: 'Author',                             abbr: '登録者' },
+  status:{ ja: 'ステータス',en: 'Status',                             abbr: 'ステータス' },
+  memo: { ja: '備考',       en: 'Memo',                               abbr: '備考' },
+  id:   { ja: 'ID',         en: 'ID',                                 abbr: 'ID' },
+}
+
+// ─── 試験方法 ────────────────────────────────────────────────────────────
+export const TEST_METHOD_TERMS: Record<string, Term> = {
+  vickers:     { ja: 'ビッカース硬さ試験',   en: 'Vickers Hardness Test',    abbr: 'HV試験' },
+  tensile:     { ja: '引張試験',             en: 'Tensile Test',             abbr: '引張' },
+  charpy:      { ja: 'シャルピー衝撃試験',   en: 'Charpy Impact Test',       abbr: 'シャルピー' },
+  fatigue:     { ja: '疲労試験',             en: 'Fatigue Test',             abbr: '疲労' },
+  creep:       { ja: 'クリープ試験',         en: 'Creep Test',               abbr: 'クリープ' },
+  corrosion:   { ja: '腐食試験',             en: 'Corrosion Test',           abbr: '腐食' },
+  metallography:{ ja: '金属組織観察',        en: 'Metallographic Analysis',  abbr: '組織観察' },
+  xrd:         { ja: 'X線回折',              en: 'X-ray Diffraction',        abbr: 'XRD' },
+  sem:         { ja: '走査電子顕微鏡',       en: 'Scanning Electron Microscopy', abbr: 'SEM' },
+  eds:         { ja: 'エネルギー分散型X線分析', en: 'Energy Dispersive X-ray Spectroscopy', abbr: 'EDS' },
+}
+
+// ─── ワークフロー (Petri net 工程) ───────────────────────────────────────
+export const WORKFLOW_TERMS: Record<string, Term> = {
+  planning:        { ja: '計画',       en: 'Planning' },
+  material_select: { ja: '材料選定',   en: 'Material Selection' },
+  raw_material:    { ja: '原料準備',   en: 'Raw Material Preparation' },
+  primary_process: { ja: '一次加工',   en: 'Primary Processing' },
+  post_process:    { ja: '後加工',     en: 'Post Processing' },
+  specimen:        { ja: '試験片採取', en: 'Specimen Extraction' },
+  evaluation:      { ja: '評価',       en: 'Evaluation' },
+  mechanical_test: { ja: '機械試験',   en: 'Mechanical Testing' },
+  environmental:   { ja: '環境試験',   en: 'Environmental Testing' },
+  fractography:    { ja: '破面解析',   en: 'Fractographic Analysis' },
+  report:          { ja: 'レポート',   en: 'Report' },
+  rework:          { ja: '再加工',     en: 'Rework' },
+  reject:          { ja: '廃棄',       en: 'Reject / Discard' },
+}
+
+// ─── UI ラベル ────────────────────────────────────────────────────────────
+export const UI_TERMS: Record<string, Term> = {
+  dashboard:      { ja: 'ダッシュボード',     en: 'Dashboard' },
+  material_list:  { ja: '材料データ一覧',     en: 'Material List' },
+  new_entry:      { ja: '新規登録',           en: 'New Entry' },
+  vector_search:  { ja: '意味検索',           en: 'Semantic Search' },
+  ai_chat:        { ja: 'AI チャット',        en: 'AI Chat' },
+  similar:        { ja: '類似材料を比較',     en: 'Similar Materials' },
+  petri_net:      { ja: '試験フロー可視化',   en: 'Workflow Visualization' },
+  bayes_opt:      { ja: 'ベイズ最適化',       en: 'Bayesian Optimization' },
+  help:           { ja: 'ヘルプ・用語集',     en: 'Help & Glossary' },
+  settings:       { ja: '設定',               en: 'Settings' },
+  export:         { ja: 'エクスポート',       en: 'Export' },
+  import:         { ja: 'インポート',         en: 'Import' },
+  download:       { ja: 'ダウンロード',       en: 'Download' },
+  preview:        { ja: 'プレビュー',         en: 'Preview' },
+  reset:          { ja: 'リセット',           en: 'Reset' },
+  undo:           { ja: '1 手戻る',           en: 'Undo' },
+  filter:         { ja: 'フィルタ',           en: 'Filter' },
+  search:         { ja: '検索',               en: 'Search' },
+}
+
+// ─── ヘルパー ─────────────────────────────────────────────────────────────
+
+/**
+ * 日英併記ラベルを生成する。
+ * @example bilingual(MATERIAL_TERMS.ts) → "引張強さ / Tensile Strength"
+ */
+export function bilingual(term: Term, separator = ' / '): string {
+  return `${term.ja}${separator}${term.en}`
+}
+
+/**
+ * 日英 + 単位を含むフルラベルを生成する。
+ * @example fullLabel(MATERIAL_TERMS.ts) → "引張強さ / Tensile Strength (MPa)"
+ */
+export function fullLabel(term: Term): string {
+  const base = bilingual(term)
+  return term.unit ? `${base} (${term.unit})` : base
+}

--- a/src/index.css
+++ b/src/index.css
@@ -32,7 +32,7 @@
   --shadow-md:0 4px 16px rgba(0,20,60,.10);
   --shadow-lg:0 8px 36px rgba(0,20,60,.13);
   --radius-sm:4px; --radius-md:6px; --radius-lg:10px; --radius-xl:14px;
-  --font-ui:-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic UI','Meiryo',Arial,sans-serif;
+  --font-ui:'Inter','Noto Sans JP',-apple-system,BlinkMacSystemFont,'Hiragino Sans','Yu Gothic UI','Meiryo',Arial,sans-serif;
   --font-mono:'SFMono-Regular',Consolas,'Courier New',monospace;
   --topbar-bg:#1e3050; --sidebar-bg:#ffffff;
 }
@@ -41,7 +41,7 @@
   --bg-sunken:#0c1018; --bg-hover:#232c3e; --bg-active:#1a2d4a;
   --border-faint:rgba(160,185,230,.10); --border-default:rgba(160,185,230,.18);
   --border-strong:rgba(160,185,230,.28); --border-focus:#5a9eff;
-  --text-hi:#e8f0ff; --text-md:#a8bcd8; --text-lo:#6e84a0;
+  --text-hi:#f0f4ff; --text-md:#c0d0e8; --text-lo:#8898b0;
   --accent:#5a9ae0; --accent-hover:#78b0ec;
   --accent-dim:#0e1e36; --accent-mid:#5a9ae0;
   --accent-glow:rgba(90,154,224,.18);
@@ -66,7 +66,7 @@
   --bg-sunken:#141820; --bg-hover:#2e3848; --bg-active:#1a2e48;
   --border-faint:rgba(100,160,220,.10); --border-default:rgba(100,160,220,.20);
   --border-strong:rgba(100,160,220,.32); --border-focus:#00c896;
-  --text-hi:#d8eaf8; --text-md:#92b0cc; --text-lo:#5e7890;
+  --text-hi:#e4f0fa; --text-md:#b0c8e0; --text-lo:#7890a8;
   --accent:#00c896; --accent-hover:#00e0aa;
   --accent-dim:rgba(0,200,150,.1); --accent-mid:#00c896;
   --accent-glow:rgba(0,200,150,.2);
@@ -82,7 +82,7 @@
   --shadow-md:0 4px 20px rgba(0,0,0,.6),0 0 16px rgba(0,200,150,.06);
   --shadow-lg:0 8px 40px rgba(0,0,0,.7),0 0 32px rgba(0,200,150,.08);
   --radius-sm:3px; --radius-md:5px; --radius-lg:8px; --radius-xl:12px;
-  --font-ui:'SF Mono',Consolas,'Courier New',monospace;
+  --font-ui:'Inter','Noto Sans JP','SF Mono',Consolas,'Courier New',monospace;
   --font-mono:'SF Mono',Consolas,'Courier New',monospace;
   --topbar-bg:#141820; --sidebar-bg:#1a1f26;
 }
@@ -91,7 +91,7 @@
   --bg-sunken:#0a0c10; --bg-hover:#1e2430; --bg-active:#142030;
   --border-faint:rgba(220,180,80,.10); --border-default:rgba(220,180,80,.20);
   --border-strong:rgba(220,180,80,.30); --border-focus:#e89020;
-  --text-hi:#f0ece4; --text-md:#b8a898; --text-lo:#6e6058;
+  --text-hi:#f4f0e8; --text-md:#d0c0b0; --text-lo:#908070;
   --accent:#e89020; --accent-hover:#f0a838;
   --accent-dim:rgba(232,144,32,.1); --accent-mid:#e89020;
   --accent-glow:rgba(232,144,32,.2);
@@ -107,7 +107,7 @@
   --shadow-md:0 4px 20px rgba(0,0,0,.75),0 0 20px rgba(232,144,32,.07);
   --shadow-lg:0 8px 40px rgba(0,0,0,.85),0 0 40px rgba(232,144,32,.1);
   --radius-sm:2px; --radius-md:4px; --radius-lg:6px; --radius-xl:10px;
-  --font-ui:'SF Mono',Consolas,'Courier New',monospace;
+  --font-ui:'Inter','Noto Sans JP','SF Mono',Consolas,'Courier New',monospace;
   --font-mono:'SF Mono',Consolas,'Courier New',monospace;
   --topbar-bg:#0a0c10; --sidebar-bg:#0e1014;
 }
@@ -117,6 +117,17 @@
 ===================================================== */
 *{box-sizing:border-box;margin:0;padding:0}
 html{font-size:14px}
+
+/* ダークテーマではサブピクセルレンダリングがフォントを細く見せるため
+   antialiased に切り替える。macOS Safari/Chrome で効果的。 */
+[data-theme="dark"] body,
+[data-theme="eng"] body,
+[data-theme="cae"] body{
+  -webkit-font-smoothing:antialiased;
+  -moz-osx-font-smoothing:grayscale;
+  text-rendering:optimizeLegibility;
+}
+
 body{
   font-family:var(--font-ui);
   background:var(--bg-base);


### PR DESCRIPTION
## 概要

issue #23 A-2 + ダークモード緊急修正。

## バイリンガル辞書 (A-2)

`src/i18n/terms.ts` に 4 カテゴリの用語辞書を追加:

| カテゴリ | 件数 | 例 |
|---|---|---|
| 材料特性 | 15 | 引張強さ / Tensile Strength (MPa) |
| 試験方法 | 10 | ビッカース硬さ試験 / Vickers Hardness Test |
| ワークフロー | 13 | 一次加工 / Primary Processing |
| UI | 16 | ダッシュボード / Dashboard |

`bilingual()` / `fullLabel()` ヘルパーで日英併記ラベルを生成。

## ダークモードフォント改善

**問題**: 英数字がかすれて見えない（特に Dark / Eng / CAE テーマ）

**原因**:
1. システムフォント (-apple-system 等) はダーク背景でのサブピクセルレンダリングでフォントが細くなる
2. `--text-md` / `--text-lo` のコントラストが不足

**修正**:
- **Inter + Noto Sans JP** を Google Fonts CDN から読み込み (preconnect + display=swap)
- 全 4 テーマの `--font-ui` 先頭に追加
- ダーク系テーマの `--text-md` / `--text-lo` コントラスト値を引き上げ
- `-webkit-font-smoothing: antialiased` をダークテーマに適用

## テスト

- 547 通過 + 2 スキップ

ref #23