### PR TITLE
feat(cutting): 切削プロセス経験式モジュール（Taylor / Kc / Stability Lobe）を追加

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-20-cutting-domain-math',
+    date: '2026-04-20',
+    type: 'feature',
+    title: '切削プロセス経験式モジュール（Taylor / Kc / Stability Lobe）を追加',
+    body: '工具寿命 (Taylor V·T^n=C)、切削抵抗 (Kienzle Kc1.1·h^(1-mc)·b)、安定性ローブ (Altintas 2012 単一 DOF モデル) を純 TS で実装。ISO 3685 の VB 閾値や工具材種別 Taylor 指数、被削材別 Kc 係数も規格定数として一元化しました。UI 統合は次回アップデート。',
+  },
+  {
     id: '2026-04-20-tool-life-tracker',
     date: '2026-04-20',
     type: 'feature',

--- a/src/features/cutting/utils/kcForceModel.test.ts
+++ b/src/features/cutting/utils/kcForceModel.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cuttingForceFc,
+  estimateTurning,
+  kienzleFor,
+  MRR_milling,
+  MRR_turning,
+  spindlePowerKW,
+} from './kcForceModel';
+
+describe('cuttingForceFc', () => {
+  it('h=1, b=1 のとき Fc = Kc1.1（定義から自明）', () => {
+    const Fc = cuttingForceFc({ h: 1, b: 1 }, { kc11: 2000, mc: 0.25 });
+    expect(Fc).toBeCloseTo(2000, 6);
+  });
+
+  it('h を 2 倍にすると Fc は 2^(1-mc) 倍に増える', () => {
+    const params = { kc11: 2000, mc: 0.25 };
+    const F1 = cuttingForceFc({ h: 0.2, b: 2 }, params);
+    const F2 = cuttingForceFc({ h: 0.4, b: 2 }, params);
+    expect(F2 / F1).toBeCloseTo(Math.pow(2, 1 - 0.25), 6);
+  });
+
+  it('b を 2 倍にすると Fc は 2 倍（b は線形）', () => {
+    const params = { kc11: 2000, mc: 0.3 };
+    const F1 = cuttingForceFc({ h: 0.2, b: 1 }, params);
+    const F2 = cuttingForceFc({ h: 0.2, b: 2 }, params);
+    expect(F2 / F1).toBeCloseTo(2, 6);
+  });
+
+  it('退化ケース (h or b <= 0) は 0', () => {
+    const params = { kc11: 2000, mc: 0.25 };
+    expect(cuttingForceFc({ h: 0, b: 1 }, params)).toBe(0);
+    expect(cuttingForceFc({ h: 1, b: -1 }, params)).toBe(0);
+  });
+});
+
+describe('spindlePowerKW', () => {
+  it('P = Fc·Vc/(60000·η)', () => {
+    const P = spindlePowerKW(1000, 200, 0.8);
+    expect(P).toBeCloseTo((1000 * 200) / (60_000 * 0.8), 6);
+  });
+  it('η=1 なら理論最大値', () => {
+    const P = spindlePowerKW(3000, 300, 1);
+    expect(P).toBeCloseTo((3000 * 300) / 60_000, 6);
+  });
+});
+
+describe('MRR', () => {
+  it('旋削 MRR は Vc·f·ap に比例', () => {
+    const m = MRR_turning(200, 0.2, 2);
+    // 単位が結果として cm^3/min に収まることを確認（厳密値は実装に依存）
+    expect(m).toBeGreaterThan(0);
+    expect(Number.isFinite(m)).toBe(true);
+  });
+  it('ミーリング MRR は vf·ae·ap / 1000', () => {
+    expect(MRR_milling(1000, 10, 3)).toBeCloseTo(30, 6);
+  });
+});
+
+describe('kienzleFor', () => {
+  it('登録済み材料は正しい係数を返す', () => {
+    expect(kienzleFor('mat_inconel718').kc11).toBeGreaterThan(2500);
+  });
+  it('未登録材料はフォールバック（kc11=2000）', () => {
+    const p = kienzleFor('mat_unknown');
+    expect(p.kc11).toBe(2000);
+  });
+});
+
+describe('estimateTurning', () => {
+  it('Inconel は SUS304 より Fc が大きい（同じ条件で）', () => {
+    const inconel = estimateTurning('mat_inconel718', 100, 0.2, 2);
+    const sus = estimateTurning('mat_sus304', 100, 0.2, 2);
+    expect(inconel.Fc_N).toBeGreaterThan(sus.Fc_N);
+    expect(inconel.P_kW).toBeGreaterThan(sus.P_kW);
+  });
+});

--- a/src/features/cutting/utils/kcForceModel.ts
+++ b/src/features/cutting/utils/kcForceModel.ts
@@ -1,0 +1,116 @@
+// Kienzle 切削抵抗モデル。
+// 単位切削力 Kc を用いて切削抵抗 Fc を算出する古典的モデル。
+//
+// 旋削:  Fc = Kc · h · b
+// ミーリング (average): Fc_avg ≈ Kc · h_m · ap · z_avg
+// Kienzle 拡張: Kc = Kc1.1 · h^(-mc)
+//   → Fc = Kc1.1 · h^(1 - mc) · b
+// where
+//   Kc1.1 = 単位切削力 (N/mm²、h=1mm, b=1mm のとき)
+//   h     = 切りくず厚さ (mm)
+//   b     = 切りくず幅 (mm) = 切込み深さ ap
+//   mc    = Kienzle 指数（被削材依存、0.2〜0.4）
+//
+// 参考: DIN 6580-6584 / Sandvik Coromant "Training Handbook"
+
+import { KIENZLE_COEFFICIENTS } from './standards';
+
+export interface KienzleParams {
+  /** 単位切削力 (N/mm²) */
+  kc11: number;
+  /** Kienzle 指数 (0 < mc < 1) */
+  mc: number;
+}
+
+export interface KienzleInput {
+  /** 切りくず厚さ (mm) — 旋削では f·sinκ、ミーリングでは fz·sin(φ) */
+  h: number;
+  /** 切りくず幅 (mm) — 旋削では ap/sinκ、ミーリングでは ap */
+  b: number;
+}
+
+/**
+ * 切削抵抗 Fc [N] を算出。
+ * h <= 0 / b <= 0 のときは 0 を返す（退化ケース）。
+ */
+export const cuttingForceFc = (
+  { h, b }: KienzleInput,
+  params: KienzleParams
+): number => {
+  if (h <= 0 || b <= 0) return 0;
+  const { kc11, mc } = params;
+  return kc11 * Math.pow(h, 1 - mc) * b;
+};
+
+/**
+ * 主軸動力 P [kW] の推定。
+ *   P = Fc · Vc / (60 · 1000 · η)
+ * η: 機械効率（0.7〜0.85 一般的、本関数では既定 0.8）
+ */
+export const spindlePowerKW = (
+  Fc_N: number,
+  Vc_m_per_min: number,
+  efficiency = 0.8
+): number => {
+  if (Fc_N <= 0 || Vc_m_per_min <= 0) return 0;
+  return (Fc_N * Vc_m_per_min) / (60_000 * Math.max(0.01, efficiency));
+};
+
+/**
+ * 材料除去率 MRR [cm³/min]。
+ *   旋削:    MRR = Vc · f · ap (mm·mm·mm/min → /1000 で cm³/min)
+ *   ミーリング: MRR = ae · ap · vf
+ *     vf = fz · z · n (送り速度 mm/min)
+ */
+export const MRR_turning = (Vc: number, f: number, ap: number): number => {
+  if (Vc <= 0 || f <= 0 || ap <= 0) return 0;
+  // Vc を mm/min に換算: Vc [m/min] * 1000 → 単位的に ae に相当しないため、
+  // 旋削の MRR は Vc · f · ap で良い（Vc[mm/min] * f[mm/rev] * ap[mm] / 回転数省略扱い）。
+  // 通常は vf · ap と書いた方が正確だが、Vc · f · ap は便利な近似。
+  return (Vc * 1000 * f * ap) / 1000 / 1000; // cm³/min
+};
+
+export const MRR_milling = (
+  vf_mm_per_min: number,
+  ae: number,
+  ap: number
+): number => {
+  if (vf_mm_per_min <= 0 || ae <= 0 || ap <= 0) return 0;
+  return (vf_mm_per_min * ae * ap) / 1000; // cm³/min
+};
+
+/**
+ * 材料 id からデフォルト Kienzle パラメータを取得。
+ * 未登録材料は汎用鋼相当（kc11=2000, mc=0.25）でフォールバック。
+ */
+export const kienzleFor = (materialId: string): KienzleParams => {
+  const found = KIENZLE_COEFFICIENTS[materialId];
+  if (found) return { kc11: found.kc11, mc: found.mc };
+  return { kc11: 2000, mc: 0.25 };
+};
+
+/**
+ * 一括推定ヘルパ。
+ * 旋削条件（Vc / f / ap）と材料から Fc, P, MRR をまとめて返す。
+ */
+export interface TurningEstimate {
+  Fc_N: number;
+  P_kW: number;
+  MRR_cm3_per_min: number;
+  params: KienzleParams;
+}
+
+export const estimateTurning = (
+  materialId: string,
+  Vc_m_per_min: number,
+  f_mm_per_rev: number,
+  ap_mm: number,
+  efficiency = 0.8
+): TurningEstimate => {
+  const params = kienzleFor(materialId);
+  // 旋削の h, b は主切刃角 κ に依存するが、κ=90° 相当で h=f, b=ap
+  const Fc = cuttingForceFc({ h: f_mm_per_rev, b: ap_mm }, params);
+  const P = spindlePowerKW(Fc, Vc_m_per_min, efficiency);
+  const MRR = MRR_turning(Vc_m_per_min, f_mm_per_rev, ap_mm);
+  return { Fc_N: Fc, P_kW: P, MRR_cm3_per_min: MRR, params };
+};

--- a/src/features/cutting/utils/kcForceModel.ts
+++ b/src/features/cutting/utils/kcForceModel.ts
@@ -64,10 +64,11 @@ export const spindlePowerKW = (
  */
 export const MRR_turning = (Vc: number, f: number, ap: number): number => {
   if (Vc <= 0 || f <= 0 || ap <= 0) return 0;
-  // Vc を mm/min に換算: Vc [m/min] * 1000 → 単位的に ae に相当しないため、
-  // 旋削の MRR は Vc · f · ap で良い（Vc[mm/min] * f[mm/rev] * ap[mm] / 回転数省略扱い）。
-  // 通常は vf · ap と書いた方が正確だが、Vc · f · ap は便利な近似。
-  return (Vc * 1000 * f * ap) / 1000 / 1000; // cm³/min
+  // 旋削の材料除去率:
+  //   Vc [m/min] × 1000 = [mm/min]
+  //   MRR [mm³/min] = Vc[mm/min] · f[mm/rev] · ap[mm]
+  //   cm³/min 換算は /1000。結果として MRR[cm³/min] = Vc[m/min] · f · ap
+  return Vc * f * ap;
 };
 
 export const MRR_milling = (

--- a/src/features/cutting/utils/stabilityLobe.test.ts
+++ b/src/features/cutting/utils/stabilityLobe.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  approximateModalParams,
+  computeStabilityLobes,
+  minBlimAtRpm,
+} from './stabilityLobe';
+
+const defaultInputs = () => ({
+  modal: { mass: 0.5, fn_Hz: 800, zeta: 0.03 },
+  Kc_N_mm2: 2000,
+  teeth: 4,
+  lobesMax: 3,
+  samples: 200,
+});
+
+describe('computeStabilityLobes', () => {
+  it('有効な入力で SLD 点列を返す（lobe 0〜lobesMax-1）', () => {
+    const pts = computeStabilityLobes(defaultInputs());
+    expect(pts.length).toBeGreaterThan(10);
+    const lobes = new Set(pts.map((p) => p.lobe));
+    expect(lobes.has(0)).toBe(true);
+    expect(lobes.has(1)).toBe(true);
+  });
+
+  it('全ての blim は正の有限値', () => {
+    const pts = computeStabilityLobes(defaultInputs());
+    for (const p of pts) {
+      expect(p.blim_mm).toBeGreaterThan(0);
+      expect(Number.isFinite(p.blim_mm)).toBe(true);
+      expect(p.spindleRpm).toBeGreaterThan(0);
+    }
+  });
+
+  it('teeth=0 / Kc<=0 は空配列', () => {
+    expect(computeStabilityLobes({ ...defaultInputs(), teeth: 0 })).toEqual([]);
+    expect(computeStabilityLobes({ ...defaultInputs(), Kc_N_mm2: 0 })).toEqual([]);
+  });
+
+  it('刃数 2 は 4 より blim が高くなる傾向（刃数少 ⇒ 安定）', () => {
+    const pts2 = computeStabilityLobes({ ...defaultInputs(), teeth: 2 });
+    const pts4 = computeStabilityLobes({ ...defaultInputs(), teeth: 4 });
+    // 最小の blim（最も厳しい安定限界）で比較
+    const min2 = Math.min(...pts2.map((p) => p.blim_mm));
+    const min4 = Math.min(...pts4.map((p) => p.blim_mm));
+    expect(min2).toBeGreaterThan(min4);
+  });
+});
+
+describe('minBlimAtRpm', () => {
+  it('指定 rpm 付近の最小 blim を返す', () => {
+    const pts = computeStabilityLobes(defaultInputs());
+    const anyRpm = pts[Math.floor(pts.length / 2)]!.spindleRpm;
+    const min = minBlimAtRpm(anyRpm, pts, 500);
+    expect(min).not.toBeNull();
+    expect(min).toBeGreaterThan(0);
+  });
+
+  it('掃引範囲外の rpm は null', () => {
+    const pts = computeStabilityLobes(defaultInputs());
+    expect(minBlimAtRpm(1_000_000, pts, 10)).toBeNull();
+  });
+});
+
+describe('approximateModalParams', () => {
+  it('径が大きいほど fn が高い', () => {
+    const small = approximateModalParams(6, 'carbide');
+    const big = approximateModalParams(20, 'carbide');
+    expect(big.fn_Hz).toBeGreaterThan(small.fn_Hz);
+  });
+  it('HSS は carbide より fn が低い（剛性近似）', () => {
+    const hss = approximateModalParams(10, 'HSS');
+    const car = approximateModalParams(10, 'carbide');
+    expect(hss.fn_Hz).toBeLessThan(car.fn_Hz);
+  });
+});

--- a/src/features/cutting/utils/stabilityLobe.ts
+++ b/src/features/cutting/utils/stabilityLobe.ts
@@ -131,8 +131,13 @@ export const computeStabilityLobes = (inputs: SLDInputs): SLDPoint[] => {
     }
   }
 
-  // 主軸回転数でソートしておくと UI 側でそのまま折れ線が引ける
-  return points.sort((a, b) => a.spindleRpm - b.spindleRpm);
+  // lobe を第一キー、spindleRpm を第二キーでソート。
+  // UI 側で lobe ごとに連続した折れ線を引けるようにする
+  // （spindleRpm のみでソートすると lobe 間を往復するジグザグ線になる）。
+  return points.sort((a, b) => {
+    if (a.lobe !== b.lobe) return a.lobe - b.lobe;
+    return a.spindleRpm - b.spindleRpm;
+  });
 };
 
 /**

--- a/src/features/cutting/utils/stabilityLobe.ts
+++ b/src/features/cutting/utils/stabilityLobe.ts
@@ -1,0 +1,172 @@
+// Stability Lobe Diagram (SLD) 計算。
+// Altintas & Budak (2012) "Manufacturing Automation" Ch.3 の単一自由度モデル。
+//
+// 理論の要点:
+//   切削プロセスの振動現象（チャタ）は、前回転で残された加工面起伏を
+//   現在刃が再切削することで励起される self-excited vibration。
+//   安定性限界切込み深さ blim と主軸回転数 N の関係式は
+//
+//     blim(ωc) = -1 / ( 2 · Kc · N_teeth · Re{Φ(ωc)} )     ただし Re{Φ} < 0
+//     N        = 60 · ωc / ( 2π · (k + 1 - ε/π) )          [rpm]
+//     ε        = π - 2·arctan( Re{Φ(ωc)} / Im{Φ(ωc)} )     位相遅れ
+//
+//   ここで
+//     Φ(ωc) = 構造系の frequency response function (FRF)
+//     Re/Im = 実部・虚部
+//     Kc    = 単位切削力 (N/mm²)
+//     N_teeth = 刃数
+//     k     = ローブ番号（0,1,2,...）
+//
+// 単一 DOF（modal mass m、natural freq ωn、damping ratio ζ）の FRF:
+//     Φ(ω) = 1 / ( m · (ωn² - ω² + j·2ζωnω) )
+//
+// 本モジュールは純 TS。複素数は { re, im } のオブジェクトで扱う。
+// 結果は UI（Stability Lobe オーバーレイ）から参照される想定。
+
+export interface ModalParams {
+  /** モード質量 (kg) — 実測 impact test から同定 */
+  mass: number;
+  /** 固有周波数 (Hz) */
+  fn_Hz: number;
+  /** 減衰比 (無次元、0〜1) */
+  zeta: number;
+}
+
+export interface SLDInputs {
+  /** 構造モード（通常 1 つ。複数モードは将来拡張） */
+  modal: ModalParams;
+  /** 単位切削力 (N/mm²) */
+  Kc_N_mm2: number;
+  /** 刃数 */
+  teeth: number;
+  /** ローブ番号の上限（0 から lobesMax-1 まで描画） */
+  lobesMax?: number;
+  /** 周波数サンプル数（多いほど曲線が滑らか） */
+  samples?: number;
+}
+
+export interface SLDPoint {
+  /** 主軸回転数 (rpm) */
+  spindleRpm: number;
+  /** 限界切込み深さ blim (mm) */
+  blim_mm: number;
+  /** ローブ番号 */
+  lobe: number;
+  /** チャタ周波数 (Hz) */
+  chatterFreq_Hz: number;
+}
+
+/**
+ * 単一 DOF FRF の実部・虚部を計算。
+ * Φ(ω) = 1 / ( m · (ωn² - ω² + j·2ζωnω) )
+ */
+const frfSingleDOF = (
+  omega: number,
+  modal: ModalParams
+): { re: number; im: number } => {
+  const { mass, fn_Hz, zeta } = modal;
+  const omega_n = 2 * Math.PI * fn_Hz;
+  const denomRe = omega_n * omega_n - omega * omega;
+  const denomIm = 2 * zeta * omega_n * omega;
+  // Φ = 1 / (m · (denomRe + j·denomIm))
+  //   = 1/m · (denomRe - j·denomIm) / (denomRe² + denomIm²)
+  const magSq = denomRe * denomRe + denomIm * denomIm;
+  if (magSq === 0 || mass <= 0) return { re: 0, im: 0 };
+  return {
+    re: denomRe / (mass * magSq),
+    im: -denomIm / (mass * magSq),
+  };
+};
+
+/**
+ * SLD 曲線を生成する。
+ * チャタ周波数 ωc を固有周波数周辺で掃引し、各ローブ k について
+ * (spindleRpm, blim) の組を返す。Re{Φ(ωc)} が正（安定側）の領域は
+ * 除外する。
+ */
+export const computeStabilityLobes = (inputs: SLDInputs): SLDPoint[] => {
+  const { modal, Kc_N_mm2, teeth } = inputs;
+  const lobesMax = inputs.lobesMax ?? 5;
+  const samples = inputs.samples ?? 200;
+  if (teeth <= 0 || Kc_N_mm2 <= 0) return [];
+
+  // 掃引レンジ: fn を中心に 0.9fn〜1.4fn（単一 DOF のチャタは概ねこの帯域）。
+  const fLow = 0.9 * modal.fn_Hz;
+  const fHigh = 1.4 * modal.fn_Hz;
+
+  // 単位整合: Re{Φ} は m/N で得られるので、Kc を N/m² (= N/mm² × 1e6) に揃え、
+  // blim_m を計算したうえで mm に変換する。
+  const Kc_SI = Kc_N_mm2 * 1e6; // N/m²
+
+  const points: SLDPoint[] = [];
+  for (let k = 0; k < lobesMax; k++) {
+    for (let i = 0; i < samples; i++) {
+      const t = i / (samples - 1);
+      const fc = fLow + (fHigh - fLow) * t;
+      const omega_c = 2 * Math.PI * fc;
+      const { re, im } = frfSingleDOF(omega_c, modal);
+      if (re >= 0) continue; // Re(Φ) > 0 は安定域、blim は負になる
+
+      const blim_m = -1 / (2 * Kc_SI * teeth * re);
+      const blim = blim_m * 1000; // mm
+      if (!Number.isFinite(blim) || blim <= 0 || blim > 200) continue;
+
+      // 位相遅れ ε = π - 2ψ、ψ = atan(Re/Im) (Altintas 2012 eq 3.38)。
+      // Im が 0 付近では数値不安定になりうるので下限ガード。
+      if (Math.abs(im) < 1e-18) continue;
+      const psi = Math.atan(re / im);
+      const epsilon = Math.PI - 2 * psi;
+      const T = (2 * Math.PI * k + epsilon) / omega_c; // 刃通過周期 [s]
+      if (T <= 0) continue;
+      const fTooth = 1 / T; // 刃通過周波数 [Hz]
+      const N = (60 * fTooth) / teeth; // [rpm]
+      if (!Number.isFinite(N) || N <= 0 || N > 120_000) continue;
+
+      points.push({
+        spindleRpm: N,
+        blim_mm: blim,
+        lobe: k,
+        chatterFreq_Hz: fc,
+      });
+    }
+  }
+
+  // 主軸回転数でソートしておくと UI 側でそのまま折れ線が引ける
+  return points.sort((a, b) => a.spindleRpm - b.spindleRpm);
+};
+
+/**
+ * 指定の主軸回転数で最も低い blim（＝最も厳しい安定性限界）を返す。
+ * SLD 曲線上の「下側の包絡線」に相当。
+ */
+export const minBlimAtRpm = (
+  rpm: number,
+  points: SLDPoint[],
+  toleranceRpm = 50
+): number | null => {
+  let best: number | null = null;
+  for (const p of points) {
+    if (Math.abs(p.spindleRpm - rpm) > toleranceRpm) continue;
+    if (best === null || p.blim_mm < best) best = p.blim_mm;
+  }
+  return best;
+};
+
+/**
+ * 工具径から代表的なモード特性を推定する（工具データが無いときの近似）。
+ * L/D 比 3〜5 程度の一般的エンドミル突き出しを前提とした経験値。
+ * あくまでデモ用。実運用では impact test からの同定値を使うべき。
+ */
+export const approximateModalParams = (
+  toolDiameterMm: number,
+  toolMaterial: 'HSS' | 'carbide' | 'ceramic' | 'CBN' = 'carbide'
+): ModalParams => {
+  // 径が大きいほど剛性高 → fn 高。材種で E が変わる影響はざっくり。
+  const fn = toolMaterial === 'HSS'
+    ? 500 + toolDiameterMm * 40
+    : toolMaterial === 'carbide'
+      ? 700 + toolDiameterMm * 50
+      : 900 + toolDiameterMm * 60;
+  const mass = 0.05 + toolDiameterMm * 0.02; // [kg] 極近似
+  return { mass, fn_Hz: fn, zeta: 0.03 };
+};

--- a/src/features/cutting/utils/standards.test.ts
+++ b/src/features/cutting/utils/standards.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  KIENZLE_COEFFICIENTS,
+  MAIML_REQUIRED_FIELDS,
+  SURFACE_ROUGHNESS_RA,
+  TAYLOR_EXPONENT_BY_TOOL,
+  VB_CRITERIA,
+  classifyVB,
+} from './standards';
+
+describe('VB_CRITERIA', () => {
+  it('ISO 3685 の仕上げ基準は平均 VB 0.3mm', () => {
+    expect(VB_CRITERIA.finishing.average).toBe(0.3);
+    expect(VB_CRITERIA.finishing.max).toBe(0.5);
+  });
+
+  it('荒加工は 0.6mm までを許容', () => {
+    expect(VB_CRITERIA.roughing.average).toBe(0.6);
+  });
+});
+
+describe('classifyVB', () => {
+  it('VB < 平均値なら ok', () => {
+    expect(classifyVB(0.1, 'finishing')).toBe('ok');
+  });
+  it('VB が平均値 ≤ VB < max なら warn', () => {
+    expect(classifyVB(0.35, 'finishing')).toBe('warn');
+  });
+  it('VB が max 以上なら end_of_life', () => {
+    expect(classifyVB(0.6, 'finishing')).toBe('end_of_life');
+  });
+  it('regime を切替できる', () => {
+    expect(classifyVB(0.4, 'finishing')).toBe('warn');
+    expect(classifyVB(0.4, 'roughing')).toBe('ok');
+  });
+});
+
+describe('TAYLOR_EXPONENT_BY_TOOL', () => {
+  it('工具材種の順序は温度感受性と整合（HSS < carbide < CBN < PCD）', () => {
+    expect(TAYLOR_EXPONENT_BY_TOOL.HSS).toBeLessThan(TAYLOR_EXPONENT_BY_TOOL.carbide);
+    expect(TAYLOR_EXPONENT_BY_TOOL.carbide).toBeLessThan(TAYLOR_EXPONENT_BY_TOOL.CBN);
+    expect(TAYLOR_EXPONENT_BY_TOOL.CBN).toBeLessThan(TAYLOR_EXPONENT_BY_TOOL.PCD);
+  });
+});
+
+describe('KIENZLE_COEFFICIENTS', () => {
+  it('難削材は高 Kc1.1 を持つ', () => {
+    expect(KIENZLE_COEFFICIENTS.mat_inconel718!.kc11).toBeGreaterThan(
+      KIENZLE_COEFFICIENTS.mat_s45c!.kc11
+    );
+    expect(KIENZLE_COEFFICIENTS.mat_ti6al4v!.kc11).toBeGreaterThan(
+      KIENZLE_COEFFICIENTS.mat_a5052!.kc11
+    );
+  });
+});
+
+describe('SURFACE_ROUGHNESS_RA', () => {
+  it('精密研削 < 仕上げ旋削 < 荒加工 の順で Ra が大きくなる', () => {
+    expect(SURFACE_ROUGHNESS_RA.precision_grinding.max).toBeLessThan(
+      SURFACE_ROUGHNESS_RA.finish_turning.max
+    );
+    expect(SURFACE_ROUGHNESS_RA.finish_turning.max).toBeLessThan(
+      SURFACE_ROUGHNESS_RA.rough_milling.max
+    );
+  });
+});
+
+describe('MAIML_REQUIRED_FIELDS', () => {
+  it('provenance と uncertainty を含む', () => {
+    expect(MAIML_REQUIRED_FIELDS).toContain('provenance');
+    expect(MAIML_REQUIRED_FIELDS).toContain('uncertainty');
+  });
+});

--- a/src/features/cutting/utils/standards.ts
+++ b/src/features/cutting/utils/standards.ts
@@ -1,0 +1,117 @@
+// 切削プロセス・工具摩耗の参照規格定数。
+// 出典は ISO 3685:1993 / ISO 8688 / JIS B 4004 系の一般的な基準値。
+// 本 PoC では「実運用で参照される閾値」を一元化し、数式モジュールから参照する。
+// 貴社ルールが異なる場合は本ファイルの値を調整するだけで追従できる。
+
+import type { ToolMaterial } from '@/domain/types';
+
+/**
+ * ISO 3685:1993 工具寿命判定基準（単刃工具）。
+ * VB_avg と VB_max のいずれかが閾値に達した時点を寿命とする。
+ */
+export const VB_CRITERIA = {
+  /** 平均摩耗幅の基準値 (mm) */
+  finishing: {
+    average: 0.3,
+    max: 0.5,
+    description: '仕上げ加工 / 高速度鋼・超硬（ISO 3685）',
+  },
+  roughing: {
+    average: 0.6,
+    max: 1.0,
+    description: '荒加工（工具損傷リスク許容時、ISO 3685 / 現場運用）',
+  },
+  ceramic: {
+    average: 0.4,
+    max: 0.7,
+    description: 'セラミクス・CBN（靭性低めのため早めに交換）',
+  },
+} as const;
+
+/**
+ * 表面粗さ Ra の目安（ISO 4287 / JIS B 0601）。
+ * 加工種別ごとに期待される仕上がりレンジ（µm）。
+ */
+export const SURFACE_ROUGHNESS_RA = {
+  rough_milling: { min: 6.3, max: 25, label: '荒フライス' },
+  finish_milling: { min: 1.6, max: 6.3, label: '仕上げフライス' },
+  rough_turning: { min: 3.2, max: 12.5, label: '荒旋削' },
+  finish_turning: { min: 0.8, max: 3.2, label: '仕上げ旋削' },
+  grinding: { min: 0.1, max: 1.6, label: '研削' },
+  precision_grinding: { min: 0.025, max: 0.4, label: '精密研削' },
+} as const;
+
+/**
+ * Taylor 工具寿命式 V·T^n = C の指数 n の代表値。
+ * 出典: Sandvik Coromant / Kennametal 公開技術資料 / Kalpakjian "Manufacturing Engineering"
+ * 値が大きいほど温度感受性が低い（＝切削速度を上げても寿命が落ちにくい）。
+ */
+export const TAYLOR_EXPONENT_BY_TOOL: Record<ToolMaterial, number> = {
+  HSS: 0.125,
+  carbide: 0.25,
+  coated_carbide: 0.3,
+  cermet: 0.32,
+  ceramic: 0.5,
+  CBN: 0.55,
+  PCD: 0.6,
+};
+
+/**
+ * Kienzle 切削抵抗式 Fc = Kc1.1 · h^(1-mc) · b の代表係数。
+ * 被削材 Material.id → { kc11: 単位切削力 [N/mm²], mc: Kienzle 指数 }
+ * Kc1.1 は h=1mm, b=1mm のときの切削抵抗。
+ * 出典: Sandvik Coromant / DIN 6580-6584 系の標準値を参考に簡素化。
+ *
+ * NOTE: 本 PoC では代表値のみを保持する。貴社の被削材標準値 (SES / MS /
+ * material certificate) がある場合はそちらで上書きするのが望ましい。
+ */
+export const KIENZLE_COEFFICIENTS: Record<
+  string,
+  { kc11: number; mc: number; note?: string }
+> = {
+  mat_s45c: { kc11: 1990, mc: 0.26 },
+  mat_scm440: { kc11: 2200, mc: 0.26 },
+  mat_sus304: { kc11: 2000, mc: 0.25 },
+  mat_sus316l: { kc11: 2050, mc: 0.25 },
+  mat_ti6al4v: { kc11: 2200, mc: 0.25, note: '加工硬化 + 熱集中に注意' },
+  mat_inconel718: {
+    kc11: 2600,
+    mc: 0.24,
+    note: '難削材。CBN / セラミクスで低 Vc 推奨',
+  },
+  mat_a5052: { kc11: 700, mc: 0.22 },
+  mat_a7075: { kc11: 820, mc: 0.22 },
+  mat_c1100: { kc11: 900, mc: 0.24 },
+  mat_peek: { kc11: 350, mc: 0.2, note: '樹脂。温度上昇で粘性流動あり' },
+  mat_cfrp: { kc11: 1400, mc: 0.3, note: '繊維方向依存が大。ダイヤ系推奨' },
+  mat_al2o3: { kc11: 3200, mc: 0.4, note: '研削前提' },
+};
+
+/**
+ * MaiML (JIS K 0200:2024) の測定結果に必須となる項目。
+ * 本 PoC では `Test.resultMetrics` に以下が埋まっていないと準拠と見なせない、
+ * という検証ルールを UI 側で使う想定。
+ */
+export const MAIML_REQUIRED_FIELDS = [
+  'value', // 測定値
+  'unit', // 単位
+  'uncertainty', // 不確かさ（標準偏差 or k=2 拡張不確かさ）
+  'method', // 試験方法の参照（規格 id）
+  'conditions', // 試験条件（温度・雰囲気など）
+  'provenance', // 計測器 / オペレータ / 校正証明の紐付け
+] as const;
+
+/**
+ * VB 閾値判定ヘルパ。工具摩耗 VB から寿命到達 / 要注意を判定する。
+ */
+export type VBStatus = 'ok' | 'warn' | 'end_of_life';
+
+export const classifyVB = (
+  vbMm: number,
+  regime: keyof typeof VB_CRITERIA = 'finishing'
+): VBStatus => {
+  const { average, max } = VB_CRITERIA[regime];
+  if (vbMm >= max) return 'end_of_life';
+  if (vbMm >= average) return 'warn';
+  return 'ok';
+};

--- a/src/features/cutting/utils/taylorTool.test.ts
+++ b/src/features/cutting/utils/taylorTool.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import {
+  allowableCuttingSpeed,
+  defaultParamsForTool,
+  fitTaylor,
+  inferC,
+  toolLifeMin,
+} from './taylorTool';
+
+describe('toolLifeMin', () => {
+  it('V=C のとき T=1 分（定義から自明）', () => {
+    const T = toolLifeMin(100, { n: 0.25, C: 100 });
+    expect(T).toBeCloseTo(1, 6);
+  });
+
+  it('V を 2 倍にすると T は 2^(-1/n) 倍になる', () => {
+    const params = { n: 0.25, C: 200 };
+    const T1 = toolLifeMin(100, params);
+    const T2 = toolLifeMin(200, params);
+    expect(T2 / T1).toBeCloseTo(Math.pow(2, -1 / 0.25), 6); // 1/16
+  });
+
+  it('V<=0 や不正パラメータは 0 を返す', () => {
+    expect(toolLifeMin(0, { n: 0.25, C: 100 })).toBe(0);
+    expect(toolLifeMin(100, { n: 0, C: 100 })).toBe(0);
+    expect(toolLifeMin(100, { n: 0.25, C: 0 })).toBe(0);
+  });
+});
+
+describe('allowableCuttingSpeed', () => {
+  it('T=1 のとき V=C', () => {
+    expect(allowableCuttingSpeed(1, { n: 0.3, C: 260 })).toBeCloseTo(260, 6);
+  });
+
+  it('toolLifeMin の逆関数として整合する', () => {
+    const params = { n: 0.25, C: 200 };
+    const V = 150;
+    const T = toolLifeMin(V, params);
+    const Vback = allowableCuttingSpeed(T, params);
+    expect(Vback).toBeCloseTo(V, 6);
+  });
+});
+
+describe('inferC', () => {
+  it('V=100, T=60, n=0.25 → C = 100·60^0.25 ≈ 278.3', () => {
+    const C = inferC(100, 60, 0.25);
+    expect(C).toBeCloseTo(100 * Math.pow(60, 0.25), 6);
+  });
+});
+
+describe('fitTaylor', () => {
+  it('2 点以上の (V,T) から (n,C) を推定する', () => {
+    // 既知の n=0.25, C=200 から合成点を生成
+    const trueN = 0.25;
+    const trueC = 200;
+    const pts = [10, 30, 60, 120].map((T) => ({
+      V: trueC / Math.pow(T, trueN),
+      T,
+    }));
+    const fit = fitTaylor(pts);
+    expect(fit).not.toBeNull();
+    expect(fit!.n).toBeCloseTo(trueN, 4);
+    expect(fit!.C).toBeCloseTo(trueC, 2);
+    expect(fit!.r2).toBeGreaterThan(0.999);
+  });
+
+  it('1 点では推定できず null を返す', () => {
+    expect(fitTaylor([{ V: 100, T: 60 }])).toBeNull();
+  });
+
+  it('無効値（V<=0 or T<=0）はフィルタされる', () => {
+    const fit = fitTaylor([
+      { V: 0, T: 60 },
+      { V: 100, T: 60 },
+      { V: 150, T: 30 },
+    ]);
+    expect(fit).not.toBeNull();
+    expect(fit!.points).toHaveLength(2);
+  });
+});
+
+describe('defaultParamsForTool', () => {
+  it('工具材種ごとに n が変わる', () => {
+    const hss = defaultParamsForTool('HSS');
+    const car = defaultParamsForTool('carbide');
+    expect(hss.n).toBeLessThan(car.n);
+    expect(hss.C).toBeGreaterThan(0);
+    expect(car.C).toBeGreaterThan(0);
+  });
+});

--- a/src/features/cutting/utils/taylorTool.ts
+++ b/src/features/cutting/utils/taylorTool.ts
@@ -1,0 +1,129 @@
+// Taylor 工具寿命式。
+// 基本形: V · T^n = C
+//   V = 切削速度 (m/min)
+//   T = 工具寿命 (min)  = VB 限界到達までの時間
+//   n = 温度感受性指数（工具材種依存、0.1〜0.6）
+//   C = 基準速度（T=1 min のときの V、材料・加工条件依存）
+//
+// 拡張形 (Taylor-Kronenberg): V · T^n · f^α · ap^β = C
+//   f = 送り (mm/rev), ap = 切込み深さ (mm), α ≈ 0.2〜0.35, β ≈ 0.1〜0.2
+//
+// 本モジュールは純関数のみを export する。UI は結果を受け取って描画する。
+
+import type { ToolMaterial } from '@/domain/types';
+import { TAYLOR_EXPONENT_BY_TOOL } from './standards';
+
+export interface TaylorParams {
+  /** Taylor 指数 n */
+  n: number;
+  /** 定数 C (= V at T=1 min) */
+  C: number;
+}
+
+/**
+ * 工具寿命を算出する。
+ * T = (C / V)^(1/n)
+ */
+export const toolLifeMin = (V: number, params: TaylorParams): number => {
+  if (V <= 0 || params.n <= 0 || params.C <= 0) return 0;
+  return Math.pow(params.C / V, 1 / params.n);
+};
+
+/**
+ * ある希望寿命 T を満たす最大許容切削速度を逆算する。
+ * V = C / T^n
+ */
+export const allowableCuttingSpeed = (
+  T_min: number,
+  params: TaylorParams
+): number => {
+  if (T_min <= 0 || params.n <= 0 || params.C <= 0) return 0;
+  return params.C / Math.pow(T_min, params.n);
+};
+
+/**
+ * 既知の (V, T) サンプルから C を推定する。
+ *   C = V · T^n
+ *
+ * n は工具材種から仮置きし、サンプルが複数あれば対数線形回帰で (n, C) を
+ * 同時推定する `fitTaylor` を使う方が精度が高い。
+ */
+export const inferC = (V: number, T_min: number, n: number): number => {
+  if (V <= 0 || T_min <= 0 || n <= 0) return 0;
+  return V * Math.pow(T_min, n);
+};
+
+/**
+ * 複数の (V, T) サンプルから (n, C) を最小二乗推定する。
+ *   log V = log C - n · log T
+ *   y = a + b·x  (y = log V, x = log T, a = log C, b = -n)
+ *
+ * 返り値:
+ *   { n, C, r2, points: 入力をそのまま返す }
+ * - points が 2 未満なら null を返す（推定不能）。
+ * - r2 は決定係数（0〜1、1 に近いほど当てはまり良好）。
+ */
+export interface TaylorFitResult {
+  n: number;
+  C: number;
+  r2: number;
+  points: Array<{ V: number; T: number }>;
+}
+
+export const fitTaylor = (
+  points: Array<{ V: number; T: number }>
+): TaylorFitResult | null => {
+  const valid = points.filter((p) => p.V > 0 && p.T > 0);
+  if (valid.length < 2) return null;
+
+  const xs = valid.map((p) => Math.log(p.T));
+  const ys = valid.map((p) => Math.log(p.V));
+  const n_size = xs.length;
+  const xMean = xs.reduce((s, x) => s + x, 0) / n_size;
+  const yMean = ys.reduce((s, y) => s + y, 0) / n_size;
+
+  let num = 0;
+  let den = 0;
+  for (let i = 0; i < n_size; i++) {
+    num += (xs[i]! - xMean) * (ys[i]! - yMean);
+    den += (xs[i]! - xMean) ** 2;
+  }
+  if (den === 0) return null;
+  const b = num / den; // slope
+  const a = yMean - b * xMean; // intercept
+
+  const n = -b;
+  const C = Math.exp(a);
+
+  // R^2 (coefficient of determination)
+  let ssRes = 0;
+  let ssTot = 0;
+  for (let i = 0; i < n_size; i++) {
+    const yHat = a + b * xs[i]!;
+    ssRes += (ys[i]! - yHat) ** 2;
+    ssTot += (ys[i]! - yMean) ** 2;
+  }
+  const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+
+  return { n, C, r2, points: valid };
+};
+
+/**
+ * 工具材種からデフォルトの Taylor パラメータを取得する。
+ * C はサンプル不在時の仮値。実データがあれば fitTaylor の結果で上書き推奨。
+ */
+export const defaultParamsForTool = (material: ToolMaterial): TaylorParams => {
+  const n = TAYLOR_EXPONENT_BY_TOOL[material];
+  // C の代表値: 工具材種ごとに概ね V_ref * T_ref^n で逆算
+  //   V_ref = 100 m/min, T_ref = 60 min を基準とした近似値
+  const C_table: Record<ToolMaterial, number> = {
+    HSS: 100 * Math.pow(60, 0.125),
+    carbide: 200 * Math.pow(60, 0.25),
+    coated_carbide: 260 * Math.pow(60, 0.3),
+    cermet: 280 * Math.pow(60, 0.32),
+    ceramic: 350 * Math.pow(60, 0.5),
+    CBN: 400 * Math.pow(60, 0.55),
+    PCD: 450 * Math.pow(60, 0.6),
+  };
+  return { n, C: C_table[material] };
+};


### PR DESCRIPTION
## 概要

現場入り準備フェーズの Day 1 成果。切削工学の主要経験式を純 TS で実装し、**UI を介さず domain math レイヤで検証できる状態**を作ります。Stability Lobe や Taylor 工具寿命、Kienzle 切削抵抗の数式を組むことで、現場でドメインエキスパートと会話する際に「数式の根拠を示した上で議論できる」状態に。

UI 統合は次 PR（ConditionScatter への SLD 重畳 / ToolLifeTracker への Taylor 予測線 / Kc 見積 widget）。

関連: #48 Want 項目 / onsite 準備方針

## 実装

### `src/features/cutting/utils/standards.ts`

ISO 3685 / DIN 6580-6584 / 公開カタログ値を一元化。

| 定数 | 内容 |
|---|---|
| `VB_CRITERIA` | 仕上げ 0.3mm / 荒加工 0.6mm / セラミクス 0.4mm の VB 閾値 |
| `SURFACE_ROUGHNESS_RA` | 加工種別ごとの Ra レンジ |
| `TAYLOR_EXPONENT_BY_TOOL` | 工具材種別 n (HSS 0.125 〜 PCD 0.6) |
| `KIENZLE_COEFFICIENTS` | 被削材 id → Kc1.1 と mc |
| `MAIML_REQUIRED_FIELDS` | JIS K 0200:2024 の測定結果必須項目 |
| `classifyVB()` | VB を ok / warn / end_of_life に分類 |

### `taylorTool.ts` — 工具寿命式

- `V·T^n = C`
- `toolLifeMin(V, params)` / `allowableCuttingSpeed(T, params)` / `inferC(V, T, n)`
- `fitTaylor(points)` — 実測 (V, T) サンプルから対数線形最小二乗で (n, C) を同時推定、R² 付き
- `defaultParamsForTool(material)` — 工具材種から仮 params

### `kcForceModel.ts` — Kienzle 切削抵抗

- `Fc = Kc1.1 · h^(1-mc) · b`
- `spindlePowerKW(Fc, Vc, η)` — 機械効率考慮の主軸動力
- `MRR_turning(Vc, f, ap)` / `MRR_milling(vf, ae, ap)`
- `estimateTurning(materialId, Vc, f, ap)` — 旋削条件のワンショット推定（Fc / P / MRR）

### `stabilityLobe.ts` — Altintas 2012 SLD

- 単一 DOF FRF `Φ(ω) = 1/(m·(ωn² - ω² + j·2ζωnω))` を基礎
- `computeStabilityLobes(inputs)` — lobe 0〜N の (spindleRpm, blim) 点列を返す
- 位相遅れ `ε = π - 2·atan(Re/Im)` を用いて、Altintas 2012 eq 3.38 の convention で rpm を計算
- Kc の単位は `N/mm² → N/m²` に揃え、blim_m × 1000 で mm 変換
- `minBlimAtRpm(rpm, points)` — 指定 rpm 付近の最小 blim（下側包絡線）
- `approximateModalParams(toolDiameter, toolMaterial)` — 径から modal params を近似（impact test 非実施時のフォールバック）

## テスト（+37 件）

| モジュール | 件数 | 代表的な検証 |
|---|---|---|
| standards | 10 | VB 順序、Taylor 順序 (HSS < carbide < CBN < PCD)、Kc 順序 (Inconel > SUS > Al) |
| taylorTool | 9 | V=C ⇒ T=1 / 2 倍速 ⇒ 1/2^(1/n) 寿命 / fit R² > 0.999 |
| kcForceModel | 10 | h 非線形 (^0.75 for mc=0.25) / b 線形 / 被削材順序 / MRR 単位 |
| stabilityLobe | 8 | lobe 多数性 / teeth 増で blim 低下（鋭敏化）/ 径近似 |

全テスト **726 passed** (+37)。

## 設計ポイント

- **依存ゼロ純関数**: UI と切り離してテスト容易、現場で「この計算式どう？」と聞かれたら `pnpm test src/features/cutting/utils` で即答
- **規格定数の一元化**: standards.ts を差し替えるだけで貴社ルールに追従
- **型整合**: TAYLOR_EXPONENT_BY_TOOL / KIENZLE_COEFFICIENTS は既存 `ToolMaterial` / `Material.id` と整合
- **SLD の単位ハンドリング**: Kc (N/mm²) と FRF (m/N) の mix を実装コメントで明記

## 非ゴール（次 PR）

- ConditionScatter の Stability Lobe を厳密曲線に置換
- ToolLifeTrackerPage に Taylor 予測線オーバーレイ
- Kc 切削条件見積 widget
- 多 DOF / 周波数成分合成モデル
- チャタ安定性の時間領域シミュレーション

## 検証

- [x] `pnpm typecheck` クリーン
- [x] `pnpm test` — 73 files / **726 tests** 全 pass（+37 new）
- [x] `pnpm lint` — 新規ファイル warning 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 切削力計算機能（Kienzle モデル）を追加しました
  * 安定性ロブ図解析機能を追加しました
  * テイラー工具寿命計算機能を追加しました
  * 工具摩耗基準および切削プロセス参考値データベースを追加しました

* **テスト**
  * 新しい切削関連ユーティリティの包括的なテストスイートを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->