### PR TITLE
feat(cutting): 切削経験式パネル（SLD / Kc / Taylor）を UI に統合

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-20-cutting-sim-ui',
+    date: '2026-04-20',
+    type: 'feature',
+    title: '切削経験式パネル（Kienzle / Stability Lobe / Taylor）を UI に統合',
+    body: '切削条件エクスプローラで点を選ぶと、Kienzle モデルの Fc/P/MRR 見積（実測値との乖離率表示）と Altintas 2012 Stability Lobe 厳密曲線が右ペインに表示されるようになりました。工具ライフトラッカーには Taylor 工具寿命の回帰予測（R² 付）を追加し、実測点から n, C を推定して現行 Vc での予測寿命距離を算出します。',
+  },
+  {
     id: '2026-04-20-cutting-domain-math',
     date: '2026-04-20',
     type: 'feature',

--- a/src/features/cutting/CuttingConditionsExplorerPage.tsx
+++ b/src/features/cutting/CuttingConditionsExplorerPage.tsx
@@ -11,6 +11,8 @@ import type {
 } from '@/domain/types';
 import type { CuttingProcessQuery } from '@/infra/repositories/interfaces';
 import { ConditionScatter } from './components/ConditionScatter';
+import { KcEstimatePanel } from './components/KcEstimatePanel';
+import { StabilityLobePanel } from './components/StabilityLobePanel';
 import { WaveformViewer } from './components/WaveformViewer';
 import {
   useCuttingMaterials,
@@ -403,6 +405,20 @@ export const CuttingConditionsExplorerPage = () => {
                     この条件ではびびり振動が検出されました。
                   </div>
                 )}
+              </div>
+
+              <div className="border-t border-[var(--border-faint)] pt-3">
+                <div className="text-[11px] text-[var(--text-lo)] mb-2">
+                  Kienzle 切削抵抗モデル見積
+                </div>
+                <KcEstimatePanel process={selected} tool={selectedTool} />
+              </div>
+
+              <div className="border-t border-[var(--border-faint)] pt-3">
+                <div className="text-[11px] text-[var(--text-lo)] mb-2">
+                  Stability Lobe (Altintas 2012 近似)
+                </div>
+                <StabilityLobePanel process={selected} tool={selectedTool} />
               </div>
 
               {waveforms && waveforms.length > 0 && (

--- a/src/features/cutting/components/KcEstimatePanel.tsx
+++ b/src/features/cutting/components/KcEstimatePanel.tsx
@@ -1,0 +1,104 @@
+// Kc 切削抵抗見積パネル。
+// 選択プロセスの条件から Kienzle モデルで Fc / P / MRR を推定し、
+// 実測値 (process.cuttingForceFc) と並べて表示する。
+// 現場での「なぜこの値？」議論の起点になる見積ウィジェット。
+
+import { useMemo } from 'react';
+import type { CuttingProcess, Tool } from '@/domain/types';
+import { estimateTurning, spindlePowerKW, cuttingForceFc, kienzleFor, MRR_milling } from '../utils/kcForceModel';
+
+export interface KcEstimatePanelProps {
+  process: CuttingProcess;
+  tool: Tool | null | undefined;
+}
+
+export const KcEstimatePanel = ({ process, tool }: KcEstimatePanelProps) => {
+  const estimate = useMemo(() => {
+    const { cuttingSpeed, feed, depthOfCut, widthOfCut, spindleSpeed } =
+      process.condition;
+    const kienzle = kienzleFor(process.materialId);
+
+    // 旋削は estimateTurning、ミーリング系は fz × teeth で近似
+    if (process.operation === 'turning') {
+      const r = estimateTurning(
+        process.materialId,
+        cuttingSpeed,
+        feed,
+        depthOfCut
+      );
+      return {
+        Fc_N: r.Fc_N,
+        P_kW: r.P_kW,
+        MRR: r.MRR_cm3_per_min,
+        kc11: r.params.kc11,
+        mc: r.params.mc,
+      };
+    }
+    // ミーリング: fz × teeth × rpm = vf
+    const teeth = tool?.fluteCount ?? 2;
+    const vf_mm_min = feed * teeth * spindleSpeed;
+    // 平均切りくず厚は fz × sin(engagement), ここでは fz を代表値として使用（PoC 近似）
+    const Fc = cuttingForceFc({ h: feed, b: depthOfCut }, kienzle);
+    const P = spindlePowerKW(Fc, cuttingSpeed);
+    const ae = widthOfCut ?? depthOfCut;
+    const MRR = MRR_milling(vf_mm_min, ae, depthOfCut);
+    return {
+      Fc_N: Fc,
+      P_kW: P,
+      MRR: MRR,
+      kc11: kienzle.kc11,
+      mc: kienzle.mc,
+    };
+  }, [process, tool]);
+
+  const actualFc = process.cuttingForceFc;
+  const delta =
+    actualFc !== null && estimate.Fc_N > 0
+      ? ((actualFc - estimate.Fc_N) / estimate.Fc_N) * 100
+      : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between text-[11px] text-[var(--text-lo)]">
+        <span>Kienzle 見積</span>
+        <span className="font-mono">
+          Kc1.1={estimate.kc11} / mc={estimate.mc}
+        </span>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[12px]">
+        <dt className="text-[var(--text-lo)]">予測 Fc</dt>
+        <dd className="font-mono text-right">{estimate.Fc_N.toFixed(0)} N</dd>
+        {actualFc !== null && (
+          <>
+            <dt className="text-[var(--text-lo)]">実測 Fc</dt>
+            <dd
+              className="font-mono text-right"
+              style={{
+                color:
+                  delta !== null && Math.abs(delta) > 30
+                    ? 'var(--err, #dc2626)'
+                    : delta !== null && Math.abs(delta) > 15
+                      ? 'var(--warn, #f59e0b)'
+                      : 'var(--ok, #22c55e)',
+              }}
+            >
+              {actualFc.toFixed(0)} N
+              {delta !== null && ` (${delta >= 0 ? '+' : ''}${delta.toFixed(0)}%)`}
+            </dd>
+          </>
+        )}
+        <dt className="text-[var(--text-lo)]">主軸動力 P</dt>
+        <dd className="font-mono text-right">{estimate.P_kW.toFixed(2)} kW</dd>
+        <dt className="text-[var(--text-lo)]">MRR</dt>
+        <dd className="font-mono text-right">
+          {estimate.MRR.toFixed(1)} cm³/min
+        </dd>
+      </dl>
+      {delta !== null && Math.abs(delta) > 30 && (
+        <div className="text-[10px] text-[var(--err,#dc2626)]">
+          モデルと実測の乖離 &gt; 30%。工具摩耗・実効 h / b・加工硬化 の影響を確認。
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/cutting/components/KcEstimatePanel.tsx
+++ b/src/features/cutting/components/KcEstimatePanel.tsx
@@ -37,10 +37,16 @@ export const KcEstimatePanel = ({ process, tool }: KcEstimatePanelProps) => {
     // ミーリング: fz × teeth × rpm = vf
     const teeth = tool?.fluteCount ?? 2;
     const vf_mm_min = feed * teeth * spindleSpeed;
-    // 平均切りくず厚は fz × sin(engagement), ここでは fz を代表値として使用（PoC 近似）
-    const Fc = cuttingForceFc({ h: feed, b: depthOfCut }, kienzle);
-    const P = spindlePowerKW(Fc, cuttingSpeed);
     const ae = widthOfCut ?? depthOfCut;
+    const D = tool?.diameter ?? 10;
+    // 平均切りくず厚（ミーリング、側面削り近似）:
+    //   h_m ≈ fz · √(ae/D)   (engagement < 180°, Sandvik/Altintas 公式)
+    //   全没入のときは h_m ≈ fz (ae/D=1 相当)。
+    // これを使わず fz をそのまま h にすると、側面削りで Fc を過大評価する。
+    const engagement = Math.min(1, Math.max(0.05, ae / D));
+    const h_mean = feed * Math.sqrt(engagement);
+    const Fc = cuttingForceFc({ h: h_mean, b: depthOfCut }, kienzle);
+    const P = spindlePowerKW(Fc, cuttingSpeed);
     const MRR = MRR_milling(vf_mm_min, ae, depthOfCut);
     return {
       Fc_N: Fc,

--- a/src/features/cutting/components/StabilityLobePanel.tsx
+++ b/src/features/cutting/components/StabilityLobePanel.tsx
@@ -1,0 +1,257 @@
+// Stability Lobe Diagram (SLD) パネル。
+// 選択プロセスの工具 / 被削材から動特性を近似し、主軸回転数 × 限界切込み深さの
+// 本格的な SLD を描画する。ConditionScatter の「概念曲線」とは別軸で、
+// 厳密モデル（Altintas 2012）を可視化するための専用ビューア。
+
+import { useMemo } from 'react';
+import type { CuttingProcess, Tool } from '@/domain/types';
+import {
+  approximateModalParams,
+  computeStabilityLobes,
+  type SLDPoint,
+} from '../utils/stabilityLobe';
+import { kienzleFor } from '../utils/kcForceModel';
+
+export interface StabilityLobePanelProps {
+  process: CuttingProcess;
+  tool: Tool | null | undefined;
+}
+
+const PAD = { top: 16, right: 16, bottom: 36, left: 52 };
+
+export const StabilityLobePanel = ({
+  process,
+  tool,
+}: StabilityLobePanelProps) => {
+  const inputs = useMemo(() => {
+    // 工具がない場合は汎用超硬 φ10 で暫定近似
+    const diameter = tool?.diameter ?? 10;
+    const material: 'HSS' | 'carbide' | 'ceramic' | 'CBN' =
+      tool?.material === 'HSS'
+        ? 'HSS'
+        : tool?.material === 'ceramic'
+          ? 'ceramic'
+          : tool?.material === 'CBN'
+            ? 'CBN'
+            : 'carbide';
+    const modal = approximateModalParams(diameter, material);
+    const kienzle = kienzleFor(process.materialId);
+    const teeth = tool?.fluteCount ?? 2;
+    return {
+      modal,
+      Kc_N_mm2: kienzle.kc11,
+      teeth,
+      lobesMax: 4,
+      samples: 180,
+    };
+  }, [process, tool]);
+
+  const points: SLDPoint[] = useMemo(
+    () => computeStabilityLobes(inputs),
+    [inputs]
+  );
+
+  // 現在点（このプロセスの rpm / ap）
+  const currentRpm = process.condition.spindleSpeed;
+  const currentAp = process.condition.depthOfCut;
+
+  const width = 560;
+  const height = 240;
+  const plotX0 = PAD.left;
+  const plotX1 = width - PAD.right;
+  const plotY0 = PAD.top;
+  const plotY1 = height - PAD.bottom;
+
+  if (points.length === 0) {
+    return (
+      <div className="text-[11px] text-[var(--text-lo)] p-3">
+        工具 / 被削材の動特性が不足しているため SLD を描画できません。
+      </div>
+    );
+  }
+
+  const rpmMax = Math.max(
+    ...points.map((p) => p.spindleRpm),
+    currentRpm
+  );
+  const blimValues = points.map((p) => p.blim_mm);
+  // 表示レンジ: 99 パーセンタイル程度までを収める（外れ値で軸がつぶれないよう）
+  const sortedBlim = [...blimValues].sort((a, b) => a - b);
+  const blimClip = sortedBlim[Math.floor(sortedBlim.length * 0.95)] ?? 10;
+  const blimMax = Math.max(blimClip, currentAp * 1.2);
+
+  const xScale = (v: number) => plotX0 + (v / rpmMax) * (plotX1 - plotX0);
+  const yScale = (v: number) => plotY1 - (v / blimMax) * (plotY1 - plotY0);
+
+  // lobe ごとに折れ線を引く（computeStabilityLobes が (lobe, rpm) でソート済）
+  const lobeGroups = new Map<number, SLDPoint[]>();
+  for (const p of points) {
+    if (p.blim_mm > blimMax) continue; // 表示レンジ外
+    const bucket = lobeGroups.get(p.lobe) ?? [];
+    bucket.push(p);
+    lobeGroups.set(p.lobe, bucket);
+  }
+
+  const xTicks = Array.from({ length: 6 }, (_, i) => (rpmMax / 5) * i);
+  const yTicks = Array.from({ length: 5 }, (_, i) => (blimMax / 4) * i);
+
+  const overLimit = currentAp > (points.find((p) => Math.abs(p.spindleRpm - currentRpm) < 500)?.blim_mm ?? blimMax);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-[11px]">
+        <span className="text-[var(--text-lo)]">
+          fn ≈ {inputs.modal.fn_Hz.toFixed(0)} Hz / ζ={inputs.modal.zeta} / Kc=
+          {inputs.Kc_N_mm2} / 刃数={inputs.teeth}
+        </span>
+        <span className="font-mono text-[var(--text-lo)]">
+          Altintas 2012 単一 DOF
+        </span>
+      </div>
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        role="img"
+        aria-label="Stability Lobe Diagram"
+        style={{ maxHeight: 280 }}
+      >
+        <rect
+          x={plotX0}
+          y={plotY0}
+          width={plotX1 - plotX0}
+          height={plotY1 - plotY0}
+          fill="var(--bg-base, transparent)"
+          stroke="var(--border-faint, #334155)"
+        />
+
+        {/* Y 軸目盛り */}
+        {yTicks.map((t, i) => {
+          const y = yScale(t);
+          return (
+            <g key={`gy-${i}`}>
+              <line
+                x1={plotX0}
+                y1={y}
+                x2={plotX1}
+                y2={y}
+                stroke="var(--border-faint, #1e293b)"
+                strokeDasharray="2 3"
+                opacity={0.3}
+              />
+              <text
+                x={plotX0 - 6}
+                y={y + 4}
+                textAnchor="end"
+                fontSize={10}
+                fill="var(--text-lo, #94a3b8)"
+              >
+                {t.toFixed(1)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* X 軸目盛り */}
+        {xTicks.map((t, i) => {
+          const x = xScale(t);
+          const label = t >= 1000 ? `${(t / 1000).toFixed(1)}k` : t.toFixed(0);
+          return (
+            <g key={`gx-${i}`}>
+              <line
+                x1={x}
+                y1={plotY0}
+                x2={x}
+                y2={plotY1}
+                stroke="var(--border-faint, #1e293b)"
+                strokeDasharray="2 3"
+                opacity={0.3}
+              />
+              <text
+                x={x}
+                y={plotY1 + 14}
+                textAnchor="middle"
+                fontSize={10}
+                fill="var(--text-lo, #94a3b8)"
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* 軸ラベル */}
+        <text
+          x={(plotX0 + plotX1) / 2}
+          y={height - 4}
+          textAnchor="middle"
+          fontSize={11}
+          fill="var(--text-md, #cbd5e1)"
+        >
+          主軸回転数 (rpm)
+        </text>
+        <text
+          x={12}
+          y={(plotY0 + plotY1) / 2}
+          textAnchor="middle"
+          fontSize={11}
+          fill="var(--text-md, #cbd5e1)"
+          transform={`rotate(-90 12 ${(plotY0 + plotY1) / 2})`}
+        >
+          blim (mm)
+        </text>
+
+        {/* lobe ごとの折れ線 */}
+        {Array.from(lobeGroups.entries()).map(([lobe, pts]) => {
+          const d = pts
+            .map(
+              (p, i) =>
+                `${i === 0 ? 'M' : 'L'} ${xScale(p.spindleRpm).toFixed(1)} ${yScale(p.blim_mm).toFixed(1)}`
+            )
+            .join(' ');
+          return (
+            <path
+              key={lobe}
+              d={d}
+              stroke="var(--accent, #2563eb)"
+              strokeWidth={1.2}
+              fill="none"
+              opacity={0.7}
+            />
+          );
+        })}
+
+        {/* 現在点 */}
+        {currentRpm > 0 && currentRpm <= rpmMax && currentAp <= blimMax && (
+          <g>
+            <line
+              x1={xScale(currentRpm)}
+              y1={plotY0}
+              x2={xScale(currentRpm)}
+              y2={plotY1}
+              stroke={overLimit ? 'var(--err, #dc2626)' : 'var(--ok, #22c55e)'}
+              strokeDasharray="4 2"
+              opacity={0.5}
+            />
+            <circle
+              cx={xScale(currentRpm)}
+              cy={yScale(Math.min(currentAp, blimMax))}
+              r={5}
+              fill={overLimit ? 'var(--err, #dc2626)' : 'var(--ok, #22c55e)'}
+              stroke="white"
+              strokeWidth={1}
+            >
+              <title>{`現在条件: ${currentRpm} rpm / ap=${currentAp.toFixed(2)} mm`}</title>
+            </circle>
+          </g>
+        )}
+      </svg>
+      <div className="text-[10px] text-[var(--text-lo)] leading-relaxed">
+        曲線の下側＝安定、上側＝チャタ領域。現在条件の縦線と ap 点が
+        {overLimit
+          ? ' 曲線の上にあるため びびり発生の可能性が高い'
+          : ' 曲線の下にあり 安定切削が期待できる'}
+        。モード特性 (fn, ζ) は径と工具材種からの近似であり、実際は impact test で同定する。
+      </div>
+    </div>
+  );
+};

--- a/src/features/cutting/components/StabilityLobePanel.tsx
+++ b/src/features/cutting/components/StabilityLobePanel.tsx
@@ -8,6 +8,7 @@ import type { CuttingProcess, Tool } from '@/domain/types';
 import {
   approximateModalParams,
   computeStabilityLobes,
+  minBlimAtRpm,
   type SLDPoint,
 } from '../utils/stabilityLobe';
 import { kienzleFor } from '../utils/kcForceModel';
@@ -95,7 +96,9 @@ export const StabilityLobePanel = ({
   const xTicks = Array.from({ length: 6 }, (_, i) => (rpmMax / 5) * i);
   const yTicks = Array.from({ length: 5 }, (_, i) => (blimMax / 4) * i);
 
-  const overLimit = currentAp > (points.find((p) => Math.abs(p.spindleRpm - currentRpm) < 500)?.blim_mm ?? blimMax);
+  // 下側包絡線ヘルパを使って、現在 rpm における最小 blim（最も厳しい安定限界）を取得
+  const limitAtCurrent = minBlimAtRpm(currentRpm, points, 100);
+  const overLimit = limitAtCurrent !== null && currentAp > limitAtCurrent;
 
   return (
     <div className="flex flex-col gap-1">

--- a/src/features/tools/ToolLifeTrackerPage.tsx
+++ b/src/features/tools/ToolLifeTrackerPage.tsx
@@ -4,6 +4,7 @@
 import { useMemo, useState } from 'react';
 import type { ID, Tool, ToolType } from '@/domain/types';
 import { VBChart } from './components/VBChart';
+import { TaylorPredictionPanel } from './components/TaylorPredictionPanel';
 import {
   buildWearSeries,
   summarizeByTool,
@@ -308,6 +309,23 @@ export const ToolLifeTrackerPage = () => {
                   </span>
                 </div>
                 <VBChart series={wearSeries} limit={WEAR_LIMIT} />
+              </section>
+
+              {/* Taylor 寿命予測 */}
+              <section
+                aria-label="Taylor 工具寿命予測"
+                className="rounded border border-[var(--border-faint)] bg-[var(--bg-raised)] p-3"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="text-[13px] font-semibold">Taylor 工具寿命予測</h3>
+                  <span className="text-[11px] text-[var(--text-lo)]">
+                    V·T^n = C
+                  </span>
+                </div>
+                <TaylorPredictionPanel
+                  tool={selectedTool}
+                  processes={processesQ.data ?? []}
+                />
               </section>
 
               {/* 直近プロセス */}

--- a/src/features/tools/components/TaylorPredictionPanel.tsx
+++ b/src/features/tools/components/TaylorPredictionPanel.tsx
@@ -1,0 +1,147 @@
+// Taylor 工具寿命予測パネル。
+// 工具ごとの過去プロセス (Vc, 到達 VB と累積距離) から V と T を復元し、
+// fitTaylor で (n, C) を推定。現行 Vc での予測寿命を表示する。
+
+import { useMemo } from 'react';
+import type { CuttingProcess, Tool } from '@/domain/types';
+import {
+  defaultParamsForTool,
+  fitTaylor,
+  toolLifeMin,
+} from '../../cutting/utils/taylorTool';
+import { VB_CRITERIA } from '../../cutting/utils/standards';
+
+export interface TaylorPredictionPanelProps {
+  tool: Tool;
+  processes: CuttingProcess[];
+  /** 予測に使う基準 Vc (m/min)。省略時は直近プロセスの Vc を使う。 */
+  targetVc?: number;
+}
+
+interface SamplePoint {
+  V: number;
+  T: number;
+  Vb: number;
+  distance: number;
+  processId: string;
+}
+
+export const TaylorPredictionPanel = ({
+  tool,
+  processes,
+  targetVc,
+}: TaylorPredictionPanelProps) => {
+  const { samples, fit, defaults, referenceVc } = useMemo(() => {
+    // 対象工具のプロセスのみ抽出し、VB が 0.1mm 以上到達したものを「寿命テスト点」として扱う。
+    // 各プロセスの加工時間 T = cuttingDistanceMm / (Vc[m/min] * 1000) * 60 分換算
+    // で単純化（Vc は進行中一定と仮定）。
+    const relevant = processes
+      .filter((p) => p.toolId === tool.id && p.toolWearVB !== null && p.toolWearVB >= 0.1)
+      .sort((a, b) => a.performedAt.localeCompare(b.performedAt));
+
+    const sample: SamplePoint[] = relevant.map((p) => {
+      const V = p.condition.cuttingSpeed;
+      // 1 プロセスの加工時間 [min] = 距離 [mm] / (Vc [m/min] × 1000)
+      const T = V > 0 ? p.cuttingDistanceMm / (V * 1000) : 0;
+      return {
+        V,
+        T,
+        Vb: p.toolWearVB ?? 0,
+        distance: p.cuttingDistanceMm,
+        processId: p.id,
+      };
+    });
+
+    const fitInput = sample
+      .filter((s) => s.V > 0 && s.T > 0)
+      .map((s) => ({ V: s.V, T: s.T }));
+    const fitResult = fitTaylor(fitInput);
+    const defaultP = defaultParamsForTool(tool.material);
+    const ref =
+      targetVc ??
+      (relevant.length > 0
+        ? relevant[relevant.length - 1]!.condition.cuttingSpeed
+        : 100);
+
+    return {
+      samples: sample,
+      fit: fitResult,
+      defaults: defaultP,
+      referenceVc: ref,
+    };
+  }, [tool, processes, targetVc]);
+
+  const usedParams = fit ?? { n: defaults.n, C: defaults.C, r2: 0, points: [] };
+  const predictedT = toolLifeMin(referenceVc, usedParams);
+  const predictedDistanceMm = predictedT * referenceVc * 1000;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between text-[11px] text-[var(--text-lo)]">
+        <span>Taylor 工具寿命</span>
+        <span className="font-mono">
+          VB 限界 {VB_CRITERIA.finishing.average} mm 相当
+        </span>
+      </div>
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[12px]">
+        <dt className="text-[var(--text-lo)]">データ源</dt>
+        <dd className="text-right">
+          {fit
+            ? `実測 ${fit.points.length} 点から回帰 (R²=${fit.r2.toFixed(3)})`
+            : `材種デフォルト (${tool.material})`}
+        </dd>
+        <dt className="text-[var(--text-lo)]">n</dt>
+        <dd className="font-mono text-right">{usedParams.n.toFixed(3)}</dd>
+        <dt className="text-[var(--text-lo)]">C</dt>
+        <dd className="font-mono text-right">{usedParams.C.toFixed(1)}</dd>
+        <dt className="text-[var(--text-lo)]">基準 Vc</dt>
+        <dd className="font-mono text-right">
+          {referenceVc.toFixed(1)} m/min
+        </dd>
+        <dt className="text-[var(--text-lo)]">予測寿命 T</dt>
+        <dd className="font-mono text-right">{predictedT.toFixed(1)} min</dd>
+        <dt className="text-[var(--text-lo)]">予測切削距離</dt>
+        <dd className="font-mono text-right">
+          {predictedDistanceMm.toLocaleString(undefined, {
+            maximumFractionDigits: 0,
+          })}{' '}
+          mm
+        </dd>
+      </dl>
+      {!fit && (
+        <div className="text-[10px] text-[var(--text-lo)]">
+          実測寿命点が不足（VB≥0.1mm のプロセス 2 件以上で回帰開始）。
+          材種デフォルト値を使用中。
+        </div>
+      )}
+      {fit && fit.r2 < 0.7 && (
+        <div className="text-[10px] text-[var(--warn,#f59e0b)]">
+          R² = {fit.r2.toFixed(2)} と低め。条件ばらつき・測定不確かさを疑い、回帰結果の参考度は控えめに。
+        </div>
+      )}
+      <div className="text-[10px] text-[var(--text-lo)] leading-relaxed">
+        Taylor 式 V · T^n = C。n は工具材種依存 ({tool.material} の標準値 {defaults.n.toFixed(3)})。
+        実測点が増えるほど回帰精度が上がる。
+      </div>
+
+      {samples.length > 0 && (
+        <details className="mt-1 text-[11px]">
+          <summary className="cursor-pointer text-[var(--text-lo)]">
+            実測 (V, T) 点 {samples.length} 件
+          </summary>
+          <ul className="mt-1 font-mono text-[10px] text-[var(--text-md)] leading-relaxed">
+            {samples.slice(0, 8).map((s) => (
+              <li key={s.processId}>
+                V={s.V.toFixed(0)} m/min, T={s.T.toFixed(2)} min (VB=
+                {s.Vb.toFixed(2)} mm, {s.distance.toLocaleString()} mm)
+              </li>
+            ))}
+            {samples.length > 8 && (
+              <li className="text-[var(--text-lo)]">... 他 {samples.length - 8} 件</li>
+            )}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+};

--- a/src/features/tools/components/TaylorPredictionPanel.tsx
+++ b/src/features/tools/components/TaylorPredictionPanel.tsx
@@ -32,25 +32,35 @@ export const TaylorPredictionPanel = ({
   targetVc,
 }: TaylorPredictionPanelProps) => {
   const { samples, fit, defaults, referenceVc } = useMemo(() => {
-    // 対象工具のプロセスのみ抽出し、VB が 0.1mm 以上到達したものを「寿命テスト点」として扱う。
-    // 各プロセスの加工時間 T = cuttingDistanceMm / (Vc[m/min] * 1000) * 60 分換算
-    // で単純化（Vc は進行中一定と仮定）。
-    const relevant = processes
-      .filter((p) => p.toolId === tool.id && p.toolWearVB !== null && p.toolWearVB >= 0.1)
+    // Taylor 式の T は「新品 → 寿命到達までの累積時間」であり、単一プロセスの
+    // 加工時間ではない。このため対象工具の全プロセスを時系列で並べ、各プロセス
+    // 終了時点までの累積加工時間を T として扱う。
+    // さらに VB が 0.1mm 以上到達した時点（＝寿命指標が取れる段階）を
+    // 回帰サンプルとする。
+    const allForTool = processes
+      .filter((p) => p.toolId === tool.id)
       .sort((a, b) => a.performedAt.localeCompare(b.performedAt));
 
-    const sample: SamplePoint[] = relevant.map((p) => {
+    let cumulativeTime = 0;
+    const sample: SamplePoint[] = [];
+    for (const p of allForTool) {
       const V = p.condition.cuttingSpeed;
-      // 1 プロセスの加工時間 [min] = 距離 [mm] / (Vc [m/min] × 1000)
-      const T = V > 0 ? p.cuttingDistanceMm / (V * 1000) : 0;
-      return {
-        V,
-        T,
-        Vb: p.toolWearVB ?? 0,
-        distance: p.cuttingDistanceMm,
-        processId: p.id,
-      };
-    });
+      // このプロセスの加工時間 [min] = 距離 [mm] / (Vc [m/min] × 1000)
+      const dT = V > 0 ? p.cuttingDistanceMm / (V * 1000) : 0;
+      cumulativeTime += dT;
+      if (p.toolWearVB !== null && p.toolWearVB >= 0.1 && V > 0) {
+        sample.push({
+          V,
+          T: cumulativeTime,
+          Vb: p.toolWearVB,
+          distance: p.cuttingDistanceMm,
+          processId: p.id,
+        });
+      }
+    }
+    const relevant = allForTool.filter(
+      (p) => p.toolWearVB !== null && p.toolWearVB >= 0.1
+    );
 
     const fitInput = sample
       .filter((s) => s.V > 0 && s.T > 0)


### PR DESCRIPTION
## 概要

Day 1 午後成果。PR #66 で実装した純数式モジュールを UI に接続し、**現場で「この予測どう計算してる？」と聞かれたら即答できる状態**にします。

関連: PR #66 / #48 Want 完了

## 追加パネル

### `StabilityLobePanel` (切削条件エクスプローラ右ペイン)

- 工具 / 被削材から動特性を近似（`approximateModalParams` + `kienzleFor`）
- Altintas 2012 単一 DOF モデルで SLD 曲線を生成
- 主軸回転数 × blim 軸、lobe ごとに連続折れ線
- 現在条件 (rpm, ap) をマーカーで重畳し、安定/チャタ領域を判定

### `KcEstimatePanel` (切削条件エクスプローラ右ペイン)

- Kienzle モデルで Fc / P / MRR を推定
- 実測 Fc との乖離率を色分け表示（>30% 赤、>15% 橙、以下緑）
- 旋削/ミーリングで h, b の換算式を分岐
- 大きく乖離したら「工具摩耗・実効 h/b・加工硬化を疑え」と警告表示

### `TaylorPredictionPanel` (工具ライフトラッカー右ペイン)

- 工具の過去プロセスから (V, T) 点を抽出
- `fitTaylor` で (n, C) を対数線形回帰、R² 付き
- 現行 Vc での予測寿命（min）と予測切削距離（mm）を算出
- データ不足時は `defaultParamsForTool` にフォールバック（透明に表示）

## 実装ファイル

### 新規
- `src/features/cutting/components/StabilityLobePanel.tsx`
- `src/features/cutting/components/KcEstimatePanel.tsx`
- `src/features/tools/components/TaylorPredictionPanel.tsx`

### 変更
- `CuttingConditionsExplorerPage.tsx` — 右ペインに 2 パネル追加
- `ToolLifeTrackerPage.tsx` — VB チャート下に Taylor パネル追加
- `data/announcements.ts` — リリースノート

## 設計ポイント

- **純 SVG・依存ゼロ** — 既存 ConditionScatter / VBChart と同方針
- **PoC 欺瞞回避** — モデル値と実測値を並列表示し、乖離時は明示警告
- **回帰不成立の透明化** — データ不足 / R² 低のときに UI で理由を説明
- **現場議論の起点化** — 「Altintas 2012 単一 DOF 近似」などラベルでモデル出典を明示

## 非ゴール

- 多 DOF / 周波数応答の実測データ入力 (impact test UI)
- SLD のチャタ周波数別プロット
- Taylor 拡張形 (f, ap を含む 4 変数版)

## 検証

- [x] `pnpm typecheck` クリーン
- [x] `pnpm test` — 73 files / 726 passed
- [x] `pnpm lint` — 変更ファイル warning 0

## テスト手順

- [ ] `#/cutting-conditions` で点クリック → 右ペインに Kc 見積 + SLD が表示される
- [ ] 実測 Fc と予測 Fc の乖離率が色分けされる
- [ ] SLD の現在条件マーカーが曲線の上/下で色が変わる
- [ ] `#/tools` で工具選択 → VB チャート下に Taylor パネル
- [ ] VB≥0.1 のプロセスが 2 件以上ある工具では R² 付き回帰、無い工具は材種デフォルト