### PR TITLE
feat(form): ステップ式入力ウィザード + カテゴリ別テンプレート

### DIFF
--- a/src/services/bayesianOpt.test.ts
+++ b/src/services/bayesianOpt.test.ts
@@ -8,6 +8,10 @@ import {
   normalize,
   denormalize,
   DEFAULT_HYPER,
+  rbfKernel2D,
+  fitGP2D,
+  predictGP2D,
+  suggestNext2D,
 } from './bayesianOpt'
 
 describe('rbfKernel', () => {
@@ -142,5 +146,63 @@ describe('normalize / denormalize', () => {
     const { normalized, min, max } = normalize([10, 20, 30])
     expect(denormalize(normalized[0]!, min, max)).toBe(10)
     expect(denormalize(normalized[2]!, min, max)).toBe(30)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════
+// 2D GP
+// ═══════════════════════════════════════════════════════════════
+
+describe('rbfKernel2D', () => {
+  it('同じ点では variance', () => {
+    expect(rbfKernel2D([0, 0], [0, 0], DEFAULT_HYPER)).toBe(DEFAULT_HYPER.variance)
+  })
+
+  it('離れた点ほど値が小さい', () => {
+    const near = rbfKernel2D([0, 0], [0.3, 0.3], DEFAULT_HYPER)
+    const far  = rbfKernel2D([0, 0], [3, 3], DEFAULT_HYPER)
+    expect(near).toBeGreaterThan(far)
+  })
+})
+
+describe('fitGP2D + predictGP2D', () => {
+  const xs: [number, number][] = [[0,0],[1,0],[0,1],[1,1],[0.5,0.5]]
+  const ys = [0, 1, 1, 2, 1.5]
+
+  it('訓練点での予測は訓練値に近い', () => {
+    const model = fitGP2D(xs, ys)
+    for (let i = 0; i < xs.length; i++) {
+      const pred = predictGP2D(model, xs[i]!)
+      expect(pred.mean).toBeCloseTo(ys[i]!, 0)
+    }
+  })
+
+  it('訓練点での分散は小さい', () => {
+    const model = fitGP2D(xs, ys)
+    const pred = predictGP2D(model, [0.5, 0.5])
+    expect(pred.std).toBeLessThan(0.3)
+  })
+
+  it('遠点では分散が大きい', () => {
+    const model = fitGP2D(xs, ys)
+    const near = predictGP2D(model, [0.5, 0.5])
+    const far  = predictGP2D(model, [5, 5])
+    expect(far.std).toBeGreaterThan(near.std)
+  })
+})
+
+describe('suggestNext2D', () => {
+  it('提案点が範囲内かつ EI 非負', () => {
+    const xs: [number, number][] = [[0,0],[1,0],[0,1],[1,1]]
+    const ys = [0, 1, 1, 2]
+    const model = fitGP2D(xs, ys)
+    const { best, grid } = suggestNext2D(model, [0,0], [1,1], 10)
+    expect(best.x[0]).toBeGreaterThanOrEqual(0)
+    expect(best.x[0]).toBeLessThanOrEqual(1)
+    expect(best.x[1]).toBeGreaterThanOrEqual(0)
+    expect(best.x[1]).toBeLessThanOrEqual(1)
+    expect(best.ei).toBeGreaterThanOrEqual(0)
+    expect(grid).toHaveLength(100) // 10×10
+    for (const p of grid) expect(p.ei).toBeGreaterThanOrEqual(0)
   })
 })

--- a/src/services/bayesianOpt.ts
+++ b/src/services/bayesianOpt.ts
@@ -272,3 +272,102 @@ export function normalize(values: number[]): { normalized: number[]; min: number
 export function denormalize(v: number, min: number, max: number): number {
   return min + v * (max - min)
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2D ガウス過程回帰
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * 2D RBF カーネル (各次元で同一の lengthScale を使う等方カーネル)。
+ */
+export function rbfKernel2D(
+  x1: [number, number], x2: [number, number], h: GPHyperParams,
+): number {
+  const d0 = x1[0] - x2[0]
+  const d1 = x1[1] - x2[1]
+  return h.variance * Math.exp(-(d0 * d0 + d1 * d1) / (2 * h.lengthScale * h.lengthScale))
+}
+
+export interface GPModel2D {
+  xs: [number, number][]
+  ys: number[]
+  h: GPHyperParams
+  alpha: number[]
+  L: number[][]
+}
+
+export function fitGP2D(
+  xs: [number, number][],
+  ys: number[],
+  h: GPHyperParams = DEFAULT_HYPER,
+): GPModel2D {
+  const n = xs.length
+  if (n === 0) throw new Error('fitGP2D: empty training data')
+  if (xs.length !== ys.length) throw new Error('fitGP2D: xs/ys length mismatch')
+
+  const K: number[][] = Array.from({ length: n }, () => new Array<number>(n).fill(0))
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < n; j++) {
+      const kij = rbfKernel2D(xs[i]!, xs[j]!, h)
+      K[i]![j] = i === j ? kij + h.noise : kij
+    }
+  }
+
+  const L = cholesky(K)
+  const z = forwardSolve(L, ys)
+  const alpha = backwardSolve(L, z)
+
+  return { xs: xs.map(p => [...p] as [number, number]), ys: [...ys], h, alpha, L }
+}
+
+export function predictGP2D(model: GPModel2D, x: [number, number]): GPPrediction {
+  const n = model.xs.length
+  const kStar: number[] = new Array(n).fill(0)
+  for (let i = 0; i < n; i++) {
+    kStar[i] = rbfKernel2D(x, model.xs[i]!, model.h)
+  }
+  let mean = 0
+  for (let i = 0; i < n; i++) mean += (kStar[i] ?? 0) * (model.alpha[i] ?? 0)
+  const kxx = rbfKernel2D(x, x, model.h)
+  const v = forwardSolve(model.L, kStar)
+  let vv = 0
+  for (let i = 0; i < n; i++) vv += (v[i] ?? 0) * (v[i] ?? 0)
+  return { mean, std: Math.sqrt(Math.max(kxx - vv, 0)) }
+}
+
+export interface Suggestion2D {
+  x: [number, number]
+  mean: number
+  std: number
+  ei: number
+}
+
+/**
+ * 2D グリッドスキャンで EI 最大点を返す。
+ * nGrid は各軸のグリッド数 (合計 nGrid² 点)。
+ */
+export function suggestNext2D(
+  model: GPModel2D,
+  xMin: [number, number],
+  xMax: [number, number],
+  nGrid = 20,
+  xi = 0.01,
+): { best: Suggestion2D; grid: Suggestion2D[] } {
+  const yBest = Math.max(...model.ys)
+  const grid: Suggestion2D[] = []
+  let best: Suggestion2D | null = null
+  const step0 = (xMax[0] - xMin[0]) / Math.max(nGrid - 1, 1)
+  const step1 = (xMax[1] - xMin[1]) / Math.max(nGrid - 1, 1)
+  for (let i = 0; i < nGrid; i++) {
+    for (let j = 0; j < nGrid; j++) {
+      const x: [number, number] = [xMin[0] + step0 * i, xMin[1] + step1 * j]
+      const pred = predictGP2D(model, x)
+      const ei = expectedImprovement(pred, yBest, xi)
+      const point: Suggestion2D = { x, mean: pred.mean, std: pred.std, ei }
+      grid.push(point)
+      if (best === null || ei > best.ei) best = point
+    }
+  }
+  if (!best) throw new Error('suggestNext2D: grid is empty')
+  return { best, grid }
+}


### PR DESCRIPTION
## Summary
- MaterialFormPage を 3 ステップウィザード (基本情報→物性データ→確認・登録) に再構築
- 再利用可能な StepWizard molecule コンポーネント (プログレスバー + ステップインジケーター + 前後ナビゲーション)
- カテゴリ別テンプレート (金属合金/セラミクス/ポリマー/複合材料) でプレースホルダー・ヒントが自動切替
- Phase A 拡張フィールド (provenance/testMethod/microstructure) を Step2 に統合
- 確認画面で全入力値の一覧 + 入力済みカウンターを表示

## IHI PoC 課題への対応
- **「入力が煩雑」** → 3 ステップ分割で 1 画面あたりのフィールド数を約半分に削減
- **「どこで何ができるか分からない」** → ステップインジケーター + サイドバー連動で現在位置を常時表示
- **カテゴリ文脈の自動切替** → 金属合金なら HV200/MPa520、セラミクスなら HV1500/GPa380 等

## 変更ファイル
| ファイル | 変更 |
|---------|------|
| `src/components/molecules/StepWizard.tsx` | 新規: 再利用可能ステッパー UI |
| `src/components/molecules/index.ts` | エクスポート追加 |
| `src/pages/MaterialForm/MaterialFormPage.tsx` | 3 ステップ化 + テンプレート + 拡張フィールド |
| `src/pages/MaterialForm/MaterialFormPage.test.tsx` | ウィザード対応テスト 7 件 |

## Test plan
- [ ] tsc --noEmit 通過
- [ ] vitest 572 テスト全通過 (回帰なし)
- [ ] Step1: 必須項目未入力で「次へ」→ エラー表示
- [ ] Step1: カテゴリ選択で placeholder 切替確認
- [ ] Step2: 物性データ入力 + 拡張フィールド
- [ ] Step3: 確認画面で全項目表示 + 入力済みカウント
- [ ] 4 テーマ (light/dark/eng/cae) での表示確認
- [ ] 編集モード (editId 指定) でのデータプリフィル

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 2次元ガウス過程回帰による最適化機能を追加しました。RBFカーネルを用いたグリッドベースの候補選択により、2次元パラメータ空間での探索が可能になります。

* **テスト**
  * 新しい2次元ガウス過程機能の包括的なテストスイートを追加しました。カーネル計算、モデルフィッティング、予測機能の正確性を検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->