### PR TITLE
fix(build): className 動的テンプレートリテラルを inline style 化して Vercel ビルドを修復

### DIFF
--- a/src/pages/About/AboutPage.tsx
+++ b/src/pages/About/AboutPage.tsx
@@ -75,7 +75,12 @@ export const AboutPage = () => {
           ] as const).map(([name,items,color],i,arr)=>(
             <React.Fragment key={name}>
               <div className="flex-1 min-w-[160px] flex flex-col gap-2 px-4 border-r border-[var(--border-faint)] last:border-r-0">
-                <div className={`text-[11px] font-bold uppercase tracking-[.05em] text-[var(--${color})]`}>{name}</div>
+                <div
+                  className="text-[11px] font-bold uppercase tracking-[.05em]"
+                  style={{ color: `var(--${color})` }}
+                >
+                  {name}
+                </div>
                 <div className="text-[12px] text-text-md leading-[1.7]">{items.split(' / ').map(c=><span key={c} className="inline-block"><code className="text-[11px] bg-raised px-1 py-0.5 rounded border border-[var(--border-faint)]">{c}</code>{' '}</span>)}</div>
               </div>
               {i < arr.length-1 && <div className="flex items-center px-1 text-text-lo flex-shrink-0"><Icon name="chevronRight" size={14} /></div>}

--- a/src/pages/UxDesign/UxDesignPage.tsx
+++ b/src/pages/UxDesign/UxDesignPage.tsx
@@ -104,7 +104,15 @@ export const UxDesignPage = () => {
       <SectionCard title="フィードバック設計の4層">
         <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
           {[['即時 (<100ms)','ボタン押下のvisual feedback。hover/focus状態。','accent'],['短期 (〜2s)','ローディング・Typing インジケーター（AI応答待ち）。','ai'],['操作完了','Toast通知（登録・更新・削除）。3秒後自動消去。','ok'],['エラー・警告','モーダル（削除確認）。インラインエラー。バナー。','warn']].map(([t,d,c])=>(
-            <div key={t} className={`bg-[var(--${c}-dim)] border border-[var(--${c})] rounded p-3`}><div className="text-[13px] font-bold text-text-hi mb-1.5">{t}</div><div className="text-[12px] text-text-md">{d}</div></div>
+            // Tailwind JIT が dynamic string を読めないよう、CSS 変数は inline style で渡す
+            <div
+              key={t}
+              className="rounded p-3 border"
+              style={{ background: `var(--${c}-dim)`, borderColor: `var(--${c})` }}
+            >
+              <div className="text-[13px] font-bold text-text-hi mb-1.5">{t}</div>
+              <div className="text-[12px] text-text-md">{d}</div>
+            </div>
           ))}
         </div>
       </SectionCard>
@@ -171,7 +179,15 @@ export const UxDesignPage = () => {
         <SectionCard title="コンポーネント構成 (Atomic Design)">
           <div className="flex flex-col gap-2 text-[12px]">
             {[['Atoms','Button·Icon·Badge·Input·Select·Textarea·UnitInput·Checkbox·ProgressBar·Typing','accent'],['Molecules','SearchBox·FilterChip·Modal·Toast·KpiCard·AIInsightCard·VecCard·MarkdownBubble·ExportModal','ai'],['Organisms','Topbar·Sidebar·VoicePanel','vec'],['Pages','Dashboard·List·Form·Detail·VecSearch·RAGChat·Similar·Voice·API·Tests·UX·Help·About','ok']].map(([name,items,color])=>(
-              <div key={name} className="py-1.5 border-b border-[var(--border-faint)] last:border-b-0"><div className={`text-[11px] font-bold uppercase tracking-[.04em] text-[var(--${color})] mb-0.5`}>{name}</div><div className="text-text-lo">{items}</div></div>
+              <div key={name} className="py-1.5 border-b border-[var(--border-faint)] last:border-b-0">
+                <div
+                  className="text-[11px] font-bold uppercase tracking-[.04em] mb-0.5"
+                  style={{ color: `var(--${color})` }}
+                >
+                  {name}
+                </div>
+                <div className="text-text-lo">{items}</div>
+              </div>
             ))}
           </div>
         </SectionCard>


### PR DESCRIPTION
## 概要

main の Vercel デプロイが Lightning CSS minify で落ちており、matlens / matlens-storybook の build が両方失敗しています。**このホットフィックスはそれを修復します。**

## エラー

\`\`\`
[plugin vite:css-post]
SyntaxError: [lightningcss minify] Unexpected token Delim('\$')
.border-\\[var\\(--\\\$\\{c\\}\\)\\] {
   border-color: var(--\${c});
}
\`\`\`

## 原因

Tailwind CSS JIT は className に含まれる文字列を **静的スキャン** する設計のため、React コンポーネント内に以下のような動的テンプレートリテラルがあると、評価後の値ではなく `\${c}` の文字列そのものをクラス名として拾います:

\`\`\`tsx
<div className={\`bg-[var(--\${c}-dim)] border border-[var(--\${c})]\`} />
\`\`\`

Tailwind は \`.border-\\[var\\(--\\\$\\{c\\}\\)\\]\` という無効なクラスを生成し、CSS 本体には \`border-color: var(--\${c});\` という無効な宣言を吐き出します。Vite の esbuild minify は通過しますが、Vercel が使っている Lightning CSS minify はこれを syntax error として拒否します。

## 修正対象

該当 3 箇所を **inline style** に置き換え:

- \`src/pages/UxDesign/UxDesignPage.tsx\` (2 箇所) — フィードバック 4 層の bg/border、Atomic Design セクションの text
- \`src/pages/About/AboutPage.tsx\` (1 箇所) — Atomic Design カテゴリ色

## 検証

- [x] \`pnpm build\` クリーン
- [x] \`pnpm build-storybook\` クリーン
- [x] \`pnpm typecheck\` クリーン

## 緊急度

main のデプロイ復旧のため即時マージ推奨。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * スタイル適用方法の最適化により、ページのレンダリング効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->