### PR TITLE
feat(integration): ADR-014 起票 + URL 規約 slash 確定 + glossary 24 anchor 反映

### DIFF
--- a/docs/adr/ADR-013-url-contract-and-terminology-ownership.md
+++ b/docs/adr/ADR-013-url-contract-and-terminology-ownership.md
@@ -1,10 +1,17 @@
 # ADR-013: URL 規約・用語 ownership・更新ポリシー（親密化の運用規約）
 
-- ステータス: **Proposed**（peer 合意中、実装一部先行済）
-- 日付: 2026-04-23
-- 関連 ADR: ADR-012（親密化統合戦略 — Proposed）、ADR-007（連動更新ルール）
+- ステータス: **Accepted**（2026-04-23 peer と全項目合意）
+- 日付: 2026-04-23（初版）/ 2026-04-23（Minor Revision #1）
+- 関連 ADR: ADR-012（親密化統合戦略 — Proposed）、ADR-014（統合実行計画 — Proposed）、ADR-007（連動更新ルール）
 - 対応 PR: #74（Phase 1 Matlens 側実装）
 - 関連 peer / repo: `BoxPistols/machining-fundamentals`
+
+## 改訂履歴
+
+| バージョン | 日付 | 変更点 |
+|---|---|---|
+| 初版 | 2026-04-23 | URL Contract / Terminology Ownership / Update Policy / Dead Link / Out of Scope を草稿 |
+| Minor Revision #1 | 2026-04-23 | URL Contract の term anchor 区切りを `#` → `/` に確定（詳細は本文 §1 末尾） |
 
 ---
 
@@ -33,20 +40,45 @@ machining-fundamentals の URL は hash-based SPA 規約:
 
 ```
 <base>                          ホーム（未知 id のフォールバック先）
-<base>#/chapter/<id>            章詳細（id は '1'..'10' / 'a1'..'a6' 等）
-<base>#/chapter/<id>#<term-id>  章内 anchor（term-id は @mc/glossary と揃える）
+<base>#/chapter/<id>            章詳細（id は '1'..'10' / 'a1'..'a6' / 'c1' 等）
+<base>#/chapter/<id>/<term-id>  章内 anchor（term-id は @mc/glossary と揃える）
 <base>#/about                   このアプリについて
 <base>#/sim                     CFD シミュレーター
 ```
 
 **保証事項**（peer から宣言済）:
 - 章の `id` は原則変更しない（外部リンクを壊さない）
-- 既存 1..10 の id は Part A 挿入後も不変（a1〜a6 は先頭に追加された別名前空間）
+- 既存 1..10 の id は Part A 挿入後も不変（a1〜a6 / c1 は別名前空間で先頭・末尾に追加）
 - 未知 `id` は **ホームにフォールバック**（404 画面を出さない）
 
 **Matlens 側の運用**:
 - `src/data/glossaryMapping.ts` の `MACHINING_FUNDAMENTALS_BASE_URL` を信頼する
 - 定数で差替え可能（staging / CI テスト用）
+
+#### Minor Revision #1（2026-04-23）: term anchor 区切り `#` → `/` に確定
+
+**変更理由**:
+- 当初提案は `<base>#/chapter/<id>#<term-id>` だったが、RFC 3986 §3.5 により
+  単一 URL は `#` を 1 つしか持てない
+- `#/chapter/8#VB` ではブラウザの `location.hash` が
+  `/chapter/8#VB` 全体となり、2 段目の `#` は literal 扱い
+- peer 側実装で「path-style の `/` 連結のほうが parser がシンプル」と判断し変更
+- 2026-04-23 に両 repo で確認・合意
+
+**変更内容**:
+- `<base>#/chapter/<id>#<term-id>`（廃案）
+- `<base>#/chapter/<id>/<term-id>`（採用）
+
+**既に配置済のリンクへの影響**:
+- PR #74 で配置した 4 画面の learnMore はコミット時点で内部生成関数経由、
+  generateURL を 1 箇所修正すれば全てが同期追従
+- 本 ADR Minor Revision と同じ PR で `glossaryMapping.ts` を更新、test 期待値も更新
+
+**「予告期間」の扱い**:
+- ADR-013 初版の Update Policy（章 id 変更 1 週間等）は「既に公開・利用されている
+  anchor の破壊的変更」を対象とする
+- 本件は **初期合意形成中のタイポ修正** に相当し、予告期間は不要
+- 両 repo とも実利用開始前のため、初期固定化として処理
 
 ### 2. Terminology Ownership（用語の責任分界）
 

--- a/docs/adr/ADR-014-monorepo-integration-execution-plan.md
+++ b/docs/adr/ADR-014-monorepo-integration-execution-plan.md
@@ -1,0 +1,263 @@
+# ADR-014: monorepo 統合の実行計画
+
+- ステータス: **Proposed**（peer 側でも同内容を配置予定）
+- 日付: 2026-04-23
+- 関連 ADR: ADR-012（戦略）/ ADR-013（運用規約）
+- 関連 peer / repo: `BoxPistols/machining-fundamentals` の `docs/monorepo-decisions.md`
+
+---
+
+## 背景
+
+ADR-012 で親密化レベル 3 を目標とし、Phase 4 として monorepo 統合を掲げた。
+ADR-013 で URL / 用語 / 更新ポリシーを明文化した。
+
+peer 側 `docs/monorepo-decisions.md` で判断点 4 件の推奨方針が出たので、
+Matlens 側が合意を形成し、**実行可能な計画** として本 ADR に固定する。
+
+「戦略 → 運用規約 → 実行計画」の三層目に相当。
+
+---
+
+## 判断点 4 件の決定
+
+peer 推奨方針に Matlens 側の微調整を加えた最終版。
+
+### 判断 1: ADR 再採番 — **プレフィックス分離（段階的移行）**
+
+- `ADR-MAT-*` — Matlens 固有
+- `ADR-LRN-*` — learning（machining-fundamentals）固有
+- `ADR-COM-*` — 共通パッケージ / 統合ルール
+
+**移行方針**:
+- monorepo 統合時点までは現名称（ADR-001〜014）を維持
+- 統合時に一括改名し、旧名 → 新名のリダイレクトテーブルを `docs/adr/README.md` に掲載
+- 履歴保持のため旧ファイルは残す（`@deprecated` マーカー付き）
+
+**Matlens 既存 ADR の移行マッピング案**（統合時に適用）:
+
+| 現名 | 移行後 | 備考 |
+|---|---|---|
+| ADR-001 レイヤードアーキテクチャ | ADR-MAT-001 | Matlens 固有 |
+| ADR-002 切削ドメイン分離 | ADR-MAT-002 | Matlens 固有 |
+| ADR-003 決定論的 fixture | ADR-MAT-003 | Matlens 固有 |
+| ADR-004 Markdown レンダラ自前実装 | ADR-COM-001 | 両 app で使う可能性 → 共通化 |
+| ADR-005 SLD 段階実装 | ADR-MAT-005 | 実装は Matlens 主、数学は @mc/math-cutting |
+| ADR-006 試験片トラッカー二重ビュー | ADR-MAT-006 | Matlens 業務固有 |
+| ADR-007 連動更新ルール | ADR-COM-002 | 両 app 共通 |
+| ADR-008 JST 正規化 | ADR-COM-003 | 両 app 共通（時刻扱い） |
+| ADR-009 純 SVG 可視化 | ADR-COM-004 | @mc/viz-svg / @mc/viz-concept 共通 |
+| ADR-010 Stage 2 集計境界 | ADR-MAT-010 | Matlens 業務固有 |
+| ADR-011 テスト戦略 | ADR-COM-005 | monorepo 共通 |
+| ADR-012 親密化戦略 | ADR-COM-012 | 統合ルール |
+| ADR-013 URL Contract | ADR-COM-013 | 統合ルール |
+| ADR-014 統合実行計画 | ADR-COM-014 | 統合ルール |
+| ADR-0001..0007（インフラ英語） | ADR-COM-101..107 | Vercel / Upstash 等は両 app で使う |
+
+### 判断 2: デザイントークン — **ベース共通 + 業務別拡張**
+
+```
+packages/@mc/ui-tokens-base/
+  ├─ light.css       # 共通（両 app で使う）
+  ├─ dark.css        # 共通
+  └─ index.ts        # CSS variable 型定義
+
+packages/@mc/ui-tokens-matlens/
+  ├─ eng.css         # Matlens 専用追加テーマ
+  ├─ cae.css         # Matlens 専用追加テーマ
+  └─ index.ts
+```
+
+**ルール**:
+- `--accent` / `--bg-surface` / `--text-hi` など基本 variable は base で定義
+- Matlens 固有の semantic token（`--test-in-progress`, `--damage-high-severity` 等）は
+  matlens 側で追加
+- learning 側は base のみを import し、light / dark の 2 テーマで完結
+
+### 判断 3: ライセンス — **SPDX パッケージ別**
+
+```
+apps/matlens/           → MIT
+apps/learning/          → MIT + CC BY 4.0 (dual)
+apps/docs-site/         → CC BY 4.0 (docs body) + MIT (code)
+packages/@mc/glossary/  → MIT (code) + CC BY 4.0 (用語定義テキスト)
+packages/@mc/math-cutting/ → MIT
+packages/@mc/standards/ → MIT（規格番号とメタのみ、全文なし）
+packages/@mc/cutting-params/ → MIT
+packages/@mc/exercises/ → MIT
+packages/@mc/ai-prompts/ → MIT
+packages/@mc/rag-knowledge/ → 混合（ソース次第、各 chunk にライセンス属性）
+packages/@mc/viz-svg/    → MIT
+packages/@mc/viz-concept/ → MIT + CC BY 4.0 (教育図解)
+packages/@mc/ui-tokens-base/ → MIT
+packages/@mc/ui-tokens-matlens/ → MIT
+```
+
+**実装**:
+- 各 `package.json` に `"license": "<SPDX-id>"` 明記
+- `/licenses/` ディレクトリに LICENSE ファイル集約
+- デュアルライセンスパッケージは `LICENSE-MIT` + `LICENSE-CC-BY-4.0` 両方配置
+
+### 判断 4: npm 公開範囲 — **4 package の段階的 public**
+
+**初期（GitHub Packages private）**:
+- 全 packages を GitHub Packages private でリリースフロー確認
+
+**Phase 1（monorepo 統合直後、2 ヶ月程度）**:
+- すべて private 維持、apps 内部でのみ使用
+
+**Phase 2（安定後、npm public 化候補）**:
+1. `@mc/glossary` — 用語データ、金属加工教育分野で広く使える
+2. `@mc/math-cutting` — Taylor / Kienzle / SLD 計算、学術利用価値
+3. `@mc/standards` — 規格定数、研究室で直接使える
+4. `@mc/viz-svg` — 純 SVG チャート、chart ライブラリ代替
+
+**npm 公開しないもの**:
+- `@mc/exercises`, `@mc/ai-prompts`, `@mc/rag-knowledge` — 特定ドメインに密結合
+- `@mc/viz-concept` — 教育図解で learning 固有
+- `@mc/ui-tokens-*` — 両 app 固有
+
+---
+
+## monorepo ディレクトリ構造（確定版）
+
+```
+mc-monorepo/
+├── apps/
+│   ├── matlens/              # Matlens（材料試験 + 切削プロセス）
+│   ├── learning/             # machining-fundamentals（教育）
+│   └── docs-site/            # 統合ドキュメントサイト（Docusaurus 候補）
+│
+├── packages/
+│   ├── @mc/glossary/
+│   ├── @mc/math-cutting/
+│   ├── @mc/standards/
+│   ├── @mc/cutting-params/
+│   ├── @mc/exercises/
+│   ├── @mc/ai-prompts/
+│   ├── @mc/rag-knowledge/
+│   ├── @mc/viz-svg/
+│   ├── @mc/viz-concept/
+│   ├── @mc/ui-tokens-base/
+│   ├── @mc/ui-tokens-matlens/
+│   ├── @mc/shared-types/
+│   └── @mc/link-checker/     # ADR-013 で合意した dead link チェック script
+│
+├── docs/
+│   ├── adr/                  # ADR-COM-*, MAT-*, LRN-* 統合
+│   ├── research/             # Matlens docs/research 移管（10 本）
+│   ├── onsite/               # Matlens onsite kit（内容次第で public 化判断）
+│   └── integration-points.md # 親密化の契約書（ADR-013 と併設）
+│
+├── scripts/
+│   ├── verify-learn-more-links.mjs
+│   └── generate-glossary-index.mjs
+│
+├── licenses/
+│   ├── LICENSE-MIT
+│   └── LICENSE-CC-BY-4.0
+│
+├── turbo.json
+├── pnpm-workspace.yaml
+└── package.json
+```
+
+---
+
+## 移行スケジュール
+
+### Phase 4-A: 準備（現在〜2026-06）
+- [x] ADR-012 / ADR-013 / ADR-014 の 3 ADR（戦略・規約・計画）を両 repo で固定化
+- [x] URL Contract / integration-points.md の配置
+- [ ] peer 側 repo に ADR-014 相当のコピー配置
+- [ ] 移行シミュレーション（ローカルで dry-run、実マージなし）
+
+### Phase 4-B: 最小統合（2026-06〜07）
+- [ ] 新 monorepo repo 作成（`BoxPistols/mc-monorepo` 仮）
+- [ ] 既存 Matlens / machining-fundamentals を **git subtree merge** で取り込み
+  （履歴保持重視）
+- [ ] `packages/@mc/math-cutting` 切り出し（Matlens の `src/features/cutting/utils/` から）
+- [ ] `packages/@mc/glossary` 切り出し（peer 側の用語 + Pack 2 用語集）
+- [ ] Turborepo + pnpm workspace 設定
+
+### Phase 4-C: UI 共通化（2026-07〜08）
+- [ ] `packages/@mc/viz-svg` 切り出し（ADR-009 実装を移植）
+- [ ] `packages/@mc/ui-tokens-base` / `ui-tokens-matlens` 分離
+- [ ] 両 apps が packages を import する形へ置換
+
+### Phase 4-D: AI 機能統合（2026-08〜09）
+- [ ] `packages/@mc/ai-prompts` / `rag-knowledge` 構築
+- [ ] 両 apps で同じ Chat AI を使えるように
+
+### Phase 4-E: 完成・公開（2026-09〜）
+- [ ] ADR 再採番を一括実施
+- [ ] npm public 化（4 package）
+- [ ] 旧 repo は archived に
+
+---
+
+## Breaking Change 予告一覧
+
+monorepo 統合までに Matlens 側で発生する可能性のある破壊的変更:
+
+| 変更 | 影響 | Phase | 予告期間 |
+|---|---|---|---|
+| ADR 再採番（ADR-MAT-* へ） | 内部参照 / URL | 4-E | 2 週間以上 |
+| デザイントークンの semantic 名変更 | Matlens 4 テーマ CSS | 4-C | 1 週間以上 |
+| `src/features/cutting/utils/` の import パス変更 | `@mc/math-cutting` 化 | 4-B | 1 週間以上 |
+| Repository 型の packages 化 | `@mc/shared-types` 化 | 4-B | 1 週間以上 |
+
+すべて ADR-013 の Update Policy に従い、両 repo に同時 issue を立てて予告する。
+
+---
+
+## リスクと rollback 計画
+
+### リスク
+
+| リスク | 緩和策 |
+|---|---|
+| monorepo 化で Matlens の開発速度が一時低下 | Phase ごとに短期で区切り、各 Phase 完了時にベンチマーク（ビルド時間 / テスト時間 / PR マージ速度） |
+| git 履歴の断絶 | `git subtree merge` で履歴保持、`--rejoin` を使わない |
+| peer 側の Part A-C 執筆と干渉 | Phase 4-B 開始前に peer 側の大型執筆完了を確認 |
+| npm public 化時の名前衝突 | `@mc/*` scope で予約、scope 取得を早期に実施 |
+| 既存のデプロイ URL が変わる | Vercel 側で alias 維持、両 URL を cutover 期間中は並行運用 |
+
+### Rollback 計画
+
+Phase 4-B 完了時点で不具合があれば:
+1. 既存 Matlens / machining-fundamentals の main は維持（削除しない）
+2. 新 monorepo は実験ブランチとして扱い、main にマージしない
+3. 各 Phase の完了ベンチマークが目標値を下回ったら Rollback 判断
+4. Rollback 時は既存 repo を primary に戻し、packages は GitHub Packages private 状態で温存
+
+### 完全断念の判断基準
+
+以下すべてに該当したら monorepo 化を断念し、別 repo 運用を継続:
+- Phase 4-C 時点で CI 時間が統合前より 3 倍以上
+- 両 apps の個別デプロイができなくなる（Vercel の制約等）
+- 3 ヶ月経過しても Phase 4-D に到達しない
+
+---
+
+## 実装チェックリスト（Phase 4-A）
+
+### Matlens 側
+- [ ] 本 ADR-014 merge（本 PR）
+- [ ] peer 側 `docs/monorepo-decisions.md` との整合を cross-check
+- [ ] ADR 再採番マッピング表を README で周知
+- [ ] `src/features/cutting/utils/` に「将来 `@mc/math-cutting` として切り出し予定」コメント追加
+
+### peer 側（依頼）
+- [ ] 本 ADR のコピー配置
+- [ ] `docs/monorepo-decisions.md` を本 ADR の決定内容と整合
+- [ ] Part A / B / C の執筆完了見込みを共有（Phase 4-B 開始タイミングの判断に必要）
+
+---
+
+## 関連
+
+- ADR-012（親密化戦略）
+- ADR-013（URL Contract / Terminology Ownership）
+- peer `BoxPistols/machining-fundamentals/docs/monorepo-decisions.md`（判断点 4 件の peer 側推奨方針）
+- `integration-points.md`（両 repo ルートの契約書）

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,7 @@ implementation details — those belong in commit messages.
 | [ADR-010](./ADR-010-stage2-aggregation-endpoints.md) | 集計 / 横断検索エンドポイントを Stage 2 で REST へ切り出す | Accepted |
 | [ADR-011](./ADR-011-testing-strategy.md) | テスト戦略（Vitest + 純関数 + 決定論的 fixture） | Accepted |
 | [ADR-012](./ADR-012-machining-fundamentals-integration.md) | machining-fundamentals との親密化統合戦略 | Proposed |
-| [ADR-013](./ADR-013-url-contract-and-terminology-ownership.md) | URL 規約・用語 ownership・更新ポリシー（親密化の運用規約） | Proposed |
+| [ADR-013](./ADR-013-url-contract-and-terminology-ownership.md) | URL 規約・用語 ownership・更新ポリシー（親密化の運用規約） | Accepted |
+| [ADR-014](./ADR-014-monorepo-integration-execution-plan.md) | monorepo 統合の実行計画（判断点 4 件の決定 + Phase 4 詳細） | Proposed |
 
 [nygard]: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-23-learning-anchors-finalized',
+    date: '2026-04-23',
+    type: 'feature',
+    title: '金属加工学習アプリの 24 anchor 本番反映 + URL 規約確定 + ADR-014 起票',
+    body: 'peer 側の machining-fundamentals が Vercel 本番デプロイ完了、24 anchor（Part A 15 / Part B 9）を付与済み。Matlens 側の glossaryMapping.ts を 24 件に拡張し pending フラグを全解除しました。URL 規約は RFC 3986 理由で <base>#/chapter/<id>/<term>（slash 区切り）に確定、ADR-013 を Minor Revision で更新し Accepted 化。ADR-014「monorepo 統合実行計画」を草稿し、判断点 4 件の決定内容を固定化しました。',
+  },
+  {
     id: '2026-04-23-adr-013-url-contract',
     date: '2026-04-23',
     type: 'info',

--- a/src/data/glossaryMapping.test.ts
+++ b/src/data/glossaryMapping.test.ts
@@ -8,8 +8,8 @@ import {
 } from './glossaryMapping';
 
 describe('glossaryMapping', () => {
-  it('contains at least the 20 terms agreed with peer', () => {
-    expect(GLOSSARY_MAPPINGS.length).toBeGreaterThanOrEqual(20);
+  it('contains at least the 24 anchors delivered by peer (2026-04-23)', () => {
+    expect(GLOSSARY_MAPPINGS.length).toBeGreaterThanOrEqual(24);
   });
 
   it('all terms have unique termId', () => {
@@ -25,11 +25,13 @@ describe('glossaryMapping', () => {
   });
 
   describe('urlForTerm', () => {
-    it('builds the agreed URL shape <base>#/chapter/<id>#<term-id>', () => {
-      expect(urlForTerm('VB')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8#VB`);
-      expect(urlForTerm('Taylor')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8#Taylor`);
-      expect(urlForTerm('SLD')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/10#SLD`);
-      expect(urlForTerm('atom')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/a1#atom`);
+    it('builds the agreed URL shape <base>#/chapter/<id>/<term-id> (slash separator)', () => {
+      // 2026-04-23: peer が RFC 3986 §3.5 理由で slash 形式に確定。ADR-013 Minor Revision 参照
+      expect(urlForTerm('VB')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8/VB`);
+      expect(urlForTerm('Taylor')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/8/Taylor`);
+      expect(urlForTerm('SLD')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/10/SLD`);
+      expect(urlForTerm('atom')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/a1/atom`);
+      expect(urlForTerm('chatter')).toBe(`${MACHINING_FUNDAMENTALS_BASE_URL}#/chapter/10/chatter`);
     });
 
     it('falls back to base URL for unknown termId (peer guarantees home fallback)', () => {
@@ -37,7 +39,7 @@ describe('glossaryMapping', () => {
     });
 
     it('accepts a custom base URL (for staging / fixture)', () => {
-      expect(urlForTerm('VB', 'https://example.test/')).toBe('https://example.test/#/chapter/8#VB');
+      expect(urlForTerm('VB', 'https://example.test/')).toBe('https://example.test/#/chapter/8/VB');
     });
   });
 
@@ -49,15 +51,11 @@ describe('glossaryMapping', () => {
   });
 
   describe('isPendingTerm', () => {
-    it('returns true for pending anchors (Part A not yet published)', () => {
-      expect(isPendingTerm('metallic-bond')).toBe(true);
-      expect(isPendingTerm('dislocation')).toBe(true);
-    });
-
-    it('returns false for already-published anchors', () => {
-      expect(isPendingTerm('VB')).toBe(false);
-      expect(isPendingTerm('Taylor')).toBe(false);
-      expect(isPendingTerm('atom')).toBe(false); // A1 は公開済と peer が報告
+    // 2026-04-23: peer が Part A 全章 + 補強完了、pending フラグは全解除済
+    it('returns false for all anchors currently in mapping (all 24 delivered)', () => {
+      for (const m of GLOSSARY_MAPPINGS) {
+        expect(isPendingTerm(m.termId)).toBe(false);
+      }
     });
 
     it('returns false for unknown term', () => {

--- a/src/data/glossaryMapping.ts
+++ b/src/data/glossaryMapping.ts
@@ -1,10 +1,15 @@
 // machining-fundamentals（金属加工学習アプリ）への用語リンクマッピング。
 //
-// ADR-012（親密化統合戦略）の Phase 1 実装。URL 規約は peer と合意済:
-//   <base>#/chapter/<id>[#<term-id>]
+// ADR-012（親密化統合戦略）の Phase 1 実装。
 //
-// peer (yilmogxd) から提供された初期 20 件 + Matlens 側で追加登録したい候補。
-// base URL は deploy 確定後に MACHINING_FUNDAMENTALS_BASE_URL で切替可能に。
+// URL 規約は peer と合意済（2026-04-23 確定、ADR-013 Minor Revision に反映）:
+//   <base>#/chapter/<id>            章 URL
+//   <base>#/chapter/<id>/<term-id>  章内用語 anchor（/ 区切り）
+//
+// 当初提案の <base>#/chapter/<id>#<term-id> は RFC 3986 §3.5 違反のため廃案。
+// hash は 1 つしか持てず parser が複雑化するため、path-style の / 区切りに変更。
+//
+// base URL は deploy 確定後に MACHINING_FUNDAMENTALS_BASE_URL で切替可能。
 
 export const MACHINING_FUNDAMENTALS_BASE_URL =
   'https://machining-fundamentals.vercel.app/';
@@ -21,23 +26,28 @@ export interface GlossaryMapping {
   pending?: boolean;
 }
 
-// 初期 20 件（peer 提供）+ Matlens 側で追加登録したい候補（pending:true）
+// peer から 2026-04-23 に anchor 24 件付与完了の通知を受領。
+// 以下は全て動作確認済、即時参照可能。
+// Part C1「金属加工研究の実例集」も追加されたが、term-id 単位ではなく章単位参照。
 export const GLOSSARY_MAPPINGS: GlossaryMapping[] = [
-  // Part A（材料科学）— peer 執筆中。pending:true のものは anchor 確定後に false に戻す
+  // Part A（材料科学）— peer が A1〜A6 全章 + 補強完了、全 anchor 動作確認済
   { termId: 'atom', ja: '原子', en: 'Atom', chapterRef: 'a1', anchor: 'atom', levelHint: 'beginner' },
   { termId: 'valence', ja: '価電子', en: 'Valence electron', chapterRef: 'a1', anchor: 'valence', levelHint: 'beginner' },
-  { termId: 'metallic-bond', ja: '金属結合', en: 'Metallic bond', chapterRef: 'a2', anchor: 'metallic-bond', levelHint: 'beginner', pending: true },
-  { termId: 'fcc', ja: 'FCC 結晶', en: 'FCC crystal', chapterRef: 'a3', anchor: 'fcc', levelHint: 'intermediate', pending: true },
-  { termId: 'bcc', ja: 'BCC 結晶', en: 'BCC crystal', chapterRef: 'a3', anchor: 'bcc', levelHint: 'intermediate', pending: true },
-  { termId: 'hcp', ja: 'HCP 結晶', en: 'HCP crystal', chapterRef: 'a3', anchor: 'hcp', levelHint: 'intermediate', pending: true },
-  { termId: 'dislocation', ja: '転位', en: 'Dislocation', chapterRef: 'a4', anchor: 'dislocation', levelHint: 'intermediate', pending: true },
-  { termId: 'slip-system', ja: 'すべり系', en: 'Slip system', chapterRef: 'a4', anchor: 'slip-system', levelHint: 'intermediate', pending: true },
-  { termId: 'work-hardening', ja: '加工硬化', en: 'Work hardening', chapterRef: 'a4', anchor: 'work-hardening', levelHint: 'intermediate', pending: true },
-  { termId: 'phase-diagram', ja: '状態図', en: 'Phase diagram', chapterRef: 'a5', anchor: 'phase-diagram', levelHint: 'intermediate', pending: true },
-  { termId: 'johnson-cook', ja: 'Johnson-Cook 構成式', en: 'Johnson-Cook constitutive equation', chapterRef: 'a6', anchor: 'johnson-cook', levelHint: 'advanced', pending: true },
-  { termId: 'shear-band', ja: 'せん断帯', en: 'Shear band', chapterRef: 'a6', anchor: 'shear-band', levelHint: 'advanced', pending: true },
+  { termId: 'metallic-bond', ja: '金属結合', en: 'Metallic bond', chapterRef: 'a2', anchor: 'metallic-bond', levelHint: 'beginner' },
+  { termId: 'thermal-conductivity', ja: '熱伝導率', en: 'Thermal conductivity', chapterRef: 'a2', anchor: 'thermal-conductivity', levelHint: 'beginner' },
+  { termId: 'fcc', ja: 'FCC 結晶', en: 'FCC crystal', chapterRef: 'a3', anchor: 'fcc', levelHint: 'intermediate' },
+  { termId: 'bcc', ja: 'BCC 結晶', en: 'BCC crystal', chapterRef: 'a3', anchor: 'bcc', levelHint: 'intermediate' },
+  { termId: 'hcp', ja: 'HCP 結晶', en: 'HCP crystal', chapterRef: 'a3', anchor: 'hcp', levelHint: 'intermediate' },
+  { termId: 'dislocation', ja: '転位', en: 'Dislocation', chapterRef: 'a4', anchor: 'dislocation', levelHint: 'intermediate' },
+  { termId: 'slip-system', ja: 'すべり系', en: 'Slip system', chapterRef: 'a4', anchor: 'slip-system', levelHint: 'intermediate' },
+  { termId: 'work-hardening', ja: '加工硬化', en: 'Work hardening', chapterRef: 'a4', anchor: 'work-hardening', levelHint: 'intermediate' },
+  { termId: 'phase-diagram', ja: '状態図', en: 'Phase diagram', chapterRef: 'a5', anchor: 'phase-diagram', levelHint: 'intermediate' },
+  { termId: 'martensite', ja: 'マルテンサイト', en: 'Martensite', chapterRef: 'a5', anchor: 'martensite', levelHint: 'intermediate' },
+  { termId: 'precipitation-hardening', ja: '析出強化', en: 'Precipitation hardening', chapterRef: 'a5', anchor: 'precipitation-hardening', levelHint: 'intermediate' },
+  { termId: 'johnson-cook', ja: 'Johnson-Cook 構成式', en: 'Johnson-Cook constitutive equation', chapterRef: 'a6', anchor: 'johnson-cook', levelHint: 'advanced' },
+  { termId: 'shear-band', ja: 'せん断帯', en: 'Shear band', chapterRef: 'a6', anchor: 'shear-band', levelHint: 'advanced' },
 
-  // Part B（切削工学）— 既存章
+  // Part B（切削工学）— 既存 10 章に anchor 付与済
   { termId: 'Vc', ja: '切削速度', en: 'Cutting speed', symbol: 'Vc', chapterRef: '3', anchor: 'Vc', levelHint: 'beginner' },
   { termId: 'f', ja: '送り', en: 'Feed per revolution', symbol: 'f', chapterRef: '3', anchor: 'f', levelHint: 'beginner' },
   { termId: 'ap', ja: '切込み深さ', en: 'Depth of cut', symbol: 'ap', chapterRef: '3', anchor: 'ap', levelHint: 'beginner' },
@@ -45,17 +55,19 @@ export const GLOSSARY_MAPPINGS: GlossaryMapping[] = [
   { termId: 'VB', ja: '逃げ面摩耗', en: 'Flank wear width', symbol: 'VB', chapterRef: '8', anchor: 'VB', levelHint: 'intermediate' },
   { termId: 'Taylor', ja: 'Taylor 工具寿命式', en: 'Taylor tool-life equation', symbol: 'V·T^n=C', chapterRef: '8', anchor: 'Taylor', levelHint: 'intermediate' },
   { termId: 'Ra', ja: '算術平均粗さ', en: 'Arithmetic mean roughness', symbol: 'Ra', chapterRef: '9', anchor: 'Ra', levelHint: 'beginner' },
+  { termId: 'chatter', ja: 'びびり振動', en: 'Chatter', chapterRef: '10', anchor: 'chatter', levelHint: 'intermediate' },
   { termId: 'SLD', ja: 'Stability Lobe', en: 'Stability Lobe Diagram', symbol: 'blim(n)', chapterRef: '10', anchor: 'SLD', levelHint: 'advanced' },
 ];
 
 /**
  * 用語 ID から machining-fundamentals の完全 URL を生成。
+ * URL 形式は <base>#/chapter/<id>/<term>（slash 区切り）。
  * 不明 ID はホーム URL を返す（peer 側で未知 id はホームフォールバックする設計）。
  */
 export function urlForTerm(termId: string, base = MACHINING_FUNDAMENTALS_BASE_URL): string {
   const mapping = GLOSSARY_MAPPINGS.find((m) => m.termId === termId);
   if (!mapping) return base;
-  return `${base}#/chapter/${mapping.chapterRef}#${mapping.anchor}`;
+  return `${base}#/chapter/${mapping.chapterRef}/${mapping.anchor}`;
 }
 
 /**


### PR DESCRIPTION
## 概要
peer (yilmogxd) からの大型アップデート（Vercel deploy 完了・24 anchor 付与・ADR-013 全項目合意・monorepo 判断点 4 件推奨）を Matlens 側に反映する。以下 3 本の変更をまとめた PR:

## 変更 1: ADR-014「monorepo 統合の実行計画」起票（Proposed）

peer 側 \`docs/monorepo-decisions.md\` の推奨方針を受け、判断点 4 件の決定内容を実行計画として固定化。

- **判断 1 ADR 再採番**: ADR-MAT-* / ADR-LRN-* / ADR-COM-* のプレフィックス分離、統合時に一括改名
- **判断 2 デザイントークン**: \`@mc/ui-tokens-base\` + \`@mc/ui-tokens-matlens\` の 2 階層
- **判断 3 ライセンス**: SPDX パッケージ別、計算/データ/UI は MIT、教育コンテンツは CC BY 4.0
- **判断 4 npm 公開**: GitHub Packages private → 安定後に 4 package（glossary / math-cutting / standards / viz-svg）を npm public

monorepo ディレクトリ構造・移行スケジュール（Phase 4-A 〜 4-E）・breaking change 予告一覧・リスクと rollback 計画を含む。

## 変更 2: ADR-013 Minor Revision #1 — URL 規約の slash 確定

- 当初提案の \`<base>#/chapter/<id>#<term-id>\` は **RFC 3986 §3.5 に基づき無効**（URL に \`#\` は 1 つまで）
- peer 側実装で \`<base>#/chapter/<id>/<term-id>\`（slash 区切り）に変更済、2026-04-23 に Matlens 側も合意
- ステータスを Proposed → **Accepted** へ
- 改訂履歴表を追加、初期合意形成中の規約修正として予告期間は不要と判断

## 変更 3: glossaryMapping.ts 拡張 — 24 anchor 全反映

- peer が Part A 全章 + 補強完了、24 anchor を動作確認済として配信
- `pending: true` フラグは全解除（12 件 → 0 件）
- 新 anchor 4 件を追加: \`thermal-conductivity\` / \`martensite\` / \`precipitation-hardening\` / \`chatter\`
- 既存 20 件 → **24 件** に拡張
- \`urlForTerm\` 関数の形式を \`/\` に修正
- テスト 9 件 green（期待値を新 URL 形式に更新、全 anchor が non-pending の網羅確認を追加）

## 連動更新 (ADR-007)
- \`docs/adr/README.md\` に ADR-014 を追記、ADR-013 のステータスを Accepted へ
- \`announcements.ts\` に feature 型で告知

## 次のアクション
- peer 側に ADR-014 のコピー配置依頼（本 PR merge 後に peer へ共有）
- UI 側の「詳しく学ぶ」ボタン実装（別 PR、ツールチップ / ヘルプパネルへの link 埋込）
- CI の dead link チェック実装（Phase 4-A）

## テスト計画
- [x] typecheck pass
- [x] glossaryMapping.test.ts 9/9 passed
- [x] URL 形式の機械的整合（slash 区切り）
- [ ] peer 側に共有してフィードバック受領