### PR TITLE
feat(bayes): 2D ガウス過程回帰 + グリッドスキャン

### DIFF
--- a/src/services/bayesianOpt.test.ts
+++ b/src/services/bayesianOpt.test.ts
@@ -8,6 +8,10 @@ import {
   normalize,
   denormalize,
   DEFAULT_HYPER,
+  rbfKernel2D,
+  fitGP2D,
+  predictGP2D,
+  suggestNext2D,
 } from './bayesianOpt'
 
 describe('rbfKernel', () => {
@@ -142,5 +146,63 @@ describe('normalize / denormalize', () => {
     const { normalized, min, max } = normalize([10, 20, 30])
     expect(denormalize(normalized[0]!, min, max)).toBe(10)
     expect(denormalize(normalized[2]!, min, max)).toBe(30)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════
+// 2D GP
+// ═══════════════════════════════════════════════════════════════
+
+describe('rbfKernel2D', () => {
+  it('同じ点では variance', () => {
+    expect(rbfKernel2D([0, 0], [0, 0], DEFAULT_HYPER)).toBe(DEFAULT_HYPER.variance)
+  })
+
+  it('離れた点ほど値が小さい', () => {
+    const near = rbfKernel2D([0, 0], [0.3, 0.3], DEFAULT_HYPER)
+    const far  = rbfKernel2D([0, 0], [3, 3], DEFAULT_HYPER)
+    expect(near).toBeGreaterThan(far)
+  })
+})
+
+describe('fitGP2D + predictGP2D', () => {
+  const xs: [number, number][] = [[0,0],[1,0],[0,1],[1,1],[0.5,0.5]]
+  const ys = [0, 1, 1, 2, 1.5]
+
+  it('訓練点での予測は訓練値に近い', () => {
+    const model = fitGP2D(xs, ys)
+    for (let i = 0; i < xs.length; i++) {
+      const pred = predictGP2D(model, xs[i]!)
+      expect(pred.mean).toBeCloseTo(ys[i]!, 0)
+    }
+  })
+
+  it('訓練点での分散は小さい', () => {
+    const model = fitGP2D(xs, ys)
+    const pred = predictGP2D(model, [0.5, 0.5])
+    expect(pred.std).toBeLessThan(0.3)
+  })
+
+  it('遠点では分散が大きい', () => {
+    const model = fitGP2D(xs, ys)
+    const near = predictGP2D(model, [0.5, 0.5])
+    const far  = predictGP2D(model, [5, 5])
+    expect(far.std).toBeGreaterThan(near.std)
+  })
+})
+
+describe('suggestNext2D', () => {
+  it('提案点が範囲内かつ EI 非負', () => {
+    const xs: [number, number][] = [[0,0],[1,0],[0,1],[1,1]]
+    const ys = [0, 1, 1, 2]
+    const model = fitGP2D(xs, ys)
+    const { best, grid } = suggestNext2D(model, [0,0], [1,1], 10)
+    expect(best.x[0]).toBeGreaterThanOrEqual(0)
+    expect(best.x[0]).toBeLessThanOrEqual(1)
+    expect(best.x[1]).toBeGreaterThanOrEqual(0)
+    expect(best.x[1]).toBeLessThanOrEqual(1)
+    expect(best.ei).toBeGreaterThanOrEqual(0)
+    expect(grid).toHaveLength(100) // 10×10
+    for (const p of grid) expect(p.ei).toBeGreaterThanOrEqual(0)
   })
 })

--- a/src/services/bayesianOpt.ts
+++ b/src/services/bayesianOpt.ts
@@ -272,3 +272,102 @@ export function normalize(values: number[]): { normalized: number[]; min: number
 export function denormalize(v: number, min: number, max: number): number {
   return min + v * (max - min)
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2D ガウス過程回帰
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 2D RBF カーネル (各次元で同一の lengthScale を使う等方カーネル)。
+ */
+export function rbfKernel2D(
+  x1: [number, number], x2: [number, number], h: GPHyperParams,
+): number {
+  const d0 = x1[0] - x2[0]
+  const d1 = x1[1] - x2[1]
+  return h.variance * Math.exp(-(d0 * d0 + d1 * d1) / (2 * h.lengthScale * h.lengthScale))
+}
+
+export interface GPModel2D {
+  xs: [number, number][]
+  ys: number[]
+  h: GPHyperParams
+  alpha: number[]
+  L: number[][]
+}
+
+export function fitGP2D(
+  xs: [number, number][],
+  ys: number[],
+  h: GPHyperParams = DEFAULT_HYPER,
+): GPModel2D {
+  const n = xs.length
+  if (n === 0) throw new Error('fitGP2D: empty training data')
+  if (xs.length !== ys.length) throw new Error('fitGP2D: xs/ys length mismatch')
+
+  const K: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const kij = rbfKernel2D(xs[i]!, xs[j]!, h)
+      K[i]![j] = i === j ? kij + h.noise : kij
+    }
+  }
+
+  const L = cholesky(K)
+  const z = forwardSolve(L, ys)
+  const alpha = backwardSolve(L, z)
+
+  return { xs: xs.map(p => [...p] as [number, number]), ys: [...ys], h, alpha, L }
+}
+
+export function predictGP2D(model: GPModel2D, x: [number, number]): GPPrediction {
+  const n = model.xs.length
+  const kStar: number[] = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    kStar[i] = rbfKernel2D(x, model.xs[i]!, model.h)
+  }
+  let mean = 0
+  for (let i = 0; i < n; i++) mean += (kStar[i] ?? 0) * (model.alpha[i] ?? 0)
+  const kxx = rbfKernel2D(x, x, model.h)
+  const v = forwardSolve(model.L, kStar)
+  let vv = 0
+  for (let i = 0; i < n; i++) vv += (v[i] ?? 0) * (v[i] ?? 0)
+  return { mean, std: Math.sqrt(Math.max(kxx - vv, 0)) }
+}
+
+export interface Suggestion2D {
+  x: [number, number]
+  mean: number
+  std: number
+  ei: number
+}
+
+/**
+ * 2D グリッドスキャンで EI 最大点を返す。
+ * nGrid は各軸のグリッド数 (合計 nGrid² 点)。
+ */
+export function suggestNext2D(
+  model: GPModel2D,
+  xMin: [number, number],
+  xMax: [number, number],
+  nGrid = 20,
+  xi = 0.01,
+): { best: Suggestion2D; grid: Suggestion2D[] } {
+  const yBest = Math.max(...model.ys)
+  const grid: Suggestion2D[] = []
+  let best: Suggestion2D | null = null
+  const step0 = (xMax[0] - xMin[0]) / Math.max(nGrid - 1, 1)
+  const step1 = (xMax[1] - xMin[1]) / Math.max(nGrid - 1, 1)
+  for (let i = 0; i < nGrid; i++) {
+    for (let j = 0; j < nGrid; j++) {
+      const x: [number, number] = [xMin[0] + step0 * i, xMin[1] + step1 * j]
+      const pred = predictGP2D(model, x)
+      const ei = expectedImprovement(pred, yBest, xi)
+      const point: Suggestion2D = { x, mean: pred.mean, std: pred.std, ei }
+      grid.push(point)
+      if (best === null || ei > best.ei) best = point
+    }
+  }
+  if (!best) throw new Error('suggestNext2D: grid is empty')
+  return { best, grid }
+}


### PR DESCRIPTION
## 概要

issue #27 B-1。既存 1D GP に 2D 特徴量空間対応を追加。ロジック層のみ（UI は後続）。

- `rbfKernel2D` / `fitGP2D` / `predictGP2D` / `suggestNext2D`
- テスト 6 件追加 (合計 25 件)

ref #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 2次元ガウス過程回帰および最適化機能を実装。グリッド探索による次の実験点の自動提案が可能に。

* **テスト**
  * 新しい2次元最適化アルゴリズムの包括的なテストスイートを追加。カーネル計算、モデル学習、予測、提案生成の動作を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->