### PR TITLE
feat(help): ページガイドを日英切替に対応

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-23-help-page-guide-i18n',
+    date: '2026-04-23',
+    type: 'feature',
+    title: 'ヘルプのページガイドを日英切替に対応',
+    body: 'トップバーの JP/EN 切替で、ヘルプ画面のページガイドタブ（概要・できること・操作のヒント・詳しく学ぶ・関連ページ・このページを開く）が日本語 / 英語で切り替わるようになりました。各画面の説明本文・機能一覧・操作ヒントも、登録済みの英語表現がある場合は英語で表示されます。海外メンバーとの共有時に活用できます。',
+  },
+  {
     id: '2026-04-23-help-learn-more-links',
     date: '2026-04-23',
     type: 'feature',

--- a/src/pages/Help/HelpPage.test.tsx
+++ b/src/pages/Help/HelpPage.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AppCtx } from '../../context/AppContext';
 
 import { HelpPage } from './HelpPage';
-import { renderWithContext } from '../../test/helpers';
+import { renderWithContext, mockContext } from '../../test/helpers';
 
 describe('HelpPage', () => {
   const onNav = vi.fn();
@@ -85,5 +86,26 @@ describe('HelpPage', () => {
     expect(firstLink.getAttribute('target')).toBe('_blank');
     expect(firstLink.getAttribute('rel')).toBe('noopener noreferrer');
     expect(firstLink.getAttribute('href')).toContain('machining-fundamentals');
+  });
+
+  it('renders English labels when lang is switched to en', () => {
+    // lang='en' のカスタムコンテキストで render
+    const enContext = {
+      ...mockContext,
+      lang: 'en' as const,
+      t: (_ja: string, en?: string) => en ?? _ja,
+    };
+    render(
+      <AppCtx.Provider value={enContext}>
+        <HelpPage onNav={onNav} />
+      </AppCtx.Provider>,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Page Guide' }));
+    // セクション見出しが英語になる
+    expect(screen.getAllByText('Overview').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Features').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Tips').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Learn More').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Open this page').length).toBeGreaterThan(0);
   });
 });

--- a/src/pages/Help/HelpPage.tsx
+++ b/src/pages/Help/HelpPage.tsx
@@ -19,119 +19,129 @@ const PageGuideSection = ({
 }: {
   guides: PageGuide[];
   onNav?: (page: string) => void;
-}) => (
-  <div className="flex flex-col gap-5">
-    {guides.map(g => (
-      <div key={g.id} className="rounded-xl border border-[var(--border-default)] bg-surface overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center gap-3 px-5 pt-4 pb-3">
-          <div className="w-9 h-9 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0">
-            <Icon name={g.icon as Parameters<typeof Icon>[0]['name']} size={18} className="text-accent" />
-          </div>
-          <div className="min-w-0">
-            <h3 className="text-[15px] font-bold text-text-hi leading-snug truncate">
-              {g.title} <span className="text-text-lo font-normal">/ {g.titleEn}</span>
-            </h3>
-          </div>
-        </div>
-
-        <div className="border-t border-[var(--border-faint)] mx-5" />
-
-        <div className="px-5 py-4 flex flex-col gap-4 text-[13px] leading-relaxed text-text-md">
-          {/* 概要 */}
-          <div>
-            <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">概要</div>
-            <p>{g.summary}</p>
+}) => {
+  const { t } = useContext(AppCtx) as AppContextValue;
+  return (
+    <div className="flex flex-col gap-5">
+      {guides.map(g => (
+        <div key={g.id} className="rounded-xl border border-[var(--border-default)] bg-surface overflow-hidden">
+          {/* Header */}
+          <div className="flex items-center gap-3 px-5 pt-4 pb-3">
+            <div className="w-9 h-9 rounded-lg bg-accent/10 flex items-center justify-center flex-shrink-0">
+              <Icon name={g.icon as Parameters<typeof Icon>[0]['name']} size={18} className="text-accent" />
+            </div>
+            <div className="min-w-0">
+              <h3 className="text-[15px] font-bold text-text-hi leading-snug truncate">
+                {g.title} <span className="text-text-lo font-normal">/ {g.titleEn}</span>
+              </h3>
+            </div>
           </div>
 
-          {/* できること */}
-          <div>
-            <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">できること</div>
-            <ul className="list-disc list-inside space-y-0.5">
-              {g.features.map((f, i) => <li key={i}>{f}</li>)}
-            </ul>
-          </div>
+          <div className="border-t border-[var(--border-faint)] mx-5" />
 
-          {/* 操作のヒント */}
-          <div>
-            <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">操作のヒント</div>
-            <ul className="list-disc list-inside space-y-0.5">
-              {g.tips.map((tip, i) => <li key={i}>{tip}</li>)}
-            </ul>
-          </div>
-
-          {/* 詳しく学ぶ: 金属加工の基礎解説サイトへの外部リンク */}
-          {g.learnMore && g.learnMore.length > 0 && (
+          <div className="px-5 py-4 flex flex-col gap-4 text-[13px] leading-relaxed text-text-md">
+            {/* 概要 */}
             <div>
-              <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">
-                詳しく学ぶ
-              </div>
-              <p className="text-[12px] text-text-lo mb-1.5">
-                画面で扱う概念を金属加工の基礎解説サイトで学べます（外部リンク・新しいタブで開きます）。
-              </p>
-              <ul className="flex flex-col gap-1">
-                {g.learnMore.map((link, i) => {
-                  const href = link.termId
-                    ? urlForTerm(link.termId)
-                    : urlForChapter(link.chapterRef);
-                  const key = link.termId ?? `chapter-${link.chapterRef}-${i}`;
-                  return (
-                    <li key={key}>
-                      <a
-                        href={href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`${link.label}（外部サイトで開きます）`}
-                        className="inline-flex items-center gap-1 text-accent hover:underline text-[13px]"
-                      >
-                        <Icon name="external" size={12} ariaHidden />
-                        <span>{link.label}</span>
-                      </a>
-                    </li>
-                  );
-                })}
+              <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">{t('概要', 'Overview')}</div>
+              <p>{t(g.summary, g.summaryEn)}</p>
+            </div>
+
+            {/* できること */}
+            <div>
+              <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">{t('できること', 'Features')}</div>
+              <ul className="list-disc list-inside space-y-0.5">
+                {g.features.map((f, i) => <li key={i}>{t(f, g.featuresEn[i] ?? f)}</li>)}
               </ul>
             </div>
-          )}
 
-          {/* Footer: 関連ページ + 遷移ボタン */}
-          <div className="flex items-center justify-between gap-4 pt-1 flex-wrap">
-            {g.related.length > 0 && (
-              <div className="text-[12px] text-text-lo">
-                関連ページ:{' '}
-                {g.related.map((rid, i) => {
-                  const label = GUIDE_TITLE_MAP[rid] ?? rid;
-                  return (
-                    <span key={rid}>
-                      {i > 0 && <span className="mx-1">|</span>}
-                      {onNav ? (
-                        <button
-                          className="text-accent hover:underline"
-                          onClick={() => onNav(rid)}
-                        >{label}</button>
-                      ) : (
-                        <span className="text-accent">{label}</span>
-                      )}
-                    </span>
-                  );
-                })}
+            {/* 操作のヒント */}
+            <div>
+              <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">{t('操作のヒント', 'Tips')}</div>
+              <ul className="list-disc list-inside space-y-0.5">
+                {g.tips.map((tip, i) => <li key={i}>{t(tip, g.tipsEn[i] ?? tip)}</li>)}
+              </ul>
+            </div>
+
+            {/* 詳しく学ぶ: 金属加工の基礎解説サイトへの外部リンク */}
+            {g.learnMore && g.learnMore.length > 0 && (
+              <div>
+                <div className="text-[12px] font-bold text-text-lo uppercase tracking-wider mb-1">
+                  {t('詳しく学ぶ', 'Learn More')}
+                </div>
+                <p className="text-[12px] text-text-lo mb-1.5">
+                  {t(
+                    '画面で扱う概念を金属加工の基礎解説サイトで学べます（外部リンク・新しいタブで開きます）。',
+                    'Learn the concepts in this page at the metal machining fundamentals site (external link, opens in a new tab).',
+                  )}
+                </p>
+                <ul className="flex flex-col gap-1">
+                  {g.learnMore.map((link, i) => {
+                    const href = link.termId
+                      ? urlForTerm(link.termId)
+                      : urlForChapter(link.chapterRef);
+                    const key = link.termId ?? `chapter-${link.chapterRef}-${i}`;
+                    const label = t(link.label, link.labelEn);
+                    return (
+                      <li key={key}>
+                        <a
+                          href={href}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={t(
+                            `${link.label}（外部サイトで開きます）`,
+                            `${link.labelEn} (opens in a new tab)`,
+                          )}
+                          className="inline-flex items-center gap-1 text-accent hover:underline text-[13px]"
+                        >
+                          <Icon name="external" size={12} ariaHidden />
+                          <span>{label}</span>
+                        </a>
+                      </li>
+                    );
+                  })}
+                </ul>
               </div>
             )}
-            {onNav && g.id !== 'help' && (
-              <button
-                className="ml-auto text-[12px] font-bold text-accent hover:underline flex items-center gap-1 flex-shrink-0"
-                onClick={() => onNav(g.id)}
-              >
-                このページを開く
-                <Icon name="chevronRight" size={12} />
-              </button>
-            )}
+
+            {/* Footer: 関連ページ + 遷移ボタン */}
+            <div className="flex items-center justify-between gap-4 pt-1 flex-wrap">
+              {g.related.length > 0 && (
+                <div className="text-[12px] text-text-lo">
+                  {t('関連ページ:', 'Related:')}{' '}
+                  {g.related.map((rid, i) => {
+                    const label = GUIDE_TITLE_MAP[rid] ?? rid;
+                    return (
+                      <span key={rid}>
+                        {i > 0 && <span className="mx-1">|</span>}
+                        {onNav ? (
+                          <button
+                            className="text-accent hover:underline"
+                            onClick={() => onNav(rid)}
+                          >{label}</button>
+                        ) : (
+                          <span className="text-accent">{label}</span>
+                        )}
+                      </span>
+                    );
+                  })}
+                </div>
+              )}
+              {onNav && g.id !== 'help' && (
+                <button
+                  className="ml-auto text-[12px] font-bold text-accent hover:underline flex items-center gap-1 flex-shrink-0"
+                  onClick={() => onNav(g.id)}
+                >
+                  {t('このページを開く', 'Open this page')}
+                  <Icon name="chevronRight" size={12} />
+                </button>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    ))}
-  </div>
-);
+      ))}
+    </div>
+  );
+};
 
 /* ---------- HelpPage ---------- */
 


### PR DESCRIPTION
## 概要
PR #80 の self-review で「`labelEn` 未活用」「`summaryEn` / `featuresEn` / `tipsEn` も hardcode」と指摘した件の **PageGuideSection 全体対応版**。既存の JP/EN 切替パターンを踏襲して一気に国際化する。

## 変更内容

### `src/pages/Help/HelpPage.tsx`
PageGuideSection を `useContext(AppCtx)` で `t` を取得する形に変更。以下を `t(ja, en)` で国際化:

**セクション見出し**:
- 「概要」→ "Overview"
- 「できること」→ "Features"
- 「操作のヒント」→ "Tips"
- 「詳しく学ぶ」→ "Learn More"
- 「関連ページ:」→ "Related:"
- 「このページを開く」→ "Open this page"

**本文**:
- `g.summary` → `t(g.summary, g.summaryEn)`
- `g.features[i]` → `t(f, g.featuresEn[i] ?? f)`（長さ不一致時に JP フォールバック）
- `g.tips[i]` → `t(tip, g.tipsEn[i] ?? tip)`
- `learnMore` の label / aria-label → 各 `labelEn` 使用
- 「画面で扱う概念を...」注釈 → 英語版あり

### `src/pages/Help/HelpPage.test.tsx`
- 既存テスト 8 件は影響なし（デフォルト JP コンテキスト）
- 新規: `lang='en'` カスタムコンテキストで render し、**Overview / Features / Tips / Learn More / Open this page** が英語で表示されることを確認するテスト追加

### `src/data/announcements.ts`
日英切替対応を feature 型で告知。

## 確認できる変化
トップバーの `JP` / `EN` 切替で、ヘルプ画面のページガイドタブの見出しと本文が日本語 / 英語で動的に切り替わる。海外メンバー共有時の実用価値あり。

## テスト計画
- [x] typecheck pass
- [x] HelpPage test 9/9 pass（新規 EN 切替テスト含む）
- [x] 既存 JP 表示テスト壊れていない
- [x] 既存 HelpPage 他の `t()` 使用箇所と一貫

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * お知らせに新しいアナウンスメントを追加しました。
  * ヘルプページのガイドセクションで英語対応を実装しました。セクションヘッダー、ガイド内容、リンク表記などが翻訳されるようになります。

* **テスト**
  * ヘルプページの多言語表示に対応するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->