### PR TITLE
feat(dashboard): 受託試験ダッシュボードに切削 KPI 2 種を追加（Phase 3.5 B-1）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-dashboard-cutting-kpi',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '受託試験ダッシュボードに切削 KPI を追加（工具寿命アラート / びびり検出率）',
+    body: 'ダッシュボードに 2 種類の切削 KPI を追加しました。工具寿命アラートは VB ≥ 0.3 mm（ISO 3685 仕上げ基準）を超過している工具の数を表示します。びびり検出率は過去 30 日の切削プロセスのうち、びびりが評価済み（true / false）なもの中の発生割合を示します。いずれも切削データがないときは表示されません。',
+  },
+  {
     id: '2026-04-23-help-page-guide-i18n',
     date: '2026-04-23',
     type: 'feature',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -668,12 +668,14 @@ export const PAGE_GUIDES: PageGuide[] = [
     summaryEn: 'PoC ops dashboard that summarizes project pipeline status via KPIs, due-risk list, and activity timeline.',
     features: [
       'KPI: 進行中案件数 / 期限 7 日以内の試験片 / 過去 30 日の完了試験 / 異常所見比率',
+      '切削 KPI: 工具寿命アラート（VB ≥ 0.3 mm 超過数）/ 過去 30 日のびびり検出率',
       '納期リスク一覧: dueAt <= +7 日 or 遅延 の進行中・レビュー中案件',
       '活動タイムライン: 完了試験と損傷所見登録を時系列降順で 20 件',
       '案件行クリックで案件詳細へ遷移',
     ],
     featuresEn: [
       'KPIs: active projects / specimens due in 7 days / completed tests in last 30 days / abnormal finding ratio',
+      'Cutting KPIs: tools over wear limit (VB ≥ 0.3 mm) / chatter detection ratio (last 30 days)',
       'Due-risk list: in-progress or reviewing projects with dueAt within 7 days or overdue',
       'Activity timeline: last 20 completed tests and damage findings in descending time order',
       'Click a project row to jump to its detail page',

--- a/src/features/dashboard/OpsDashboardPage.tsx
+++ b/src/features/dashboard/OpsDashboardPage.tsx
@@ -4,15 +4,18 @@
 import { useMemo } from 'react';
 import { KpiCard } from '@/components/molecules';
 import {
+  useAllCuttingProcesses,
   useAllDamages,
   useAllProjects,
   useAllSpecimens,
   useAllTests,
+  useAllTools,
   useCustomersIndex,
 } from './api';
 import {
   buildActivityTimeline,
   collectDueRisk,
+  computeCuttingKpi,
   computeOpsKpi,
 } from './utils/opsMetrics';
 
@@ -31,6 +34,9 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
   const specimensQ = useAllSpecimens();
   const testsQ = useAllTests();
   const damagesQ = useAllDamages();
+  // 切削 KPI 用。取得失敗でも受託試験側 KPI / 納期リスク / タイムラインはブロックしない設計。
+  const toolsQ = useAllTools();
+  const cuttingProcessesQ = useAllCuttingProcesses();
   // 顧客名はリスク行の表示のみに使う副次情報。取得失敗でもダッシュボード全体はブロックしない。
   const customersQ = useCustomersIndex();
 
@@ -59,6 +65,17 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
       now,
     });
   }, [projectsQ.data, specimensQ.data, testsQ.data, damagesQ.data, now]);
+
+  // 切削 KPI は toolsQ / cuttingProcessesQ 両方揃ったときのみ算出。
+  // どちらか取得失敗でも null のままで、UI 側で「切削データなし」と表示する。
+  const cuttingKpi = useMemo(() => {
+    if (!toolsQ.data || !cuttingProcessesQ.data) return null;
+    return computeCuttingKpi({
+      tools: toolsQ.data,
+      cuttingProcesses: cuttingProcessesQ.data,
+      now,
+    });
+  }, [toolsQ.data, cuttingProcessesQ.data, now]);
 
   const dueRisk = useMemo(() => {
     if (!projectsQ.data) return [];
@@ -132,6 +149,34 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
                   : 'var(--ok, #22c55e)'
               }
             />
+            {cuttingKpi && (
+              <>
+                <KpiCard
+                  label="工具寿命アラート"
+                  value={cuttingKpi.toolsOverWearLimit}
+                  delta={`全 ${cuttingKpi.totalTools} 工具中・VB ≥ 0.3 mm`}
+                  color={
+                    cuttingKpi.toolsOverWearLimit > 0
+                      ? 'var(--warn, #d97706)'
+                      : 'var(--ok, #22c55e)'
+                  }
+                />
+                <KpiCard
+                  label="びびり検出率 (30日)"
+                  value={`${(cuttingKpi.chatterRatioLast30Days * 100).toFixed(1)}%`}
+                  delta={
+                    cuttingKpi.evaluatedCuttingProcessesLast30Days > 0
+                      ? `評価済 ${cuttingKpi.evaluatedCuttingProcessesLast30Days} 件の切削`
+                      : '評価済データなし'
+                  }
+                  color={
+                    cuttingKpi.chatterRatioLast30Days > 0.3
+                      ? 'var(--warn, #d97706)'
+                      : 'var(--ok, #22c55e)'
+                  }
+                />
+              </>
+            )}
           </div>
         </section>
 

--- a/src/features/dashboard/api.ts
+++ b/src/features/dashboard/api.ts
@@ -8,6 +8,8 @@ export const dashboardKeys = {
   specimens: ['ops-dashboard', 'specimens'] as const,
   tests: ['ops-dashboard', 'tests'] as const,
   damages: ['ops-dashboard', 'damages'] as const,
+  tools: ['ops-dashboard', 'tools'] as const,
+  cuttingProcesses: ['ops-dashboard', 'cutting-processes'] as const,
   projectsIndex: ['ops-dashboard', 'projects-index'] as const,
   materialsIndex: ['ops-dashboard', 'materials-index'] as const,
   customersIndex: ['ops-dashboard', 'customers-index'] as const,
@@ -47,6 +49,8 @@ const DASHBOARD_TEST_PAGE_SIZE = 3000;
 const DASHBOARD_SPECIMEN_PAGE_SIZE = 1000;
 const DASHBOARD_PROJECT_PAGE_SIZE = 500;
 const DASHBOARD_DAMAGE_PAGE_SIZE = 500;
+const DASHBOARD_TOOL_PAGE_SIZE = 200;
+const DASHBOARD_CUTTING_PAGE_SIZE = 2000;
 
 export const useAllTests = () => {
   const { tests } = useRepositories();
@@ -66,6 +70,30 @@ export const useAllDamages = () => {
     queryKey: dashboardKeys.damages,
     queryFn: async () => {
       const page = await damage.list({ pageSize: DASHBOARD_DAMAGE_PAGE_SIZE });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};
+
+export const useAllTools = () => {
+  const { tools } = useRepositories();
+  return useQuery({
+    queryKey: dashboardKeys.tools,
+    queryFn: async () => {
+      const page = await tools.list({ pageSize: DASHBOARD_TOOL_PAGE_SIZE });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};
+
+export const useAllCuttingProcesses = () => {
+  const { cuttingProcesses } = useRepositories();
+  return useQuery({
+    queryKey: dashboardKeys.cuttingProcesses,
+    queryFn: async () => {
+      const page = await cuttingProcesses.list({ pageSize: DASHBOARD_CUTTING_PAGE_SIZE });
       return page.items;
     },
     staleTime: 60_000,

--- a/src/features/dashboard/utils/opsMetrics.test.ts
+++ b/src/features/dashboard/utils/opsMetrics.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import type {
+  CuttingProcess,
   DamageFinding,
   Project,
   Specimen,
   Test,
+  Tool,
 } from '@/domain/types';
 import {
   buildActivityTimeline,
   collectDueRisk,
+  computeCuttingKpi,
   computeOpsKpi,
 } from './opsMetrics';
 
@@ -175,6 +178,137 @@ describe('collectDueRisk', () => {
       NOW
     );
     expect(risk).toHaveLength(0);
+  });
+});
+
+const makeTool = (p: Partial<Tool> & { id: string }): Tool => ({
+  id: p.id,
+  code: p.code ?? `TOOL-${p.id}`,
+  name: p.name ?? 'テスト工具',
+  nameEn: 'Test Tool',
+  type: p.type ?? 'end_mill',
+  material: p.material ?? 'coated_carbide',
+  coating: null,
+  diameter: 10,
+  fluteCount: 4,
+  rakeAngle: null,
+  reliefAngle: null,
+  helixAngle: null,
+  cornerRadius: null,
+  maxDepthOfCut: null,
+  applicableMaterials: [],
+  vendor: null,
+  description: null,
+  createdAt: '2026-03-01T00:00:00Z',
+  updatedAt: '2026-03-01T00:00:00Z',
+  createdBy: 'usr_op_001',
+  updatedBy: 'usr_op_001',
+});
+
+const makeCuttingProcess = (
+  p: Partial<CuttingProcess> & { id: string; toolId: string; performedAt: string }
+): CuttingProcess => ({
+  id: p.id,
+  code: p.code ?? `CUT-${p.id}`,
+  specimenId: p.specimenId ?? null,
+  materialId: p.materialId ?? 'mat_ti64',
+  toolId: p.toolId,
+  operation: p.operation ?? 'milling_face',
+  condition: {
+    cuttingSpeed: 80,
+    feed: 0.1,
+    feedUnit: 'mm/tooth',
+    depthOfCut: 1,
+    widthOfCut: null,
+    spindleSpeed: 2500,
+    coolant: 'flood',
+    notes: null,
+  },
+  machiningTimeSec: 300,
+  cuttingDistanceMm: 5000,
+  surfaceRoughnessRa: null,
+  toolWearVB: p.toolWearVB ?? null,
+  chatterDetected: p.chatterDetected ?? null,
+  cuttingForceFc: null,
+  cuttingTemperatureC: null,
+  waveformIds: [],
+  operatorId: 'usr_op_001',
+  machine: null,
+  performedAt: p.performedAt,
+  notes: null,
+  createdAt: '2026-03-01T00:00:00Z',
+  updatedAt: '2026-03-01T00:00:00Z',
+  createdBy: 'usr_op_001',
+  updatedBy: 'usr_op_001',
+});
+
+describe('computeCuttingKpi', () => {
+  it('VB >= 0.3 の最新プロセスを持つ工具を「限界超過」としてカウント', () => {
+    const tools = [makeTool({ id: 'tool_a' }), makeTool({ id: 'tool_b' }), makeTool({ id: 'tool_c' })];
+    const cuttingProcesses = [
+      // tool_a: 最新 VB=0.32 (超過)
+      makeCuttingProcess({ id: 'p1', toolId: 'tool_a', performedAt: '2026-04-18T10:00:00Z', toolWearVB: 0.20 }),
+      makeCuttingProcess({ id: 'p2', toolId: 'tool_a', performedAt: '2026-04-19T10:00:00Z', toolWearVB: 0.32 }),
+      // tool_b: 最新 VB=0.25 (未超過)
+      makeCuttingProcess({ id: 'p3', toolId: 'tool_b', performedAt: '2026-04-18T10:00:00Z', toolWearVB: 0.25 }),
+      // tool_c: プロセスなし（未使用工具）
+    ];
+    const kpi = computeCuttingKpi({ tools, cuttingProcesses, now: NOW });
+    expect(kpi.toolsOverWearLimit).toBe(1);
+    expect(kpi.totalTools).toBe(3);
+  });
+
+  it('最新プロセスで toolWearVB が null の場合は 1 つ前の評価済み値を採用', () => {
+    const tools = [makeTool({ id: 'tool_a' })];
+    const cuttingProcesses = [
+      makeCuttingProcess({ id: 'p1', toolId: 'tool_a', performedAt: '2026-04-18T10:00:00Z', toolWearVB: 0.35 }),
+      makeCuttingProcess({ id: 'p2', toolId: 'tool_a', performedAt: '2026-04-19T10:00:00Z', toolWearVB: null }),
+    ];
+    const kpi = computeCuttingKpi({ tools, cuttingProcesses, now: NOW });
+    expect(kpi.toolsOverWearLimit).toBe(1);
+  });
+
+  it('過去 30 日のびびり検出率を evaluated only で算出（null は分母から除外）', () => {
+    const tools = [makeTool({ id: 'tool_a' })];
+    const cuttingProcesses = [
+      makeCuttingProcess({ id: 'p1', toolId: 'tool_a', performedAt: '2026-04-18T10:00:00Z', chatterDetected: true }),
+      makeCuttingProcess({ id: 'p2', toolId: 'tool_a', performedAt: '2026-04-18T11:00:00Z', chatterDetected: false }),
+      makeCuttingProcess({ id: 'p3', toolId: 'tool_a', performedAt: '2026-04-18T12:00:00Z', chatterDetected: false }),
+      makeCuttingProcess({ id: 'p4', toolId: 'tool_a', performedAt: '2026-04-18T13:00:00Z', chatterDetected: null }),
+    ];
+    const kpi = computeCuttingKpi({ tools, cuttingProcesses, now: NOW });
+    // evaluated: 3 (p1 true, p2 false, p3 false)、chatter=1 → 1/3 ≈ 0.333
+    expect(kpi.evaluatedCuttingProcessesLast30Days).toBe(3);
+    expect(kpi.chatterRatioLast30Days).toBeCloseTo(1 / 3, 5);
+  });
+
+  it('過去 30 日より古いプロセスは分母から除外', () => {
+    const tools = [makeTool({ id: 'tool_a' })];
+    const cuttingProcesses = [
+      makeCuttingProcess({ id: 'p1', toolId: 'tool_a', performedAt: '2026-04-18T10:00:00Z', chatterDetected: true }),
+      // 60 日前
+      makeCuttingProcess({ id: 'p_old', toolId: 'tool_a', performedAt: '2026-02-18T10:00:00Z', chatterDetected: false }),
+    ];
+    const kpi = computeCuttingKpi({ tools, cuttingProcesses, now: NOW });
+    expect(kpi.evaluatedCuttingProcessesLast30Days).toBe(1);
+    expect(kpi.chatterRatioLast30Days).toBe(1);
+  });
+
+  it('評価済みデータがゼロなら chatter 率は 0', () => {
+    const tools = [makeTool({ id: 'tool_a' })];
+    const cuttingProcesses = [
+      makeCuttingProcess({ id: 'p1', toolId: 'tool_a', performedAt: '2026-04-18T10:00:00Z', chatterDetected: null }),
+    ];
+    const kpi = computeCuttingKpi({ tools, cuttingProcesses, now: NOW });
+    expect(kpi.evaluatedCuttingProcessesLast30Days).toBe(0);
+    expect(kpi.chatterRatioLast30Days).toBe(0);
+  });
+
+  it('tools が空なら toolsOverWearLimit=0', () => {
+    const kpi = computeCuttingKpi({ tools: [], cuttingProcesses: [], now: NOW });
+    expect(kpi.toolsOverWearLimit).toBe(0);
+    expect(kpi.totalTools).toBe(0);
+    expect(kpi.chatterRatioLast30Days).toBe(0);
   });
 });
 

--- a/src/features/dashboard/utils/opsMetrics.ts
+++ b/src/features/dashboard/utils/opsMetrics.ts
@@ -2,11 +2,14 @@
 // 純関数で実装してテスト容易に。UI 側は結果を受け取って描画するだけに寄せる。
 
 import type {
+  CuttingProcess,
   DamageFinding,
   Project,
   Specimen,
   Test,
+  Tool,
 } from '@/domain/types';
+import { VB_CRITERIA } from '@/features/cutting/utils/standards';
 
 export interface OpsKpi {
   /** 進行中案件数（inquiry / quoting / in_progress / reviewing） */
@@ -88,6 +91,76 @@ export const computeOpsKpi = (input: {
     pendingSpecimens,
     completedTestsLast30Days,
     abnormalFindingRatio: ratio,
+  };
+};
+
+export interface CuttingKpi {
+  /**
+   * 工具寿命アラート: VB 限界値（ISO 3685 / 仕上げ 0.3 mm）を超過している工具の数。
+   * 判定: 各工具について最新 cuttingProcess の toolWearVB を見て、
+   * VB_CRITERIA.finishing.average 以上なら 1 としてカウント。
+   */
+  toolsOverWearLimit: number;
+  /** 工具総数（母数表示用） */
+  totalTools: number;
+  /**
+   * 過去 30 日のびびり検出率。
+   * 分母: performedAt が過去 30 日以内で chatterDetected が true / false の cuttingProcess 件数
+   * （null は「未評価」として分母から除外）。
+   * 分子: 上記のうち chatterDetected === true の件数。
+   */
+  chatterRatioLast30Days: number;
+  /** 過去 30 日の切削プロセスのうち chatter が評価済（true / false）の件数（母数表示用） */
+  evaluatedCuttingProcessesLast30Days: number;
+}
+
+export const computeCuttingKpi = (input: {
+  tools: Tool[];
+  cuttingProcesses: CuttingProcess[];
+  now?: Date;
+}): CuttingKpi => {
+  const { tools, cuttingProcesses } = input;
+  const now = input.now ?? new Date();
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const thirtyDaysAgo = now.getTime() - 30 * msPerDay;
+
+  // 各工具の最新 VB を収集（performedAt 降順で最初に見つかった値）。
+  // 工具ごとにソートして、先頭要素の toolWearVB を採用する。
+  const processByTool = new Map<string, CuttingProcess[]>();
+  for (const p of cuttingProcesses) {
+    const arr = processByTool.get(p.toolId) ?? [];
+    arr.push(p);
+    processByTool.set(p.toolId, arr);
+  }
+  const limit = VB_CRITERIA.finishing.average;
+  let toolsOverWearLimit = 0;
+  for (const tool of tools) {
+    const arr = processByTool.get(tool.id);
+    if (!arr || arr.length === 0) continue;
+    // 降順ソート（最新が先頭）
+    arr.sort((a, b) => Date.parse(b.performedAt) - Date.parse(a.performedAt));
+    const latest = arr.find((p) => p.toolWearVB !== null && p.toolWearVB !== undefined);
+    if (latest && latest.toolWearVB !== null && latest.toolWearVB >= limit) {
+      toolsOverWearLimit += 1;
+    }
+  }
+
+  // びびり検出率: 過去 30 日 + chatterDetected が評価済（非 null）のみ
+  const recentEvaluated = cuttingProcesses.filter((p) => {
+    if (p.chatterDetected === null || p.chatterDetected === undefined) return false;
+    const t = Date.parse(p.performedAt);
+    return !Number.isNaN(t) && t >= thirtyDaysAgo;
+  });
+  const chatterCount = recentEvaluated.filter((p) => p.chatterDetected === true).length;
+  const chatterRatio = recentEvaluated.length > 0
+    ? chatterCount / recentEvaluated.length
+    : 0;
+
+  return {
+    toolsOverWearLimit,
+    totalTools: tools.length,
+    chatterRatioLast30Days: chatterRatio,
+    evaluatedCuttingProcessesLast30Days: recentEvaluated.length,
   };
 };
 


### PR DESCRIPTION
## 概要
Issue #82 の Phase 3.5 最優先 B の前半。ダッシュボードに切削ドメインの KPI 2 種を追加する。B-2（試験種別 / 材料カテゴリ分布）は別 PR。

## 追加した KPI

### 1. 工具寿命アラート
- VB 限界値（ISO 3685 仕上げ基準 0.3 mm）を超過している工具の数
- 判定: 各工具について最新の `toolWearVB` を取得し、`VB_CRITERIA.finishing.average` 以上でカウント
- 表示: `{超過数}` / `全 {totalTools} 工具中・VB ≥ 0.3 mm`
- 色分け: 超過あり→warn / なし→ok

### 2. びびり検出率 (30 日)
- 過去 30 日の `cuttingProcess` のうち、`chatterDetected` が `true` / `false` で評価済みのもの中の発生率
- `null`（未評価）は分母から除外
- 表示: `{X.X}%` / `評価済 {N} 件の切削` or `評価済データなし`
- 色分け: > 30% → warn / ≤ 30% → ok

## 変更ファイル

- `src/features/dashboard/utils/opsMetrics.ts`: `computeCuttingKpi()` 追加
- `src/features/dashboard/api.ts`: `useAllTools` / `useAllCuttingProcesses` + dashboardKeys 追加
- `src/features/dashboard/OpsDashboardPage.tsx`: 2 KPI カードを grid に追加（データ未取得時は表示しない）
- `src/data/constants.ts`: `ops-dash` PAGE_GUIDES の features に切削 KPI 行を追加（日英両対応）
- `src/data/announcements.ts`: feature 告知を先頭追加

## 挙動の設計

- 切削データ取得失敗でも受託試験側 KPI / 納期リスク / タイムラインはブロックしない
- `cuttingKpi === null` のときは切削 KPI カード 2 枚が非表示（grid が自動で詰まる）
- 既存 4 KPI レイアウトを壊さない

## テスト計画
- [x] typecheck pass
- [x] dashboard テスト 12/12 pass（既存 6 + 新規 6）
- [x] computeCuttingKpi の 6 ケース:
  - VB 超過工具カウント
  - 最新 VB が null の場合は 1 つ前の評価済み値を採用
  - chatter 評価率（null 除外）
  - 30 日より古いプロセスの除外
  - 評価済データなしで 0
  - tools 空で 0

## 次の予定
- B-2: 試験種別分布 + 材料カテゴリ分布（純 SVG 円グラフ、Issue #82 内）
- D / C / A を順次実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードに新しい切削KPIメトリクスを追加しました。工具の磨耗アラートとチャタリング検出率（過去30日間）が表示されるようになりました。
  * 新しいアナウンスメント（2026年4月24日）を追加しました。

* **ドキュメント**
  * ページガイドに新しい切削KPI指標の説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->