### PR TITLE
feat(dashboard): 受託試験ダッシュボードに分布チャート 2 種を追加（Phase 3.5 B-2）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-dashboard-distribution-charts',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '受託試験ダッシュボードに分布チャートを追加（試験種別 / 材料カテゴリ）',
+    body: 'ダッシュボードに 2 つの円グラフを追加しました。試験種別分布は過去 30 日の完了試験を testType 別に、材料カテゴリ分布は進行中案件の試験片を母材カテゴリ（鋼 / ステンレス / Ti / Ni 基 / Al / セラミクス / 複合材 等）別に集計します。チャートは純 SVG で実装、凡例で件数と割合を併記します。',
+  },
+  {
     id: '2026-04-24-dashboard-cutting-kpi',
     date: '2026-04-24',
     type: 'feature',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -669,6 +669,7 @@ export const PAGE_GUIDES: PageGuide[] = [
     features: [
       'KPI: 進行中案件数 / 期限 7 日以内の試験片 / 過去 30 日の完了試験 / 異常所見比率',
       '切削 KPI: 工具寿命アラート（VB ≥ 0.3 mm 超過数）/ 過去 30 日のびびり検出率',
+      '分布チャート: 過去 30 日の試験種別 / 進行中案件の材料カテゴリ（純 SVG 円グラフ）',
       '納期リスク一覧: dueAt <= +7 日 or 遅延 の進行中・レビュー中案件',
       '活動タイムライン: 完了試験と損傷所見登録を時系列降順で 20 件',
       '案件行クリックで案件詳細へ遷移',
@@ -676,6 +677,7 @@ export const PAGE_GUIDES: PageGuide[] = [
     featuresEn: [
       'KPIs: active projects / specimens due in 7 days / completed tests in last 30 days / abnormal finding ratio',
       'Cutting KPIs: tools over wear limit (VB ≥ 0.3 mm) / chatter detection ratio (last 30 days)',
+      'Distribution charts: test types (last 30 days) / material categories of active projects (pure SVG pie charts)',
       'Due-risk list: in-progress or reviewing projects with dueAt within 7 days or overdue',
       'Activity timeline: last 20 completed tests and damage findings in descending time order',
       'Click a project row to jump to its detail page',

--- a/src/features/dashboard/OpsDashboardPage.tsx
+++ b/src/features/dashboard/OpsDashboardPage.tsx
@@ -11,13 +11,18 @@ import {
   useAllTests,
   useAllTools,
   useCustomersIndex,
+  useMaterialsIndex,
+  useTestTypesIndex,
 } from './api';
 import {
   buildActivityTimeline,
   collectDueRisk,
   computeCuttingKpi,
+  computeMaterialCategoryDistribution,
   computeOpsKpi,
+  computeTestTypeDistribution,
 } from './utils/opsMetrics';
+import { PieChart } from './components/PieChart';
 
 interface OpsDashboardPageProps {
   onNav?: (page: string) => void;
@@ -37,6 +42,9 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
   // 切削 KPI 用。取得失敗でも受託試験側 KPI / 納期リスク / タイムラインはブロックしない設計。
   const toolsQ = useAllTools();
   const cuttingProcessesQ = useAllCuttingProcesses();
+  // 分布チャート用。materialsIndex / testTypesIndex は副次情報、取得失敗時はチャート側を非表示にする。
+  const materialsIndexQ = useMaterialsIndex();
+  const testTypesIndexQ = useTestTypesIndex();
   // 顧客名はリスク行の表示のみに使う副次情報。取得失敗でもダッシュボード全体はブロックしない。
   const customersQ = useCustomersIndex();
 
@@ -76,6 +84,20 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
       now,
     });
   }, [toolsQ.data, cuttingProcessesQ.data, now]);
+
+  const testTypeDistribution = useMemo(() => {
+    if (!testsQ.data || !testTypesIndexQ.data) return null;
+    return computeTestTypeDistribution(testsQ.data, testTypesIndexQ.data, now, 30);
+  }, [testsQ.data, testTypesIndexQ.data, now]);
+
+  const materialDistribution = useMemo(() => {
+    if (!projectsQ.data || !specimensQ.data || !materialsIndexQ.data) return null;
+    return computeMaterialCategoryDistribution({
+      projects: projectsQ.data,
+      specimens: specimensQ.data,
+      materials: materialsIndexQ.data,
+    });
+  }, [projectsQ.data, specimensQ.data, materialsIndexQ.data]);
 
   const dueRisk = useMemo(() => {
     if (!projectsQ.data) return [];
@@ -179,6 +201,32 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
             )}
           </div>
         </section>
+
+        {/* 分布チャート */}
+        {(testTypeDistribution || materialDistribution) && (
+          <section
+            aria-label="分布"
+            className="grid gap-4"
+            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}
+          >
+            {testTypeDistribution && (
+              <div className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
+                <h2 className="text-[14px] font-semibold mb-3">
+                  試験種別分布（過去 30 日の完了試験）
+                </h2>
+                <PieChart slices={testTypeDistribution} title="試験種別分布" />
+              </div>
+            )}
+            {materialDistribution && (
+              <div className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
+                <h2 className="text-[14px] font-semibold mb-3">
+                  材料カテゴリ分布（進行中案件の試験片）
+                </h2>
+                <PieChart slices={materialDistribution} title="材料カテゴリ分布" />
+              </div>
+            )}
+          </section>
+        )}
 
         {/* 納期リスク */}
         <section

--- a/src/features/dashboard/api.ts
+++ b/src/features/dashboard/api.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useRepositories } from '@/app/providers';
-import type { ID, Material, Project, Customer } from '@/domain/types';
+import type { ID, Material, Project, Customer, TestType } from '@/domain/types';
 
 export const dashboardKeys = {
   all: ['ops-dashboard'] as const,
@@ -13,6 +13,7 @@ export const dashboardKeys = {
   projectsIndex: ['ops-dashboard', 'projects-index'] as const,
   materialsIndex: ['ops-dashboard', 'materials-index'] as const,
   customersIndex: ['ops-dashboard', 'customers-index'] as const,
+  testTypesIndex: ['ops-dashboard', 'test-types-index'] as const,
 };
 
 /**
@@ -131,6 +132,18 @@ export const useCustomersIndex = () => {
     queryFn: async () => {
       const page = await customers.list();
       return new Map<ID, Customer>(page.items.map((c) => [c.id, c]));
+    },
+    staleTime: 5 * 60_000,
+  });
+};
+
+export const useTestTypesIndex = () => {
+  const { testTypes } = useRepositories();
+  return useQuery({
+    queryKey: dashboardKeys.testTypesIndex,
+    queryFn: async () => {
+      const all = await testTypes.list();
+      return new Map<ID, TestType>(all.map((t) => [t.id, t]));
     },
     staleTime: 5 * 60_000,
   });

--- a/src/features/dashboard/components/PieChart.test.tsx
+++ b/src/features/dashboard/components/PieChart.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PieChart } from './PieChart';
+
+describe('PieChart', () => {
+  it('renders title and legend entries with label + value + percent', () => {
+    render(
+      <PieChart
+        title="試験種別分布"
+        slices={[
+          { label: '引張試験', value: 3 },
+          { label: '硬度試験', value: 1 },
+        ]}
+      />,
+    );
+    // aria-label で識別できる
+    expect(screen.getByRole('figure', { name: '試験種別分布' })).toBeInTheDocument();
+    // 凡例の label + 件数 + % 表記が出ている
+    expect(screen.getByText('引張試験')).toBeInTheDocument();
+    expect(screen.getByText('3（75%）')).toBeInTheDocument();
+    expect(screen.getByText('硬度試験')).toBeInTheDocument();
+    expect(screen.getByText('1（25%）')).toBeInTheDocument();
+  });
+
+  it('renders "データなし" when total is zero', () => {
+    render(<PieChart title="空の分布" slices={[]} />);
+    expect(screen.getByText('空の分布')).toBeInTheDocument();
+    expect(screen.getByText('データなし')).toBeInTheDocument();
+  });
+
+  it('omits legend when showLegend is false', () => {
+    render(
+      <PieChart
+        title="分布"
+        showLegend={false}
+        slices={[{ label: 'A', value: 1 }]}
+      />,
+    );
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+  });
+
+  it('renders a single slice as a full circle (value === total)', () => {
+    const { container } = render(
+      <PieChart title="単一" slices={[{ label: 'Only', value: 10 }]} />,
+    );
+    // 単一 100% のとき、スライスは 1 本の path で完全円を描く
+    const paths = container.querySelectorAll('svg path');
+    expect(paths.length).toBe(1);
+  });
+});

--- a/src/features/dashboard/components/PieChart.tsx
+++ b/src/features/dashboard/components/PieChart.tsx
@@ -1,0 +1,137 @@
+// 純 SVG 円グラフ（ADR-009 純 SVG + 依存ゼロ方針）。
+// ダッシュボードの分布表示専用。ラベルは凡例で表示し、スライス上には最大カウントのみ表示する。
+
+import { useId } from 'react';
+
+export interface PieSlice {
+  label: string;
+  value: number;
+  colorKey?: string; // CSS 変数名の接頭辞（未指定時はインデックスでローテート）
+}
+
+interface PieChartProps {
+  slices: PieSlice[];
+  /** SVG 描画サイズ（円の直径に近い） */
+  size?: number;
+  /** 凡例の表示有無 */
+  showLegend?: boolean;
+  /** a11y 用の図表タイトル */
+  title: string;
+}
+
+// テーマ変数を優先し、不足分は CSS 変数のデフォルトでカバー。
+// Matlens の 4 テーマで自然に追従する。
+const DEFAULT_COLORS = [
+  'var(--accent, #2563eb)',
+  'var(--ok, #22c55e)',
+  'var(--warn, #d97706)',
+  'var(--err, #dc2626)',
+  'var(--ai-col, #a855f7)',
+  'var(--vec, #0ea5e9)',
+  'var(--text-md, #64748b)',
+  'var(--text-lo, #94a3b8)',
+];
+
+export const PieChart = ({
+  slices,
+  size = 180,
+  showLegend = true,
+  title,
+}: PieChartProps) => {
+  // useId() は複数同時描画時の id 衝突を防ぐ。Matlens の決定論描画パターンを踏襲。
+  const uid = useId();
+
+  const total = slices.reduce((sum, s) => sum + s.value, 0);
+
+  if (total === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 text-[12px] text-[var(--text-lo)] py-4">
+        <span>{title}</span>
+        <span>データなし</span>
+      </div>
+    );
+  }
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const r = (size / 2) * 0.92; // 少し内側に描いてラベルのオーバーハングを回避
+
+  // スライスパス生成。角度は 12 時方向（-90°）から時計回り。
+  let cumulative = 0;
+  const paths = slices
+    .filter((s) => s.value > 0)
+    .map((s, i) => {
+      const startAngle = (cumulative / total) * Math.PI * 2 - Math.PI / 2;
+      cumulative += s.value;
+      const endAngle = (cumulative / total) * Math.PI * 2 - Math.PI / 2;
+
+      const x1 = cx + r * Math.cos(startAngle);
+      const y1 = cy + r * Math.sin(startAngle);
+      const x2 = cx + r * Math.cos(endAngle);
+      const y2 = cy + r * Math.sin(endAngle);
+
+      const largeArcFlag = endAngle - startAngle > Math.PI ? 1 : 0;
+
+      // スライス全体が 100% の場合は円を 2 分割して描く（SVG arc は 360° を描けない）
+      const d =
+        s.value === total
+          ? `M ${cx - r} ${cy} A ${r} ${r} 0 1 1 ${cx + r} ${cy} A ${r} ${r} 0 1 1 ${cx - r} ${cy} Z`
+          : `M ${cx} ${cy} L ${x1.toFixed(2)} ${y1.toFixed(2)} A ${r} ${r} 0 ${largeArcFlag} 1 ${x2.toFixed(2)} ${y2.toFixed(2)} Z`;
+
+      const color = s.colorKey ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length];
+      const percent = ((s.value / total) * 100).toFixed(0);
+
+      return {
+        key: `${uid}-${i}`,
+        d,
+        color,
+        label: s.label,
+        value: s.value,
+        percent,
+      };
+    });
+
+  return (
+    <figure
+      className="flex items-center gap-3 flex-wrap"
+      role="figure"
+      aria-label={title}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        role="img"
+      >
+        <title>{title}</title>
+        {paths.map((p) => (
+          <path
+            key={p.key}
+            d={p.d}
+            fill={p.color}
+            stroke="var(--bg-raised, #fff)"
+            strokeWidth={1}
+          />
+        ))}
+      </svg>
+
+      {showLegend && (
+        <ul className="flex flex-col gap-0.5 text-[12px]">
+          {paths.map((p) => (
+            <li key={`legend-${p.key}`} className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="inline-block w-2.5 h-2.5 rounded-sm flex-shrink-0"
+                style={{ background: p.color }}
+              />
+              <span className="text-[var(--text-hi)]">{p.label}</span>
+              <span className="tabular-nums text-[var(--text-lo)]">
+                {p.value}（{p.percent}%）
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </figure>
+  );
+};

--- a/src/features/dashboard/utils/opsMetrics.test.ts
+++ b/src/features/dashboard/utils/opsMetrics.test.ts
@@ -2,16 +2,20 @@ import { describe, expect, it } from 'vitest';
 import type {
   CuttingProcess,
   DamageFinding,
+  Material,
   Project,
   Specimen,
   Test,
+  TestType,
   Tool,
 } from '@/domain/types';
 import {
   buildActivityTimeline,
   collectDueRisk,
   computeCuttingKpi,
+  computeMaterialCategoryDistribution,
   computeOpsKpi,
+  computeTestTypeDistribution,
 } from './opsMetrics';
 
 const NOW = new Date('2026-04-20T00:00:00+09:00');
@@ -309,6 +313,121 @@ describe('computeCuttingKpi', () => {
     expect(kpi.toolsOverWearLimit).toBe(0);
     expect(kpi.totalTools).toBe(0);
     expect(kpi.chatterRatioLast30Days).toBe(0);
+  });
+});
+
+describe('computeTestTypeDistribution', () => {
+  const makeTestType = (id: string, name: string): TestType => ({
+    id,
+    name,
+    nameEn: name,
+    category: 'mechanical',
+    defaultStandardIds: [],
+    iconKey: 'test',
+    description: '',
+  });
+
+  it('完了試験を testTypeId 別に集計、多い順にソート', () => {
+    const tests = [
+      makeTest({ id: 't1', status: 'completed', performedAt: '2026-04-18T10:00:00Z' }),
+      makeTest({ id: 't2', status: 'completed', performedAt: '2026-04-18T11:00:00Z' }),
+      makeTest({ id: 't3', status: 'completed', performedAt: '2026-04-18T12:00:00Z' }),
+      makeTest({ id: 't4', status: 'completed', performedAt: '2026-04-18T13:00:00Z' }),
+    ];
+    // t1/t2/t3 は tt_tensile、t4 は tt_hardness とする
+    (tests[0] as Test).testTypeId = 'tt_tensile';
+    (tests[1] as Test).testTypeId = 'tt_tensile';
+    (tests[2] as Test).testTypeId = 'tt_tensile';
+    (tests[3] as Test).testTypeId = 'tt_hardness';
+
+    const types = new Map<string, TestType>([
+      ['tt_tensile', makeTestType('tt_tensile', '引張試験')],
+      ['tt_hardness', makeTestType('tt_hardness', '硬度試験')],
+    ]);
+
+    const dist = computeTestTypeDistribution(tests, types, NOW);
+    expect(dist).toHaveLength(2);
+    expect(dist[0]!.label).toBe('引張試験');
+    expect(dist[0]!.value).toBe(3);
+    expect(dist[1]!.label).toBe('硬度試験');
+    expect(dist[1]!.value).toBe(1);
+  });
+
+  it('過去 30 日より古い試験と未完了試験は除外', () => {
+    const tests = [
+      makeTest({ id: 't1', status: 'completed', performedAt: '2026-04-18T10:00:00Z' }),
+      makeTest({ id: 't_old', status: 'completed', performedAt: '2026-02-18T10:00:00Z' }),
+      makeTest({ id: 't_scheduled', status: 'scheduled', performedAt: '2026-04-19T10:00:00Z' }),
+    ];
+    (tests[0] as Test).testTypeId = 'tt_tensile';
+    (tests[1] as Test).testTypeId = 'tt_tensile';
+    (tests[2] as Test).testTypeId = 'tt_tensile';
+
+    const types = new Map<string, TestType>([['tt_tensile', makeTestType('tt_tensile', '引張試験')]]);
+    const dist = computeTestTypeDistribution(tests, types, NOW);
+    expect(dist).toHaveLength(1);
+    expect(dist[0]!.value).toBe(1);
+  });
+
+  it('testTypes index にない id は id そのままをラベルに使う', () => {
+    const tests = [makeTest({ id: 't1', status: 'completed', performedAt: '2026-04-18T10:00:00Z' })];
+    (tests[0] as Test).testTypeId = 'tt_unknown';
+    const dist = computeTestTypeDistribution(tests, new Map(), NOW);
+    expect(dist[0]!.label).toBe('tt_unknown');
+  });
+});
+
+describe('computeMaterialCategoryDistribution', () => {
+  const makeMaterial = (id: string, category: Material['category']): Material => ({
+    id,
+    designation: id,
+    category,
+    composition: [],
+    standardRefs: [],
+    properties: {},
+    description: null,
+    createdAt: '2026-03-01T00:00:00Z',
+    updatedAt: '2026-03-01T00:00:00Z',
+  });
+
+  it('進行中案件の試験片を母材カテゴリ別に集計', () => {
+    const projects = [
+      makeProject({ id: 'p_active', status: 'in_progress' }),
+      makeProject({ id: 'p_done', status: 'completed' }),
+    ];
+    const specimens = [
+      makeSpecimen({ id: 's1', projectId: 'p_active', status: 'received', receivedAt: '2026-04-18', materialId: 'mat_ti' }),
+      makeSpecimen({ id: 's2', projectId: 'p_active', status: 'testing', receivedAt: '2026-04-18', materialId: 'mat_ti' }),
+      makeSpecimen({ id: 's3', projectId: 'p_active', status: 'prepared', receivedAt: '2026-04-18', materialId: 'mat_ni' }),
+      // 完了案件の試験片は除外される
+      makeSpecimen({ id: 's4', projectId: 'p_done', status: 'stored', receivedAt: '2026-04-01', materialId: 'mat_ti' }),
+    ];
+    const materials = new Map<string, Material>([
+      ['mat_ti', makeMaterial('mat_ti', 'titanium')],
+      ['mat_ni', makeMaterial('mat_ni', 'nickel_alloy')],
+    ]);
+
+    const dist = computeMaterialCategoryDistribution({ projects, specimens, materials });
+    expect(dist).toHaveLength(2);
+    expect(dist[0]!.key).toBe('titanium');
+    expect(dist[0]!.label).toBe('Ti 合金');
+    expect(dist[0]!.value).toBe(2);
+    expect(dist[1]!.key).toBe('nickel_alloy');
+    expect(dist[1]!.label).toBe('Ni 基超合金');
+    expect(dist[1]!.value).toBe(1);
+  });
+
+  it('materials index にない materialId の試験片は除外', () => {
+    const projects = [makeProject({ id: 'p_active', status: 'in_progress' })];
+    const specimens = [
+      makeSpecimen({ id: 's1', projectId: 'p_active', status: 'received', receivedAt: '2026-04-18', materialId: 'mat_missing' }),
+    ];
+    const dist = computeMaterialCategoryDistribution({
+      projects,
+      specimens,
+      materials: new Map(),
+    });
+    expect(dist).toHaveLength(0);
   });
 });
 

--- a/src/features/dashboard/utils/opsMetrics.ts
+++ b/src/features/dashboard/utils/opsMetrics.ts
@@ -4,9 +4,12 @@
 import type {
   CuttingProcess,
   DamageFinding,
+  Material,
+  MaterialCategory,
   Project,
   Specimen,
   Test,
+  TestType,
   Tool,
 } from '@/domain/types';
 import { VB_CRITERIA } from '@/features/cutting/utils/standards';
@@ -198,6 +201,94 @@ export const collectDueRisk = (
   }
   // 残日数が少ない（＝リスク高）順に並べる。同値は stable order（元の順序）を保つ。
   return items.sort((a, b) => a.daysLeft - b.daysLeft);
+};
+
+export interface DistributionBucket {
+  key: string;
+  label: string;
+  value: number;
+}
+
+/**
+ * 過去 30 日の完了試験を testTypeId 別に集計してバケット化。
+ * テスト種別 index から日本語名を解決、未登録の id は id そのまま表示。
+ */
+export const computeTestTypeDistribution = (
+  tests: Test[],
+  testTypes: Map<string, TestType>,
+  now: Date = new Date(),
+  days = 30
+): DistributionBucket[] => {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const since = now.getTime() - days * msPerDay;
+
+  const counts = new Map<string, number>();
+  for (const t of tests) {
+    if (t.status !== 'completed') continue;
+    const ts = Date.parse(t.performedAt);
+    if (Number.isNaN(ts) || ts < since) continue;
+    counts.set(t.testTypeId, (counts.get(t.testTypeId) ?? 0) + 1);
+  }
+
+  const buckets: DistributionBucket[] = Array.from(counts.entries()).map(
+    ([id, value]) => ({
+      key: id,
+      label: testTypes.get(id)?.name ?? id,
+      value,
+    })
+  );
+  // 多い順にソート。同数は label で安定ソート。
+  buckets.sort((a, b) => b.value - a.value || a.label.localeCompare(b.label));
+  return buckets;
+};
+
+const MATERIAL_CATEGORY_LABEL: Record<MaterialCategory, string> = {
+  steel: '鋼',
+  stainless: 'ステンレス',
+  aluminum: 'アルミ合金',
+  titanium: 'Ti 合金',
+  nickel_alloy: 'Ni 基超合金',
+  copper: '銅合金',
+  polymer: 'ポリマー',
+  composite: '複合材',
+  ceramic: 'セラミクス',
+  other: 'その他',
+};
+
+/**
+ * 案件に紐づく試験片の母材カテゴリを集計。
+ * 進行中案件（computeOpsKpi の活性状態と同じ定義）に絞って、
+ * 「今動いている案件ではどのカテゴリの材料が扱われているか」を可視化する。
+ */
+export const computeMaterialCategoryDistribution = (input: {
+  projects: Project[];
+  specimens: Specimen[];
+  materials: Map<string, Material>;
+}): DistributionBucket[] => {
+  const { projects, specimens, materials } = input;
+  const activeProjectIds = new Set(
+    projects
+      .filter((p) => ACTIVE_STATUSES.includes(p.status))
+      .map((p) => p.id)
+  );
+
+  const counts = new Map<MaterialCategory, number>();
+  for (const s of specimens) {
+    if (!activeProjectIds.has(s.projectId)) continue;
+    const m = materials.get(s.materialId);
+    if (!m) continue;
+    counts.set(m.category, (counts.get(m.category) ?? 0) + 1);
+  }
+
+  const buckets: DistributionBucket[] = Array.from(counts.entries()).map(
+    ([cat, value]) => ({
+      key: cat,
+      label: MATERIAL_CATEGORY_LABEL[cat] ?? cat,
+      value,
+    })
+  );
+  buckets.sort((a, b) => b.value - a.value || a.label.localeCompare(b.label));
+  return buckets;
 };
 
 export type ActivityKind = 'test_completed' | 'damage_reported';


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 B-2。ダッシュボードに試験種別分布と材料カテゴリ分布の純 SVG 円グラフを追加する。B-1（PR #85）に続き B を完遂する。

## 追加した要素

### PieChart コンポーネント（純 SVG）
- `src/features/dashboard/components/PieChart.tsx`
- ADR-009 純 SVG + 依存ゼロ方針
- `useId()` で複数同時描画時の id 衝突を回避
- 凡例で label + 件数 + % 併記
- 単一 100% スライスは完全円で描画（SVG arc の 360° 制約回避）
- `slices` 空 / `total === 0` は「データなし」プレースホルダ
- `showLegend={false}` でチャートのみ描画も可能

### 分布計算

- **試験種別分布**: `computeTestTypeDistribution(tests, testTypes, now, days=30)`
  - 過去 30 日の完了試験を `testTypeId` 別に集計
  - 多い順ソート、同値は label で安定ソート
  - testTypes index に無い id は id そのままラベル表示

- **材料カテゴリ分布**: `computeMaterialCategoryDistribution({ projects, specimens, materials })`
  - 進行中案件（computeOpsKpi の活性状態と同じ定義）の試験片を母材 `category` 別に集計
  - カテゴリラベルは日本語（鋼 / ステンレス / アルミ合金 / Ti 合金 / Ni 基超合金 / 銅合金 / ポリマー / 複合材 / セラミクス / その他）
  - materials index に無い id の試験片は除外

## 変更ファイル

- `src/features/dashboard/components/PieChart.tsx` 新規
- `src/features/dashboard/components/PieChart.test.tsx` 新規（4 テスト）
- `src/features/dashboard/utils/opsMetrics.ts`: 分布関数 2 つ追加
- `src/features/dashboard/utils/opsMetrics.test.ts`: 分布関数テスト 5 件追加
- `src/features/dashboard/api.ts`: `useTestTypesIndex` + dashboardKeys エントリ
- `src/features/dashboard/OpsDashboardPage.tsx`: 2 円グラフセクションを KPI grid 下に配置
- `src/data/constants.ts`: `ops-dash` PAGE_GUIDES に分布チャート行追加（日英両対応）
- `src/data/announcements.ts`: feature 告知

## 挙動

- チャートは KPI カード 6 種（4 基本 + 2 切削）の下に配置
- データが揃わない（testTypesIndex / materialsIndex 取得失敗）側は非表示
- 両方取得失敗なら section 全体が描画されない

## テスト

- typecheck pass
- dashboard テスト **21/21 pass**（既存 6 + 切削 KPI 6 + 分布 5 + PieChart 4）

## Phase 3.5 進捗
- [x] B-1 切削 KPI（PR #85）
- [x] B-2 分布チャート（本 PR）
- [ ] D 試験マトリクス軸追加（次）
- [ ] C 案件詳細情報密度
- [ ] A MaiML エクスポート UI 拡張