### PR TITLE
fix: 類似材料検索の候補拡大 + セルフレビュー修正

### DIFF
--- a/src/pages/Dashboard/DashboardPage.tsx
+++ b/src/pages/Dashboard/DashboardPage.tsx
@@ -197,7 +197,7 @@ export const DashboardPage = ({ db, onNav, claude, announcements, onOpenAnnounce
               <span className="w-1.5 h-1.5 rounded-full flex-shrink-0" style={{ background: ['var(--accent)','var(--ok)','var(--warn)','var(--ai-mid)','#D4537E'][i] }} />
               <div className="flex-1 min-w-0">
                 <div className="text-[13px] font-semibold truncate">{r.name}</div>
-                <div className="text-[12px] text-text-lo font-mono">{r.id} · {r.batch}</div>
+                <div className="text-[12px] text-text-lo">{r.id} · {r.batch}</div>
               </div>
               <Badge>{r.status}</Badge>
             </div>
@@ -208,7 +208,7 @@ export const DashboardPage = ({ db, onNav, claude, announcements, onOpenAnnounce
             <div key={lbl} className="flex items-center gap-2.5 py-1.5 text-[12px]">
               <span className="w-20 text-text-md flex-shrink-0">{lbl}</span>
               <ProgressBar value={val} color={col} className="flex-1 h-1.5" />
-              <span className="w-7 text-right font-mono text-text-lo">{val}%</span>
+              <span className="w-7 text-right tabular-nums text-text-lo">{val}%</span>
             </div>
           ))}
         </SectionCard>

--- a/src/pages/Detail/DetailPage.tsx
+++ b/src/pages/Detail/DetailPage.tsx
@@ -103,7 +103,7 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
             <Icon name="chevronLeft" size={12} />
             {prevId && <span className="hidden sm:inline text-text-md truncate max-w-[80px]">{db[currentIndex - 1]?.name}</span>}
           </button>
-          <span className="text-[11px] text-text-lo font-mono px-1">{currentIndex + 1} / {db.length}</span>
+          <span className="text-[11px] text-text-lo tabular-nums px-1">{currentIndex + 1} / {db.length}</span>
           <button onClick={() => goTo(nextId)} disabled={!nextId}
             className="flex items-center gap-1 px-2.5 py-1.5 rounded-md border border-[var(--border-default)] bg-raised hover:bg-hover hover:border-accent disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-[11px]"
             title="次の材料">
@@ -118,7 +118,7 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
           <MaterialVisual name={r.name} cat={r.cat} hv={r.hv} size={100} className="flex-shrink-0" showLabel={false} />
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 mb-1">
-              <span className="font-mono text-[11px] bg-raised px-2 py-1 rounded text-text-lo flex-shrink-0">{r.id}</span>
+              <span className="text-[11px] bg-raised tabular-nums px-2 py-1 rounded text-text-lo flex-shrink-0">{r.id}</span>
             </div>
             <h1 className="text-[19px] font-bold tracking-tight">{r.name}</h1>
             <div className="flex items-center gap-2 flex-wrap mt-2">
@@ -194,11 +194,11 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
           <SectionCard title="同カテゴリ 硬度比較">
             {cmpData.map((x,i) => (
               <div key={x.id} className="flex items-center gap-2.5 text-[12px] py-1">
-                <span className="w-16 text-right text-text-lo font-mono flex-shrink-0">{x.id.slice(-4)}</span>
+                <span className="w-16 text-right text-text-lo tabular-nums flex-shrink-0">{x.id.slice(-4)}</span>
                 <div className="flex-1 h-1.5 bg-raised rounded-full overflow-hidden">
                   <div className="h-full rounded-full transition-all duration-500" style={{ width:`${Math.round(x.hv/maxHv*100)}%`, background: colors[i] }} />
                 </div>
-                <span className="w-14 font-mono text-text-lo text-right">{x.hv.toLocaleString()} HV</span>
+                <span className="w-14 tabular-nums text-text-lo text-right">{x.hv.toLocaleString()} HV</span>
               </div>
             ))}
           </SectionCard>
@@ -229,7 +229,7 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
             <div className="text-[12px] font-bold text-vec uppercase tracking-[.04em] mb-2">Embedding 近傍</div>
             {vecNear.length === 0 ? <p className="text-[12px]">—</p> : vecNear.map(x=>(
               <div key={x.id} className="flex items-center gap-2 py-1 border-b border-[var(--border-faint)] last:border-b-0 text-[12px]">
-                <span className="font-mono text-text-lo">{x.id}</span>
+                <span className="text-text-lo">{x.id}</span>
                 <span className="flex-1 truncate">{x.name}</span>
                 <span className="text-[11px] font-bold text-vec">{Math.round((x.score||0)*100)}%</span>
               </div>
@@ -240,7 +240,7 @@ export const DetailPage = ({ db, recordId, dispatch, onBack, onEdit, claude, emb
             {db.filter(x=>x.batch===r.batch&&x.id!==r.id).slice(0,4).map(x=>(
               <div key={x.id} className="flex items-center gap-2 py-1.5 border-b border-[var(--border-faint)] last:border-b-0 text-[13px]">
                 <span className="w-1.5 h-1.5 rounded-full bg-accent flex-shrink-0" />
-                <div className="flex-1 min-w-0"><div className="font-semibold truncate">{x.name}</div><div className="text-[12px] text-text-lo font-mono">{x.id}</div></div>
+                <div className="flex-1 min-w-0"><div className="font-semibold truncate">{x.name}</div><div className="text-[12px] text-text-lo">{x.id}</div></div>
                 <Badge>{x.status}</Badge>
               </div>
             ))}

--- a/src/pages/MasterSettings/MasterSettingsPage.tsx
+++ b/src/pages/MasterSettings/MasterSettingsPage.tsx
@@ -38,7 +38,7 @@ export const MasterSettingsPage = ({ db }: MasterSettingsPageProps) => {
                 <div className="flex-1">
                   <ProgressBar value={Math.round(count / db.length * 100)} color="var(--accent)" />
                 </div>
-                <span className="text-[12px] text-text-lo font-mono w-10 text-right">{count}件</span>
+                <span className="text-[12px] text-text-lo tabular-nums w-10 text-right">{count}件</span>
               </div>
             );
           })}
@@ -61,7 +61,7 @@ export const MasterSettingsPage = ({ db }: MasterSettingsPageProps) => {
                   <div className="text-[11px] text-text-lo">{desc}</div>
                 </div>
                 <Badge>{s}</Badge>
-                <span className="text-[12px] text-text-lo font-mono w-8 text-right">{count}</span>
+                <span className="text-[12px] text-text-lo tabular-nums w-8 text-right">{count}</span>
               </div>
             );
           })}
@@ -74,11 +74,11 @@ export const MasterSettingsPage = ({ db }: MasterSettingsPageProps) => {
               const count = db.filter(r => r.batch === batch).length;
               return (
                 <div key={batch} className="flex items-center gap-3 py-1.5 border-b border-[var(--border-faint)] last:border-b-0 text-[13px]">
-                  <span className="font-mono text-accent">{batch}</span>
+                  <span className="text-accent">{batch}</span>
                   <div className="flex-1">
                     <ProgressBar value={Math.round(count / db.length * 100)} color="var(--accent)" />
                   </div>
-                  <span className="text-[12px] text-text-lo font-mono w-8 text-right">{count}</span>
+                  <span className="text-[12px] text-text-lo tabular-nums w-8 text-right">{count}</span>
                 </div>
               );
             })}
@@ -95,7 +95,7 @@ export const MasterSettingsPage = ({ db }: MasterSettingsPageProps) => {
                   {author.slice(0,1)}
                 </div>
                 <span className="text-[13px] font-semibold flex-1">{author}</span>
-                <span className="text-[12px] text-text-lo font-mono">{count}件担当</span>
+                <span className="text-[12px] text-text-lo tabular-nums">{count}件担当</span>
               </div>
             );
           })}

--- a/src/pages/MaterialList/MaterialListPage.tsx
+++ b/src/pages/MaterialList/MaterialListPage.tsx
@@ -447,7 +447,7 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
                   <th className="border-b border-[var(--border-faint)]">
                     <label className="flex items-center justify-center p-2.5 cursor-pointer"><Checkbox checked={slice.length > 0 && slice.every(r => selected.has(r.id))} onChange={(e: React.ChangeEvent<HTMLInputElement>) => toggleAll(e.target.checked)} aria-label="全選択" /></label>
                   </th>
-                  {[['ID', 'font-mono'], ['材料名称', ''], ['カテゴリ', ''], ['硬度 HV', ''], ['組成', ''], ['登録日', ''], ['ステータス', ''], ['AI', 'text-center'], ['操作', 'text-center']].map(([l, cls]) => (
+                  {[['ID', ''], ['材料名称', ''], ['カテゴリ', ''], ['硬度 HV', ''], ['組成', ''], ['登録日', ''], ['ステータス', ''], ['AI', 'text-center'], ['操作', 'text-center']].map(([l, cls]) => (
                     <th key={l} className={`px-3.5 py-2.5 text-left text-[11px] font-bold text-text-lo tracking-[.05em] uppercase border-b border-[var(--border-faint)] ${cls}`}>{l}</th>
                   ))}
                 </tr>
@@ -458,11 +458,11 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
                 ) : slice.map(r => (
                   <tr key={r.id} className={`border-b border-[var(--border-faint)] last:border-b-0 cursor-pointer transition-colors duration-75 ${selected.has(r.id) ? 'bg-accent-dim' : 'hover:bg-hover'}`} onClick={e => { if ((e.target as HTMLElement).tagName === 'BUTTON' || (e.target as HTMLElement).tagName === 'INPUT') return; onDetail(r.id); }}>
                     <td onClick={e => e.stopPropagation()}><label className="flex items-center justify-center p-2.5 cursor-pointer"><Checkbox checked={selected.has(r.id)} onChange={() => toggleSelect(r.id)} aria-label={`${r.name} を選択`} /></label></td>
-                    <td className="px-3.5 py-2.5"><span className="font-mono text-[12px] text-text-lo"><Hl text={r.id} query={filters.q} /></span></td>
+                    <td className="px-3.5 py-2.5"><span className="text-[12px] text-text-lo tabular-nums"><Hl text={r.id} query={filters.q} /></span></td>
                     <td className="px-3.5 py-2.5"><span className="font-semibold"><Hl text={r.name} query={filters.q} /></span></td>
                     <td className="px-3.5 py-2.5"><Badge variant="gray">{r.cat}</Badge></td>
-                    <td className="px-3.5 py-2.5 font-mono">{r.hv.toLocaleString()}</td>
-                    <td className="px-3.5 py-2.5"><span className="font-mono text-[12px] block truncate text-text-md"><Hl text={r.comp} query={filters.q} /></span></td>
+                    <td className="px-3.5 py-2.5 tabular-nums">{r.hv.toLocaleString()}</td>
+                    <td className="px-3.5 py-2.5"><span className="text-[12px] block truncate text-text-md"><Hl text={r.comp} query={filters.q} /></span></td>
                     <td className="px-3.5 py-2.5 text-[12px] text-text-lo">{r.date}</td>
                     <td className="px-3.5 py-2.5"><Badge>{r.status}</Badge></td>
                     <td className="px-3.5 py-2.5 text-center">{r.ai && <Badge variant="ai">検出</Badge>}</td>
@@ -492,7 +492,7 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
                   <MaterialVisual name={r.name} cat={r.cat} hv={r.hv} size={80} />
                 </div>
                 <div className="p-3 flex flex-col gap-1 flex-1">
-                  <div className="text-[10px] font-mono text-text-lo"><Hl text={r.id} query={filters.q} /></div>
+                  <div className="text-[10px] text-text-lo tabular-nums"><Hl text={r.id} query={filters.q} /></div>
                   <div className="text-[13px] font-bold text-text-hi group-hover:text-accent transition-colors leading-tight"><Hl text={r.name} query={filters.q} /></div>
                   <div className="flex items-center gap-1.5 mt-1 flex-wrap">
                     <Badge variant="gray">{r.cat}</Badge>
@@ -500,9 +500,9 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
                     {r.ai && <Badge variant="ai">AI</Badge>}
                   </div>
                   <div className="grid grid-cols-3 gap-1 mt-2 text-[10px]">
-                    <div><span className="text-text-lo">硬度</span><div className="font-mono font-bold">{r.hv.toLocaleString()}</div></div>
-                    <div><span className="text-text-lo">引張</span><div className="font-mono font-bold">{r.ts.toLocaleString()}</div></div>
-                    <div><span className="text-text-lo">弾性</span><div className="font-mono font-bold">{r.el}</div></div>
+                    <div><span className="text-text-lo">硬度</span><div className="font-bold tabular-nums">{r.hv.toLocaleString()}</div></div>
+                    <div><span className="text-text-lo">引張</span><div className="font-bold tabular-nums">{r.ts.toLocaleString()}</div></div>
+                    <div><span className="text-text-lo">弾性</span><div className="font-bold tabular-nums">{r.el}</div></div>
                   </div>
                 </div>
               </button>
@@ -519,10 +519,10 @@ export const MaterialListPage = ({ db, dispatch, onNav, onDetail, search }: Mate
               <button key={r.id} onClick={() => onDetail(r.id)}
                 className="group flex items-center gap-3 px-4 py-2.5 border-b border-[var(--border-faint)] last:border-b-0 hover:bg-hover transition-colors text-left">
                 <MaterialVisual name={r.name} cat={r.cat} hv={r.hv} size={36} className="flex-shrink-0" />
-                <span className="font-mono text-[11px] text-text-lo w-16 flex-shrink-0"><Hl text={r.id} query={filters.q} /></span>
+                <span className="text-[11px] tabular-nums text-text-lo w-16 flex-shrink-0"><Hl text={r.id} query={filters.q} /></span>
                 <span className="text-[13px] font-semibold text-text-hi group-hover:text-accent flex-1 truncate"><Hl text={r.name} query={filters.q} /></span>
                 <Badge variant="gray">{r.cat}</Badge>
-                <span className="font-mono text-[12px] text-text-md w-16 text-right flex-shrink-0">{r.hv.toLocaleString()} HV</span>
+                <span className="text-[12px] text-text-md tabular-nums w-16 text-right flex-shrink-0">{r.hv.toLocaleString()} HV</span>
                 <Badge>{r.status}</Badge>
                 {r.ai && <Badge variant="ai">AI</Badge>}
                 <Icon name="chevronRight" size={12} className="text-text-lo group-hover:text-accent flex-shrink-0" />

--- a/src/pages/Similar/SimilarPage.tsx
+++ b/src/pages/Similar/SimilarPage.tsx
@@ -28,8 +28,8 @@ export const SimilarPage = ({ db, embedding, claude, initialBase, clearInitialBa
   const [base, setBase] = useState(() => resolveBase(initialBase || 'MAT-0237', db));
   const autoRan = useRef(false);
   const [weight, setWeight] = useState('総合スコア');
-  const [k, setK] = useState(10);
-  const [threshold, setThreshold] = useState(60);
+  const [k, setK] = useState(15);
+  const [threshold, setThreshold] = useState(30);
   const [results, setResults] = useState<MaterialWithScore[]>([]);
   const [aiComment, setAiComment] = useState('');
   const [running, setRunning] = useState(false);
@@ -37,9 +37,11 @@ export const SimilarPage = ({ db, embedding, claude, initialBase, clearInitialBa
 
   const runWith = async (baseLabel: string) => {
     setRunning(true);
-    const baseId = (baseLabel.match(/MAT-\d+/)||[])[0];
+    // MAT-XXXX と MT-XXXX の両方にマッチするよう正規表現を拡張
+    const baseId = (baseLabel.match(/(?:MAT|MT)-\d+/)||[])[0];
     const baseRec = db.find(r=>r.id===baseId);
-    const q = baseRec ? `${baseRec.name} ${baseRec.comp}` : baseLabel;
+    // 名称 + 組成 + カテゴリ + メモをクエリに含めて広い候補を得る
+    const q = baseRec ? `${baseRec.name} ${baseRec.cat} ${baseRec.comp} ${baseRec.memo}` : baseLabel;
     const res = await embedding.search(q, k);
     const filtered = res.filter(r => r.id !== baseId && (r.score||0) >= threshold/100);
     setResults(filtered);
@@ -108,7 +110,7 @@ export const SimilarPage = ({ db, embedding, claude, initialBase, clearInitialBa
             <Card key={r.id} className="p-3 hover:border-[var(--vec-mid)] transition-colors">
               <div className="flex items-center gap-2.5 mb-1.5">
                 <span className="text-[13px] font-bold text-text-lo">#{i+1}</span>
-                <span className="font-mono text-[12px] text-text-lo">{r.id}</span>
+                <span className="text-[12px] text-text-lo">{r.id}</span>
                 <span className="font-semibold flex-1">{r.name}</span>
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[12px] font-bold bg-vec-dim text-vec border border-[var(--border-default)]">
                   <Icon name="embed" size={11} />{Math.round((r.score||0)*100)}%

--- a/src/pages/VectorSearch/VectorSearchPage.tsx
+++ b/src/pages/VectorSearch/VectorSearchPage.tsx
@@ -115,7 +115,7 @@ export const VectorSearchPage = ({ db, embedding, claude }: VectorSearchPageProp
             <Card key={r.id} className="p-3 hover:border-[var(--vec-mid)] transition-colors cursor-pointer">
               <div className="flex items-center gap-2.5 mb-1.5">
                 <span className="text-[13px] font-bold text-text-lo">#{i+1}</span>
-                <span className="font-mono text-[12px] text-text-lo">{r.id}</span>
+                <span className="text-[12px] text-text-lo">{r.id}</span>
                 <span className="font-semibold flex-1">{r.name}</span>
                 <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[12px] font-bold bg-vec-dim text-vec border border-[var(--border-default)]">
                   <Icon name="embed" size={11} />{Math.round((r.score||0)*100)}%


### PR DESCRIPTION
類似材料検索: しきい値 60%→30%、k 10→15、MT- ID 対応、クエリにカテゴリ・備考追加。セルフレビュー M3/M4/m2 修正。お知らせ 3 件追加。596 テスト通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 類似検索の条件を更新：取得件数を15件に、閾値を30に変更し、検索対象フィールドを拡張

* **改善**
  * 各ページの数値表示のアライメントを改善：ダッシュボード、詳細ページ、マテリアルリスト、ベクトル検索結果全体で数値の桁揃えを強化
  * 識別子パターンのマッチング範囲を拡張：MAT-####に加えてMT-####にも対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->