### PR TITLE
refactor(help): 詳しく学ぶリンクの a11y と key を補強 + テスト追加

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -71,9 +71,11 @@ interface IconProps {
   name: IconName;
   size?: number;
   className?: string;
+  /** 装飾用途でスクリーンリーダーから隠す場合に true。親要素で意味を伝えているときに使う */
+  ariaHidden?: boolean;
 }
 
-export const Icon = ({ name, size = 16, className = '' }: IconProps) => {
+export const Icon = ({ name, size = 16, className = '', ariaHidden = false }: IconProps) => {
   const LucideComponent = ICON_MAP[name];
   if (!LucideComponent) return null;
   return (
@@ -81,6 +83,7 @@ export const Icon = ({ name, size = 16, className = '' }: IconProps) => {
       size={size}
       className={`inline-flex flex-shrink-0 ${className}`}
       strokeWidth={1.75}
+      aria-hidden={ariaHidden || undefined}
     />
   );
 };

--- a/src/pages/Help/HelpPage.test.tsx
+++ b/src/pages/Help/HelpPage.test.tsx
@@ -65,4 +65,25 @@ describe('HelpPage', () => {
     fireEvent.click(openButtons[0]!);
     expect(onNav).toHaveBeenCalledWith('dash');
   });
+
+  it('renders "詳しく学ぶ" section for guides with learnMore links', () => {
+    setup();
+    fireEvent.click(screen.getByRole('tab', { name: 'ページガイド' }));
+    // PAGE_GUIDES に learnMore が設定されている画面（cutting-conditions / tools / mat-master / ops-dash）
+    // のいずれかで「詳しく学ぶ」セクションが表示される
+    expect(screen.getAllByText('詳しく学ぶ').length).toBeGreaterThan(0);
+  });
+
+  it('learn-more links open machining-fundamentals in a new tab with proper rel', () => {
+    setup();
+    fireEvent.click(screen.getByRole('tab', { name: 'ページガイド' }));
+    // Vc / f / ap のリンク（切削条件エクスプローラの learnMore エントリ）は
+    // 必ず存在する — glossaryMapping で動作確認済み
+    const links = screen.getAllByRole('link', { name: /外部サイトで開きます/ });
+    expect(links.length).toBeGreaterThan(0);
+    const firstLink = links[0]!;
+    expect(firstLink.getAttribute('target')).toBe('_blank');
+    expect(firstLink.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(firstLink.getAttribute('href')).toContain('machining-fundamentals');
+  });
 });

--- a/src/pages/Help/HelpPage.tsx
+++ b/src/pages/Help/HelpPage.tsx
@@ -74,15 +74,17 @@ const PageGuideSection = ({
                   const href = link.termId
                     ? urlForTerm(link.termId)
                     : urlForChapter(link.chapterRef);
+                  const key = link.termId ?? `chapter-${link.chapterRef}-${i}`;
                   return (
-                    <li key={i}>
+                    <li key={key}>
                       <a
                         href={href}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`${link.label}（外部サイトで開きます）`}
                         className="inline-flex items-center gap-1 text-accent hover:underline text-[13px]"
                       >
-                        <Icon name="external" size={12} />
+                        <Icon name="external" size={12} ariaHidden />
                         <span>{link.label}</span>
                       </a>
                     </li>


### PR DESCRIPTION
## 概要
PR #79 後の自己レビューで指摘した 3 点（a11y / key 安定化 / テスト欠落）を解消するフォロー PR。

## 変更内容

### `src/components/Icon/Icon.tsx`
- `ariaHidden?: boolean` prop を追加
- 装飾用途（テキストで意味が伝わっている場面）でスクリーンリーダーから隠す

### `src/pages/Help/HelpPage.tsx`
- 外部リンクに `aria-label="{label}（外部サイトで開きます）"` を付与
- `<Icon name="external" size={12} ariaHidden />` に変更（冗長な SR 読み上げ抑制）
- `key` を `i` から `link.termId ?? \`chapter-\${link.chapterRef}-\${i}\`` の安定値に変更

### `src/pages/Help/HelpPage.test.tsx`
テスト 2 件追加:
1. ページガイドタブで「詳しく学ぶ」セクションが表示されること
2. 外部リンクに `target="_blank"` / `rel="noopener noreferrer"` / `machining-fundamentals` を含む `href` が設定されていること

## 国際化は別 issue として切り出す
PR #79 の /review で `labelEn` 未活用を High として指摘したが、実際には PageGuideSection 全体が `summary` / `features` / `tips` も日本語 hardcode で、`summaryEn` 等も未使用。**PageGuideSection 全体の国際化** は個別対応より scope が広いので、別 issue で一括対応する方針。

## テスト計画
- [x] typecheck pass
- [x] 関連 3 テストファイル（Help / Icon / glossaryMapping）59/59 pass
- [x] 既存テスト破壊なし（Icon 42 / HelpPage 既存 6 + 新規 2 / glossaryMapping 9）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * アイコンと外部リンクのアクセシビリティを改善しました。スクリーンリーダーの対応が向上し、外部リンクが新しいタブで開くことを明確に表示するようになります。

* **テスト**
  * ガイドセクションと外部リンク機能のテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->