### PR TITLE
feat(matrix): 試験マトリクスに集計期間フィルタと未経験セルハイライトを追加（Phase 3.5 D-1）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-matrix-period-filter',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '試験マトリクスに集計期間フィルタと未経験セルのハイライトを追加',
+    body: 'ヘッダ右側に「全期間 / 直近 1 年 / 直近 6 ヶ月」の切替を追加し、期間ごとの実績件数を比較できるようになりました。実績 0 件の組合せ（材料 × 試験種別）は破線でハイライトし、新規提案候補として視覚的に識別できます。スクリーンリーダー向けラベルも専用文言に切り替わります。',
+  },
+  {
     id: '2026-04-24-dashboard-distribution-charts',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/tests/matrix/HeatmapMatrix.test.tsx
+++ b/src/features/tests/matrix/HeatmapMatrix.test.tsx
@@ -73,7 +73,18 @@ describe('HeatmapMatrix', () => {
   it('件数が 0 のセルは中黒表示、件数ありは数値表示', () => {
     render(<HeatmapMatrix materials={materials} testTypes={testTypes} cells={cells} />);
     expect(screen.getByLabelText('SUS304 × 引張試験: 5件')).toHaveTextContent('5');
-    expect(screen.getByLabelText('SUS304 × 疲労試験: 0件')).toHaveTextContent('·');
+    // 0 件セルは新規提案候補として専用ラベルでアクセス可能
+    expect(
+      screen.getByLabelText('SUS304 × 疲労試験: 未経験の組合せ（新規提案候補）'),
+    ).toHaveTextContent('·');
+  });
+
+  it('0 件セルは data-empty-cell="true" で識別でき、視覚的強調用の破線が当たる', () => {
+    render(<HeatmapMatrix materials={materials} testTypes={testTypes} cells={cells} />);
+    const emptyCell = screen.getByLabelText('SUS304 × 疲労試験: 未経験の組合せ（新規提案候補）');
+    expect(emptyCell.getAttribute('data-empty-cell')).toBe('true');
+    // 破線強調 class
+    expect(emptyCell.className).toContain('outline-dashed');
   });
 
   it('セルクリックで onCellClick が呼ばれる', () => {

--- a/src/features/tests/matrix/HeatmapMatrix.tsx
+++ b/src/features/tests/matrix/HeatmapMatrix.tsx
@@ -88,6 +88,7 @@ export const HeatmapMatrix = ({
               {testTypes.map((tt) => {
                 const cell = cellMap.get(cellKey(mat.id, tt.id));
                 const count = cell?.count ?? 0;
+                const isEmpty = count === 0;
                 return (
                   <td
                     key={tt.id}
@@ -96,8 +97,18 @@ export const HeatmapMatrix = ({
                     <button
                       type="button"
                       onClick={() => onCellClick?.(mat.id, tt.id)}
-                      aria-label={`${mat.designation} × ${tt.name}: ${count}件`}
-                      className="w-full h-full min-h-[34px] px-1 py-1 font-mono tabular-nums transition-colors hover:outline hover:outline-2 hover:outline-[var(--accent,#2563eb)]"
+                      aria-label={
+                        isEmpty
+                          ? `${mat.designation} × ${tt.name}: 未経験の組合せ（新規提案候補）`
+                          : `${mat.designation} × ${tt.name}: ${count}件`
+                      }
+                      data-empty-cell={isEmpty ? 'true' : undefined}
+                      className={
+                        'w-full h-full min-h-[34px] px-1 py-1 font-mono tabular-nums transition-colors hover:outline hover:outline-2 hover:outline-[var(--accent,#2563eb)]' +
+                        (isEmpty
+                          ? ' outline outline-1 outline-dashed outline-[var(--warn,#d97706)] -outline-offset-2'
+                          : '')
+                      }
                       style={{
                         background: colorForCount(count, maxCount),
                         color: textColorForCount(count, maxCount),

--- a/src/features/tests/matrix/TestMatrixPage.tsx
+++ b/src/features/tests/matrix/TestMatrixPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ID } from '@/domain/types';
 import { HeatmapMatrix } from './HeatmapMatrix';
 import { useMaterials, useTestMatrix, useTestTypes } from './api';
@@ -8,8 +8,30 @@ interface SelectedCell {
   testTypeId: ID;
 }
 
+type PeriodPreset = 'all' | 'last6m' | 'last1y';
+
+const PERIOD_PRESETS: { key: PeriodPreset; label: string; labelEn: string; months: number | null }[] = [
+  { key: 'all', label: '全期間', labelEn: 'All time', months: null },
+  { key: 'last1y', label: '直近 1 年', labelEn: 'Last year', months: 12 },
+  { key: 'last6m', label: '直近 6 ヶ月', labelEn: 'Last 6 months', months: 6 },
+];
+
+const dateFromForPreset = (preset: PeriodPreset, now: Date = new Date()): string | undefined => {
+  const entry = PERIOD_PRESETS.find((p) => p.key === preset);
+  if (!entry || entry.months === null) return undefined;
+  const from = new Date(now);
+  from.setMonth(from.getMonth() - entry.months);
+  return from.toISOString().slice(0, 10); // YYYY-MM-DD
+};
+
 export const TestMatrixPage = () => {
-  const { data: matrix, isLoading: matrixLoading, isError: matrixError } = useTestMatrix();
+  const [period, setPeriod] = useState<PeriodPreset>('all');
+  const query = useMemo(() => {
+    const dateFrom = dateFromForPreset(period);
+    return dateFrom ? { dateFrom } : undefined;
+  }, [period]);
+
+  const { data: matrix, isLoading: matrixLoading, isError: matrixError } = useTestMatrix(query);
   const {
     data: testTypes,
     isLoading: testTypesLoading,
@@ -56,10 +78,40 @@ export const TestMatrixPage = () => {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       <header className="px-6 py-4 border-b border-[var(--border-faint)]">
-        <h1 className="text-xl font-bold">試験マトリクス</h1>
-        <p className="text-[13px] text-[var(--text-lo)] mt-1">
-          材料 × 試験種別ごとの実績件数を俯瞰し、過去試験の厚み薄さを可視化します。
-        </p>
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-xl font-bold">試験マトリクス</h1>
+            <p className="text-[13px] text-[var(--text-lo)] mt-1">
+              材料 × 試験種別ごとの実績件数を俯瞰し、過去試験の厚み薄さを可視化します。
+              0 件の組合せは新規提案の機会として破線で強調されます。
+            </p>
+          </div>
+          <div
+            role="radiogroup"
+            aria-label="集計期間"
+            className="flex gap-1 rounded-md border border-[var(--border-faint)] bg-[var(--bg-raised)] p-1"
+          >
+            {PERIOD_PRESETS.map((p) => {
+              const active = period === p.key;
+              return (
+                <button
+                  key={p.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => setPeriod(p.key)}
+                  className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                    active
+                      ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                      : 'text-[var(--text-md)] hover:bg-[var(--hover)]'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </header>
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 p-6 overflow-auto">


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 D の前半。試験マトリクスに 2 つの UI 改善を入れる。D-2（セル値切替 / 軸切替）は別 PR。

## 変更

### 1. 集計期間フィルタ
- ヘッダ右に radiogroup トグル（全期間 / 直近 1 年 / 直近 6 ヶ月）
- 選択時に `dateFrom` を計算し `useTestMatrix` に渡す
- 既存 `MatrixQuery.dateFrom` を活用する小さな差分

### 2. 未経験セルのハイライト
- `count === 0` のセルを破線枠でハイライト（outline-dashed + warn 色）
- `aria-label` を「未経験の組合せ（新規提案候補）」に切替
- `data-empty-cell="true"` 属性で CSS / テスト識別可能に

## テスト
- typecheck pass
- matrix テスト 4/4 pass（既存 2 + 新規 2: 0 件セル ラベル + 破線 class）

## Phase 3.5 進捗
- [x] B-1 切削 KPI（PR #85）
- [x] B-2 分布チャート（PR #86）
- [x] D-1 期間フィルタ + 未経験ハイライト（本 PR）
- [ ] D-2 セル値切替 / 軸切替（次）
- [ ] C 案件詳細情報密度
- [ ] A MaiML エクスポート UI 拡張