### PR TITLE
docs(adr): ADR-012 / ADR-014 を Accepted に昇格（両 repo 同時合意）

### DIFF
--- a/docs/adr/ADR-012-machining-fundamentals-integration.md
+++ b/docs/adr/ADR-012-machining-fundamentals-integration.md
@@ -1,9 +1,16 @@
 # ADR-012: machining-fundamentals との親密化統合戦略
 
-- ステータス: **Proposed**（peer と合意途中、user 方針確認済）
-- 日付: 2026-04-23
+- ステータス: **Accepted**（2026-04-23 両 repo で合意、Phase 1 実装で実証済）
+- 日付: 2026-04-23（初版 Proposed → 同日 Accepted 昇格）
 - 関連 peer / PR: `~/dev/Asagiri/Metal/machining-fundamentals`（GitHub: BoxPistols/machining-fundamentals）
-- 関連 ADR: ADR-001 / ADR-002 / ADR-005 / ADR-009
+- 関連 ADR: ADR-001 / ADR-002 / ADR-005 / ADR-009 / ADR-013 / ADR-014
+
+## 改訂履歴
+
+| バージョン | 日付 | 変更点 |
+|---|---|---|
+| 初版 Proposed | 2026-04-23 | 親密化レベル 3 目標、相互リンク戦略 5 パターン、Phase 0〜4 の草稿 |
+| Accepted 昇格 | 2026-04-23 | Phase 1 実装（PR #74）で 4 画面 learnMore が peer 配信の 24 anchor を実参照可能になったことで、戦略の技術的実証が完了。peer 側も同日同意。両 repo 同時昇格 |
 
 ---
 

--- a/docs/adr/ADR-014-monorepo-integration-execution-plan.md
+++ b/docs/adr/ADR-014-monorepo-integration-execution-plan.md
@@ -1,9 +1,16 @@
 # ADR-014: monorepo 統合の実行計画
 
-- ステータス: **Proposed**（peer 側でも同内容を配置予定）
-- 日付: 2026-04-23
+- ステータス: **Accepted**（2026-04-23 peer 側 owner 承認、両 repo 同時合意）
+- 日付: 2026-04-23（初版 Proposed → 同日 Accepted 昇格）
 - 関連 ADR: ADR-012（戦略）/ ADR-013（運用規約）
-- 関連 peer / repo: `BoxPistols/machining-fundamentals` の `docs/monorepo-decisions.md`
+- 関連 peer / repo: `BoxPistols/machining-fundamentals/docs/adr/ADR-COM-014-monorepo-integration-execution-plan.md`（peer 側コピー、263 行完全一致）
+
+## 改訂履歴
+
+| バージョン | 日付 | 変更点 |
+|---|---|---|
+| 初版 Proposed | 2026-04-23 | 判断点 4 件の決定、monorepo ディレクトリ構造、Phase 4-A 〜 4-E 移行スケジュール、Rollback 計画を起票 |
+| Accepted 昇格 | 2026-04-23 | peer 側 owner が ALL OK 承認、ADR-COM-014 として peer repo にコピー配置済。両 repo 同時昇格 |
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,8 +52,8 @@ implementation details — those belong in commit messages.
 | [ADR-009](./ADR-009-pure-svg-zero-dependency-visualization.md) | 可視化は純 SVG + 依存ゼロ（chart ライブラリ不採用） | Accepted |
 | [ADR-010](./ADR-010-stage2-aggregation-endpoints.md) | 集計 / 横断検索エンドポイントを Stage 2 で REST へ切り出す | Accepted |
 | [ADR-011](./ADR-011-testing-strategy.md) | テスト戦略（Vitest + 純関数 + 決定論的 fixture） | Accepted |
-| [ADR-012](./ADR-012-machining-fundamentals-integration.md) | machining-fundamentals との親密化統合戦略 | Proposed |
+| [ADR-012](./ADR-012-machining-fundamentals-integration.md) | machining-fundamentals との親密化統合戦略 | Accepted |
 | [ADR-013](./ADR-013-url-contract-and-terminology-ownership.md) | URL 規約・用語 ownership・更新ポリシー（親密化の運用規約） | Accepted |
-| [ADR-014](./ADR-014-monorepo-integration-execution-plan.md) | monorepo 統合の実行計画（判断点 4 件の決定 + Phase 4 詳細） | Proposed |
+| [ADR-014](./ADR-014-monorepo-integration-execution-plan.md) | monorepo 統合の実行計画（判断点 4 件の決定 + Phase 4 詳細） | Accepted |
 
 [nygard]: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-23-adr-012-014-accepted',
+    date: '2026-04-23',
+    type: 'info',
+    title: 'ADR-012 親密化戦略 + ADR-014 monorepo 実行計画を Accepted に昇格',
+    body: 'peer 側 owner の ALL OK 承認と peer repo への ADR-COM-014 コピー配置（263 行完全一致）を受け、ADR-012（親密化戦略）と ADR-014（monorepo 統合の実行計画）を両 repo 同時に Accepted に昇格しました。Phase 1 実装（PR #74）で 4 画面 learnMore が 24 anchor を実参照できる状態が、戦略の技術的実証として機能。これで ADR-012/013/014 の 3 本構成（戦略・運用規約・実行計画）が固定化され、Phase 4-A（2026-06 開始見込み）まで設計議論は一段落します。',
+  },
+  {
     id: '2026-04-23-learning-anchors-finalized',
     date: '2026-04-23',
     type: 'feature',


### PR DESCRIPTION
## 概要
peer 側 owner の ALL OK 承認と ADR-COM-014 のコピー配置（263 行完全一致）を受け、ADR-012 と ADR-014 を両 repo 同時に Accepted に昇格する。

## 昇格判定の根拠

### ADR-012「親密化統合戦略」→ Accepted
- **Phase 1 実装（PR #74）で 4 画面 learnMore が peer 配信の 24 anchor を実参照できる状態**
- 戦略レベル（レベル 3: 相互参照で強結合）の技術的実証が完了
- peer も 2026-04-23 に同意表明

### ADR-014「monorepo 統合の実行計画」→ Accepted
- peer 側 owner の ALL OK 承認
- peer repo に ADR-COM-014 として 263 行完全一致のコピー配置済
  - https://github.com/BoxPistols/machining-fundamentals/tree/main/docs/adr
- 判断点 4 件（ADR 再採番 / デザイントークン / ライセンス / npm 公開）の両 repo 一致

## 状態整理（今後の運用）

これで ADR-012 / 013 / 014 の 3 本構成が固定化:

| ADR | 役割 | ステータス |
|-----|------|-----------|
| ADR-012 | 親密化戦略（ビジョン・レベル定義） | Accepted |
| ADR-013 | 運用規約（URL / 用語 master / 予告期間 / dead link） | Accepted |
| ADR-014 | 実行計画（monorepo 構造・Phase 4 移行） | Accepted |

Phase 4-A 開始（2026-06 見込み）まで、親密化の設計議論は一段落。
以降は実装タスク（UI 側の「詳しく学ぶ」ボタン / CI dead link チェック / Part B 拡充との連動）に集中。

## 連動更新 (ADR-007)
- 両 ADR に改訂履歴表を追加、Accepted 判定の根拠を明記
- docs/adr/README.md のステータス列を更新
- announcements.ts に info 型で告知

## テスト計画
- [x] typecheck pass
- [x] ドキュメントのみ