### PR TITLE
feat(guides): PAGE_GUIDES に machining-fundamentals へのリンクを追加（ADR-012 Phase 1）

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,14 @@ src/
 | ディレクトリ | 内容 |
 |------|------|
 | [`docs/onsite/`](./docs/onsite/) | 現場入り準備キット。ヒアリングシート（11 画面）／ペルソナ別ワークフロー仮説（4 ペルソナ）／既存ツール比較マトリクス／痛み候補 30 件／知識ギャップ棚卸し |
-| [`docs/adr/`](./docs/adr/) | Architecture Decision Records。インフラ系 7 本（英語）＋ フロント / ドメイン系 11 本（日本語、ADR-001〜011） |
+| [`docs/adr/`](./docs/adr/) | Architecture Decision Records。インフラ系 7 本（英語）＋ フロント / ドメイン系 12 本（日本語、ADR-001〜012）。ADR-012 は並行開発中の learning アプリとの親密化統合戦略 |
 | [`docs/research/`](./docs/research/) | ドメイン調査メモ・参照論文リンク |
 
 現場ヒアリングの結果は seeds / announcements / PAGE_GUIDES に反映する運用（ADR-007）を取っています。
+
+### 関連プロジェクト
+
+- [machining-fundamentals](https://github.com/BoxPistols/machining-fundamentals) — 金属加工の学習アプリ（独立 repo、MIT + CC BY 4.0 デュアルライセンス）。ADR-012 に基づき、用語・章・学習コンテンツを相互参照する親密化を進めています。
 
 ## Getting Started
 

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-23-phase1-learning-links',
+    date: '2026-04-23',
+    type: 'feature',
+    title: 'PAGE_GUIDES に金属加工学習アプリへの「詳しく学ぶ」リンクを追加（ADR-012 Phase 1）',
+    body: '切削条件エクスプローラ / 工具ライフトラッカー / 材料マスタ / 受託試験ダッシュボードの 4 画面に、並行開発中の学習アプリ machining-fundamentals の該当章 / 用語へのリンクを追加しました。URL 規約は peer と合意済（<base>#/chapter/<id>#<term-id>）。Matlens 側で glossaryMapping.ts を新設し 20 件の用語マッピングを管理します。Part A の anchor は pending で管理し、公開後に順次有効化されます。',
+  },
+  {
     id: '2026-04-23-adr-012-integration-strategy',
     date: '2026-04-23',
     type: 'info',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -115,6 +115,15 @@ export const HELP_TERMS: { id: string; term: string; en: string; cat: string; ca
   {id:'guide-about',term:'技術スタック',en:'Tech Stack',cat:'guide',catLabel:'ページガイド',catVariant:'blue',body:'Matlens を構成する技術の一覧です。フロントエンド（React + TypeScript + Vite）、AI/ML（AI SDK + TensorFlow.js）、データフォーマット（MaiML + PNML）、テスト（Vitest + Playwright）などの技術選定とプロジェクト構成を確認できます。',related:'ヘルプ・用語集'},
 ];
 
+// machining-fundamentals（金属加工学習アプリ）への学習リンク。
+// URL 規約: `<base>#/chapter/<id>[#<term-id>]`。ADR-012 で合意済み。
+export interface LearnMoreLink {
+  chapterRef: string; // 論理参照 ('3' / 'a4' / '10' 等)、URL が変わっても不変
+  label: string;
+  labelEn: string;
+  termId?: string; // 章内 anchor（任意）
+}
+
 export interface PageGuide {
   id: string;
   icon: string;
@@ -127,6 +136,7 @@ export interface PageGuide {
   tips: string[];
   tipsEn: string[];
   related: string[];
+  learnMore?: LearnMoreLink[]; // 関連学習章（machining-fundamentals 参照）
 }
 
 export const PAGE_GUIDES: PageGuide[] = [
@@ -679,6 +689,9 @@ export const PAGE_GUIDES: PageGuide[] = [
       'Abnormal finding ratio = non-low-confidence damage findings / completed tests in last 30 days',
     ],
     related: ['pjlist', 'specimens', 'matrix'],
+    learnMore: [
+      { chapterRef: '1', label: '金属加工の基礎（序章）', labelEn: 'Foundations of Metal Machining' },
+    ],
   },
   {
     id: 'reports', icon: 'report',
@@ -762,6 +775,11 @@ export const PAGE_GUIDES: PageGuide[] = [
       'Use "Open in matrix" link in the detail view to jump to the test type × material heatmap',
     ],
     related: ['matrix', 'specimens', 'pjlist'],
+    learnMore: [
+      { chapterRef: 'a1', termId: 'atom', label: '原子と電子（Part A1）', labelEn: 'Atoms and Electrons (Part A1)' },
+      { chapterRef: 'a3', termId: 'fcc', label: '結晶構造 FCC / BCC / HCP', labelEn: 'Crystal Structures' },
+      { chapterRef: 'a5', termId: 'phase-diagram', label: '合金と相変態（Part A5）', labelEn: 'Alloys and Phase Transformations' },
+    ],
   },
   {
     id: 'specimens', icon: 'list',
@@ -822,6 +840,10 @@ export const PAGE_GUIDES: PageGuide[] = [
       'Wear rate changes with material — compare the material column in the recent process table',
     ],
     related: ['cutting-conditions', 'mat-master'],
+    learnMore: [
+      { chapterRef: '8', termId: 'VB', label: 'VB（逃げ面摩耗）とは', labelEn: 'About VB (Flank Wear)' },
+      { chapterRef: '8', termId: 'Taylor', label: 'Taylor 工具寿命式', labelEn: 'Taylor Tool Life Equation' },
+    ],
   },
   {
     id: 'cutting-conditions', icon: 'scan',
@@ -853,6 +875,11 @@ export const PAGE_GUIDES: PageGuide[] = [
       'When multiple waveform channels exist, switch between them via the tabs at the top of the right pane',
     ],
     related: ['matrix', 'damage', 'pjlist'],
+    learnMore: [
+      { chapterRef: '3', termId: 'Vc', label: '切削速度 Vc / 送り f / 切込 ap', labelEn: 'Vc / f / ap Basics' },
+      { chapterRef: '6', termId: 'Kc', label: '比切削抵抗 Kc（Kienzle）', labelEn: 'Specific Cutting Force Kc' },
+      { chapterRef: '10', termId: 'SLD', label: 'Stability Lobe Diagram', labelEn: 'Stability Lobe Diagram' },
+    ],
   },
 ];
 

--- a/src/data/glossaryMapping.test.ts
+++ b/src/data/glossaryMapping.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  GLOSSARY_MAPPINGS,
+  MACHINING_FUNDAMENTALS_BASE_URL,
+  urlForTerm,
+  urlForChapter,
+  isPendingTerm,
+} from './glossaryMapping';
+
+describe('glossaryMapping', () => {
+  it('contains at least the 20 terms agreed with peer', () => {
+    expect(GLOSSARY_MAPPINGS.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('all terms have unique termId', () => {
+    const ids = GLOSSARY_MAPPINGS.map((m) => m.termId);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('all terms have non-empty chapter / anchor', () => {
+    for (const m of GLOSSARY_MAPPINGS) {
+      expect(m.chapterRef).toMatch(/^[a-z0-9-]+$/i);
+      expect(m.anchor.length).toBeGreaterThan(0);
+    }
+  });
+
+  describe('urlForTerm', () => {
+    it('builds the agreed URL shape <base>#/chapter/<id>#<term-id>', () => {
+      expect(urlForTerm('VB')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8#VB`);
+      expect(urlForTerm('Taylor')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8#Taylor`);
+      expect(urlForTerm('SLD')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/10#SLD`);
+      expect(urlForTerm('atom')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/a1#atom`);
+    });
+
+    it('falls back to base URL for unknown termId (peer guarantees home fallback)', () => {
+      expect(urlForTerm('nonexistent-term')).toBe(MACHINING_FUNDAMENTALS_BASE_URL);
+    });
+
+    it('accepts a custom base URL (for staging / fixture)', () => {
+      expect(urlForTerm('VB', 'https://example.test/')).toBe('https://example.test/#/chapter/8#VB');
+    });
+  });
+
+  describe('urlForChapter', () => {
+    it('returns chapter URL without anchor', () => {
+      expect(urlForChapter('8')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8`);
+      expect(urlForChapter('a4')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/a4`);
+    });
+  });
+
+  describe('isPendingTerm', () => {
+    it('returns true for pending anchors (Part A not yet published)', () => {
+      expect(isPendingTerm('metallic-bond')).toBe(true);
+      expect(isPendingTerm('dislocation')).toBe(true);
+    });
+
+    it('returns false for already-published anchors', () => {
+      expect(isPendingTerm('VB')).toBe(false);
+      expect(isPendingTerm('Taylor')).toBe(false);
+      expect(isPendingTerm('atom')).toBe(false); // A1 は公開済と peer が報告
+    });
+
+    it('returns false for unknown term', () => {
+      expect(isPendingTerm('unknown')).toBe(false);
+    });
+  });
+});

--- a/src/data/glossaryMapping.ts
+++ b/src/data/glossaryMapping.ts
@@ -1,0 +1,74 @@
+// machining-fundamentals（金属加工学習アプリ）への用語リンクマッピング。
+//
+// ADR-012（親密化統合戦略）の Phase 1 実装。URL 規約は peer と合意済:
+//   <base>#/chapter/<id>[#<term-id>]
+//
+// peer (yilmogxd) から提供された初期 20 件 + Matlens 側で追加登録したい候補。
+// base URL は deploy 確定後に MACHINING_FUNDAMENTALS_BASE_URL で切替可能に。
+
+export const MACHINING_FUNDAMENTALS_BASE_URL =
+  'https://machining-fundamentals.vercel.app/';
+
+export interface GlossaryMapping {
+  termId: string;
+  ja: string;
+  en: string;
+  symbol?: string;
+  chapterRef: string;
+  anchor: string;
+  levelHint: 'beginner' | 'intermediate' | 'advanced';
+  /** Part A 執筆完了前の未実装 anchor は pending: true を立てる。dead-link チェックで skip */
+  pending?: boolean;
+}
+
+// 初期 20 件（peer 提供）+ Matlens 側で追加登録したい候補（pending:true）
+export const GLOSSARY_MAPPINGS: GlossaryMapping[] = [
+  // Part A（材料科学）— peer 執筆中。pending:true のものは anchor 確定後に false に戻す
+  { termId: 'atom', ja: '原子', en: 'Atom', chapterRef: 'a1', anchor: 'atom', levelHint: 'beginner' },
+  { termId: 'valence', ja: '価電子', en: 'Valence electron', chapterRef: 'a1', anchor: 'valence', levelHint: 'beginner' },
+  { termId: 'metallic-bond', ja: '金属結合', en: 'Metallic bond', chapterRef: 'a2', anchor: 'metallic-bond', levelHint: 'beginner', pending: true },
+  { termId: 'fcc', ja: 'FCC 結晶', en: 'FCC crystal', chapterRef: 'a3', anchor: 'fcc', levelHint: 'intermediate', pending: true },
+  { termId: 'bcc', ja: 'BCC 結晶', en: 'BCC crystal', chapterRef: 'a3', anchor: 'bcc', levelHint: 'intermediate', pending: true },
+  { termId: 'hcp', ja: 'HCP 結晶', en: 'HCP crystal', chapterRef: 'a3', anchor: 'hcp', levelHint: 'intermediate', pending: true },
+  { termId: 'dislocation', ja: '転位', en: 'Dislocation', chapterRef: 'a4', anchor: 'dislocation', levelHint: 'intermediate', pending: true },
+  { termId: 'slip-system', ja: 'すべり系', en: 'Slip system', chapterRef: 'a4', anchor: 'slip-system', levelHint: 'intermediate', pending: true },
+  { termId: 'work-hardening', ja: '加工硬化', en: 'Work hardening', chapterRef: 'a4', anchor: 'work-hardening', levelHint: 'intermediate', pending: true },
+  { termId: 'phase-diagram', ja: '状態図', en: 'Phase diagram', chapterRef: 'a5', anchor: 'phase-diagram', levelHint: 'intermediate', pending: true },
+  { termId: 'johnson-cook', ja: 'Johnson-Cook 構成式', en: 'Johnson-Cook constitutive equation', chapterRef: 'a6', anchor: 'johnson-cook', levelHint: 'advanced', pending: true },
+  { termId: 'shear-band', ja: 'せん断帯', en: 'Shear band', chapterRef: 'a6', anchor: 'shear-band', levelHint: 'advanced', pending: true },
+
+  // Part B（切削工学）— 既存章
+  { termId: 'Vc', ja: '切削速度', en: 'Cutting speed', symbol: 'Vc', chapterRef: '3', anchor: 'Vc', levelHint: 'beginner' },
+  { termId: 'f', ja: '送り', en: 'Feed per revolution', symbol: 'f', chapterRef: '3', anchor: 'f', levelHint: 'beginner' },
+  { termId: 'ap', ja: '切込み深さ', en: 'Depth of cut', symbol: 'ap', chapterRef: '3', anchor: 'ap', levelHint: 'beginner' },
+  { termId: 'Kc', ja: '比切削抵抗', en: 'Specific cutting force', symbol: 'Kc', chapterRef: '6', anchor: 'Kc', levelHint: 'intermediate' },
+  { termId: 'VB', ja: '逃げ面摩耗', en: 'Flank wear width', symbol: 'VB', chapterRef: '8', anchor: 'VB', levelHint: 'intermediate' },
+  { termId: 'Taylor', ja: 'Taylor 工具寿命式', en: 'Taylor tool-life equation', symbol: 'V·T^n=C', chapterRef: '8', anchor: 'Taylor', levelHint: 'intermediate' },
+  { termId: 'Ra', ja: '算術平均粗さ', en: 'Arithmetic mean roughness', symbol: 'Ra', chapterRef: '9', anchor: 'Ra', levelHint: 'beginner' },
+  { termId: 'SLD', ja: 'Stability Lobe', en: 'Stability Lobe Diagram', symbol: 'blim(n)', chapterRef: '10', anchor: 'SLD', levelHint: 'advanced' },
+];
+
+/**
+ * 用語 ID から machining-fundamentals の完全 URL を生成。
+ * 不明 ID はホーム URL を返す（peer 側で未知 id はホームフォールバックする設計）。
+ */
+export function urlForTerm(termId: string, base = MACHINING_FUNDAMENTALS_BASE_URL): string {
+  const mapping = GLOSSARY_MAPPINGS.find((m) => m.termId === termId);
+  if (!mapping) return base;
+  return `${base}#/chapter/${mapping.chapterRef}#${mapping.anchor}`;
+}
+
+/**
+ * 章 ID から machining-fundamentals の章 URL を生成（anchor なし）。
+ */
+export function urlForChapter(chapterRef: string, base = MACHINING_FUNDAMENTALS_BASE_URL): string {
+  return `${base}#/chapter/${chapterRef}`;
+}
+
+/**
+ * 未実装 anchor かどうか（CI の dead-link チェックで skip 判定に使う）。
+ */
+export function isPendingTerm(termId: string): boolean {
+  const mapping = GLOSSARY_MAPPINGS.find((m) => m.termId === termId);
+  return mapping?.pending === true;
+}


### PR DESCRIPTION
## 概要
ADR-012「親密化統合戦略」の Phase 1 実装。並行開発中の金属加工学習アプリ machining-fundamentals へ、Matlens の PAGE_GUIDES から「詳しく学ぶ」導線を追加する。

## 変更内容

### 新規
- \`src/data/glossaryMapping.ts\`
  - 用語 ID → machining-fundamentals 章 / anchor の URL マッピング（20 件）
  - \`urlForTerm\` / \`urlForChapter\` / \`isPendingTerm\` のヘルパ関数
  - \`MACHINING_FUNDAMENTALS_BASE_URL\` は定数で差替え可能（staging / CI 用）
  - Part A の anchor は \`pending: true\` でフラグ、公開後に false へ
- \`src/data/glossaryMapping.test.ts\`
  - URL 生成の正しさ / 未知 ID のフォールバック / pending 判定を計 10 テスト

### 修正
- \`src/data/constants.ts\`
  - \`PageGuide\` 型に \`learnMore?: LearnMoreLink[]\` を追加
  - 4 画面に初期リンクを配置:
    - \`ops-dash\` → 章 1（序章）
    - \`tools\` → 章 8 (VB / Taylor)
    - \`cutting-conditions\` → 章 3 (Vc / f / ap) / 章 6 (Kc) / 章 10 (SLD)
    - \`mat-master\` → 章 a1 (原子) / a3 (結晶構造) / a5 (相変態) — 全て pending

### 連動更新 (ADR-007)
- \`README.md\`: ADR 本数を 12 本に更新、「関連プロジェクト」節で machining-fundamentals を紹介
- \`announcements.ts\`: Phase 1 告知を feature 型で先頭に追加

## URL 規約（peer と合意済）
\`\`\`
<base>#/chapter/<id>        # 章 URL
<base>#/chapter/<id>#<term> # 用語 anchor
\`\`\`
未知 ID はホームフォールバック（peer 側で実装済、dead link にならない）

## 今後
- Part A（a1〜a6）の章公開後、pending フラグを順次解除
- Matlens UI 側でツールチップ / ヘルプパネルに「詳しく学ぶ」ボタンを表示する改修（別 PR）
- 各画面の learnMore 初期リンクを拡充

## テスト計画
- [x] typecheck pass
- [x] glossaryMapping.test.ts 10 passed
- [ ] レビュー時に URL 規約の表記揺れ確認