### PR TITLE
feat(help): ヘルプのページガイドに外部学習サイトへのリンクを表示

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -6,7 +6,7 @@ import {
   Square, RefreshCw, Play, Sparkles, Share2, AlertTriangle,
   Info, Filter, ArrowDownWideNarrow, FileText, Braces, FileSpreadsheet, ClipboardList,
   Sun, ScanLine, Workflow, Atom,
-  Bot, Send, PanelRight,
+  Bot, Send, PanelRight, ExternalLink,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -18,7 +18,7 @@ export type IconName =
   | 'stop' | 'refresh' | 'play' | 'spark' | 'embed' | 'warning'
   | 'info' | 'filter' | 'sort' | 'pdf' | 'json' | 'csv' | 'report'
   | 'ai' | 'scan'
-  | 'bot' | 'send' | 'panelRight'
+  | 'bot' | 'send' | 'panelRight' | 'external'
   | 'workflow' | 'atom';
 
 const ICON_MAP: Record<IconName, LucideIcon> = {
@@ -62,6 +62,7 @@ const ICON_MAP: Record<IconName, LucideIcon> = {
   bot:          Bot,
   send:         Send,
   panelRight:   PanelRight,
+  external:     ExternalLink,
   workflow:     Workflow,
   atom:         Atom,
 };

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-23-help-learn-more-links',
+    date: '2026-04-23',
+    type: 'feature',
+    title: 'ヘルプの「ページガイド」に金属加工の基礎解説サイトへのリンクを追加',
+    body: 'ヘルプ画面の「ページガイド」タブで表示される各画面解説に、金属加工の基礎（原子・結晶構造・転位・切削条件・工具摩耗・安定性ローブ等）を解説する外部サイトへのリンクを追加しました。切削条件エクスプローラ・工具ライフトラッカー・材料マスタ・受託試験ダッシュボードの 4 画面で、登場する専門用語（VB / Taylor / Kc / Vc / f / ap 等）を深掘りできます。リンクは新しいタブで開きます。',
+  },
+  {
     id: '2026-04-20-cutting-sim-ui',
     date: '2026-04-20',
     type: 'feature',

--- a/src/pages/Help/HelpPage.tsx
+++ b/src/pages/Help/HelpPage.tsx
@@ -6,6 +6,7 @@ import { AppCtx } from '../../context/AppContext';
 import type { AppContextValue } from '../../types';
 import { HELP_TERMS, PAGE_GUIDES } from '../../data/constants';
 import type { PageGuide } from '../../data/constants';
+import { urlForChapter, urlForTerm } from '../../data/glossaryMapping';
 
 /* ---------- ページガイド専用ビュー ---------- */
 
@@ -58,6 +59,38 @@ const PageGuideSection = ({
               {g.tips.map((tip, i) => <li key={i}>{tip}</li>)}
             </ul>
           </div>
+
+          {/* 詳しく学ぶ: 金属加工の基礎解説サイトへの外部リンク */}
+          {g.learnMore && g.learnMore.length > 0 && (
+            <div>
+              <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">
+                詳しく学ぶ
+              </div>
+              <p className="text-[12px] text-text-lo mb-1.5">
+                画面で扱う概念を金属加工の基礎解説サイトで学べます（外部リンク・新しいタブで開きます）。
+              </p>
+              <ul className="flex flex-col gap-1">
+                {g.learnMore.map((link, i) => {
+                  const href = link.termId
+                    ? urlForTerm(link.termId)
+                    : urlForChapter(link.chapterRef);
+                  return (
+                    <li key={i}>
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-accent hover:underline text-[13px]"
+                      >
+                        <Icon name="external" size={12} />
+                        <span>{link.label}</span>
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
 
           {/* Footer: 関連ページ + 遷移ボタン */}
           <div className="flex items-center justify-between gap-4 pt-1 flex-wrap">


### PR DESCRIPTION
## 概要
PR #74 で仕込んだ `learnMore` データを、実際にヘルプ画面に露出する。UI レベルで閲覧者に伝わる変化が出る PR。

## 変更内容

### `src/pages/Help/HelpPage.tsx`
PageGuideSection の「操作のヒント」と「関連ページ」の間に **「詳しく学ぶ」セクション** を追加。
- `g.learnMore` 配列があれば表示、なければセクション自体を描画しない
- 各リンクは `urlForTerm()` / `urlForChapter()` で URL 生成
- `target="_blank" rel="noopener noreferrer"` で新しいタブ
- external アイコン + ラベルの箇条書き

### `src/components/Icon/Icon.tsx`
`external` アイコンを追加（lucide-react の `ExternalLink`）。

### `src/data/announcements.ts`
ヘルプに学習サイトリンクが表示されるようになったことを feature 型で告知。**今度は実際に画面に出る変化** なので告知の正当性あり。

## UI で確認できる変化
ヘルプ → 「ページガイド」タブで以下の 4 画面のガイドに「詳しく学ぶ」ボタンが表示される:

| 画面 | リンク先 |
|---|---|
| 受託試験ダッシュボード | 金属加工の基礎（序章） |
| 工具ライフトラッカー | VB（逃げ面摩耗）/ Taylor 工具寿命式 |
| 切削条件エクスプローラ | Vc / f / ap / Kc / Stability Lobe |
| 材料マスタ | 原子 / 結晶構造 / 相変態 |

クリックすると外部サイト（`https://machining-fundamentals.vercel.app/#/chapter/<id>/<term>`）が新しいタブで開く。

## テスト計画
- [x] typecheck pass
- [x] Icon コンポーネント 42/42 テスト pass
- [x] PR #76 で追加した glossaryMapping.test.ts 9/9 テスト pass
- [ ] レビュー時にブラウザで Help 画面の「ページガイド」タブを開いて確認

## 親密化戦略（ADR-012）Phase 1 の伏線回収
- PR #74: `learnMore` データを PAGE_GUIDES に追加（UI 露出なし）
- PR #76: 24 anchor の URL マッピング整備（データのみ）
- **本 PR**: データを UI に露出 ← ここでユーザーが実際に使える状態に

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ヘルプページのガイドに「詳しく学ぶ」セクションを追加。専門用語や関連情報への外部リンクに素早くアクセスできるようになりました
  * 外部リンク表示用の新しいアイコンを追加
  * 新機能に関する告知がお知らせセクションに表示されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->