### PR TITLE
feat(matrix): 試験マトリクスのセル値を件数 / 異常率で切替可能に（Phase 3.5 D-2）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-matrix-cell-value-switching',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '試験マトリクスのセル値を「件数」と「異常率」で切替可能に',
+    body: 'マトリクスのヘッダ右に「件数 / 異常率」のセル値切替を追加しました。異常率モードでは、各セル（材料 × 試験種別）の完了試験のうち、非 low 確信度の損傷所見が紐づく試験の割合を % 表示します。セルの色も異常率が高いほど赤が濃くなり、Xray 的に異常の多い組合せを一目で特定できます。選択中の期間フィルタと組み合わせられます。',
+  },
+  {
     id: '2026-04-24-matrix-period-filter',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/tests/matrix/HeatmapMatrix.tsx
+++ b/src/features/tests/matrix/HeatmapMatrix.tsx
@@ -1,11 +1,18 @@
 import type { Material, TestType, ID } from '@/domain/types';
 import type { MatrixCell } from '@/infra/repositories/interfaces';
+import type { AbnormalCell } from './abnormalRatio';
+
+export type MatrixValueType = 'count' | 'abnormalRatio';
 
 export interface HeatmapMatrixProps {
   materials: Material[];
   testTypes: TestType[];
   cells: MatrixCell[];
   onCellClick?: (materialId: ID, testTypeId: ID) => void;
+  /** セル値の表示モード。既定 'count'。 */
+  valueType?: MatrixValueType;
+  /** 異常率モード時の補助マップ。count モードでは不要。 */
+  abnormalMap?: Map<string, AbnormalCell>;
 }
 
 const cellKey = (materialId: ID, testTypeId: ID) => `${materialId}__${testTypeId}`;
@@ -24,11 +31,27 @@ const textColorForCount = (count: number, max: number): string => {
   return ratio > 0.5 ? '#ffffff' : 'var(--text-hi, #0f172a)';
 };
 
+// 異常率用: 0..1 を赤系のグラデーションで表現（低=透明、高=赤）
+const colorForRatio = (ratio: number): string => {
+  if (ratio <= 0) return 'transparent';
+  const alpha = 0.15 + ratio * 0.7;
+  return `rgba(220, 38, 38, ${alpha.toFixed(3)})`;
+};
+
+const textColorForRatio = (ratio: number): string => {
+  if (ratio <= 0) return 'var(--text-lo, #94a3b8)';
+  return ratio > 0.5 ? '#ffffff' : 'var(--text-hi, #0f172a)';
+};
+
+const formatRatio = (ratio: number): string => `${(ratio * 100).toFixed(0)}%`;
+
 export const HeatmapMatrix = ({
   materials,
   testTypes,
   cells,
   onCellClick,
+  valueType = 'count',
+  abnormalMap,
 }: HeatmapMatrixProps) => {
   const cellMap = new Map<string, MatrixCell>();
   cells.forEach((c) => cellMap.set(cellKey(c.materialId, c.testTypeId), c));
@@ -89,6 +112,32 @@ export const HeatmapMatrix = ({
                 const cell = cellMap.get(cellKey(mat.id, tt.id));
                 const count = cell?.count ?? 0;
                 const isEmpty = count === 0;
+                const abnormal = abnormalMap?.get(cellKey(mat.id, tt.id));
+                const isAbnormalMode = valueType === 'abnormalRatio';
+                const ratio = abnormal?.ratio ?? 0;
+
+                const displayText = isAbnormalMode
+                  ? isEmpty
+                    ? '·'
+                    : formatRatio(ratio)
+                  : count > 0
+                    ? String(count)
+                    : '·';
+
+                const background = isAbnormalMode && !isEmpty
+                  ? colorForRatio(ratio)
+                  : colorForCount(count, maxCount);
+
+                const textColor = isAbnormalMode && !isEmpty
+                  ? textColorForRatio(ratio)
+                  : textColorForCount(count, maxCount);
+
+                const ariaLabel = isEmpty
+                  ? `${mat.designation} × ${tt.name}: 未経験の組合せ（新規提案候補）`
+                  : isAbnormalMode && abnormal
+                    ? `${mat.designation} × ${tt.name}: 異常率 ${formatRatio(ratio)}（${abnormal.abnormalCount} / ${abnormal.totalCount}）`
+                    : `${mat.designation} × ${tt.name}: ${count}件`;
+
                 return (
                   <td
                     key={tt.id}
@@ -97,11 +146,7 @@ export const HeatmapMatrix = ({
                     <button
                       type="button"
                       onClick={() => onCellClick?.(mat.id, tt.id)}
-                      aria-label={
-                        isEmpty
-                          ? `${mat.designation} × ${tt.name}: 未経験の組合せ（新規提案候補）`
-                          : `${mat.designation} × ${tt.name}: ${count}件`
-                      }
+                      aria-label={ariaLabel}
                       data-empty-cell={isEmpty ? 'true' : undefined}
                       className={
                         'w-full h-full min-h-[34px] px-1 py-1 font-mono tabular-nums transition-colors hover:outline hover:outline-2 hover:outline-[var(--accent,#2563eb)]' +
@@ -110,11 +155,11 @@ export const HeatmapMatrix = ({
                           : '')
                       }
                       style={{
-                        background: colorForCount(count, maxCount),
-                        color: textColorForCount(count, maxCount),
+                        background,
+                        color: textColor,
                       }}
                     >
-                      {count > 0 ? count : '·'}
+                      {displayText}
                     </button>
                   </td>
                 );

--- a/src/features/tests/matrix/TestMatrixPage.tsx
+++ b/src/features/tests/matrix/TestMatrixPage.tsx
@@ -1,7 +1,15 @@
 import { useMemo, useState } from 'react';
 import type { ID } from '@/domain/types';
-import { HeatmapMatrix } from './HeatmapMatrix';
-import { useMaterials, useTestMatrix, useTestTypes } from './api';
+import { HeatmapMatrix, type MatrixValueType } from './HeatmapMatrix';
+import {
+  useMaterials,
+  useMatrixDamages,
+  useMatrixSpecimens,
+  useMatrixTests,
+  useTestMatrix,
+  useTestTypes,
+} from './api';
+import { computeAbnormalCellMap } from './abnormalRatio';
 
 interface SelectedCell {
   materialId: ID;
@@ -26,6 +34,7 @@ const dateFromForPreset = (preset: PeriodPreset, now: Date = new Date()): string
 
 export const TestMatrixPage = () => {
   const [period, setPeriod] = useState<PeriodPreset>('all');
+  const [valueType, setValueType] = useState<MatrixValueType>('count');
   const query = useMemo(() => {
     const dateFrom = dateFromForPreset(period);
     return dateFrom ? { dateFrom } : undefined;
@@ -42,6 +51,23 @@ export const TestMatrixPage = () => {
     isLoading: materialsLoading,
     isError: materialsError,
   } = useMaterials();
+
+  // 異常率モードのみで必要な補助データ。count モードではクエリ結果が揃っていなくても UI に影響しない。
+  const dateFrom = useMemo(() => dateFromForPreset(period), [period]);
+  const matrixTestsQ = useMatrixTests(dateFrom);
+  const matrixDamagesQ = useMatrixDamages();
+  const matrixSpecimensQ = useMatrixSpecimens();
+
+  const abnormalMap = useMemo(() => {
+    if (valueType !== 'abnormalRatio') return undefined;
+    if (!matrixTestsQ.data || !matrixDamagesQ.data || !matrixSpecimensQ.data) return undefined;
+    return computeAbnormalCellMap({
+      tests: matrixTestsQ.data,
+      damages: matrixDamagesQ.data,
+      specimens: matrixSpecimensQ.data,
+    });
+  }, [valueType, matrixTestsQ.data, matrixDamagesQ.data, matrixSpecimensQ.data]);
+
   const [selected, setSelected] = useState<SelectedCell | null>(null);
 
   if (matrixError || testTypesError || materialsError) {
@@ -86,30 +112,60 @@ export const TestMatrixPage = () => {
               0 件の組合せは新規提案の機会として破線で強調されます。
             </p>
           </div>
-          <div
-            role="radiogroup"
-            aria-label="集計期間"
-            className="flex gap-1 rounded-md border border-[var(--border-faint)] bg-[var(--bg-raised)] p-1"
-          >
-            {PERIOD_PRESETS.map((p) => {
-              const active = period === p.key;
-              return (
-                <button
-                  key={p.key}
-                  type="button"
-                  role="radio"
-                  aria-checked={active}
-                  onClick={() => setPeriod(p.key)}
-                  className={`px-3 py-1 text-[12px] rounded transition-colors ${
-                    active
-                      ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
-                      : 'text-[var(--text-md)] hover:bg-[var(--hover)]'
-                  }`}
-                >
-                  {p.label}
-                </button>
-              );
-            })}
+          <div className="flex gap-3 flex-wrap">
+            <div
+              role="radiogroup"
+              aria-label="集計期間"
+              className="flex gap-1 rounded-md border border-[var(--border-faint)] bg-[var(--bg-raised)] p-1"
+            >
+              {PERIOD_PRESETS.map((p) => {
+                const active = period === p.key;
+                return (
+                  <button
+                    key={p.key}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => setPeriod(p.key)}
+                    className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                      active
+                        ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                        : 'text-[var(--text-md)] hover:bg-[var(--hover)]'
+                    }`}
+                  >
+                    {p.label}
+                  </button>
+                );
+              })}
+            </div>
+            <div
+              role="radiogroup"
+              aria-label="セル値"
+              className="flex gap-1 rounded-md border border-[var(--border-faint)] bg-[var(--bg-raised)] p-1"
+            >
+              {([
+                { key: 'count' as const, label: '件数' },
+                { key: 'abnormalRatio' as const, label: '異常率' },
+              ]).map((v) => {
+                const active = valueType === v.key;
+                return (
+                  <button
+                    key={v.key}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => setValueType(v.key)}
+                    className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                      active
+                        ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                        : 'text-[var(--text-md)] hover:bg-[var(--hover)]'
+                    }`}
+                  >
+                    {v.label}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       </header>
@@ -119,6 +175,8 @@ export const TestMatrixPage = () => {
             materials={materials}
             testTypes={testTypes}
             cells={matrix.cells}
+            valueType={valueType}
+            abnormalMap={abnormalMap}
             onCellClick={(materialId, testTypeId) => setSelected({ materialId, testTypeId })}
           />
           <div className="mt-4 flex items-center gap-4 text-[11px] text-[var(--text-lo)]">

--- a/src/features/tests/matrix/abnormalRatio.test.ts
+++ b/src/features/tests/matrix/abnormalRatio.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import type { DamageFinding, Specimen, Test } from '@/domain/types';
+import { computeAbnormalCellMap } from './abnormalRatio';
+
+const makeSpecimen = (id: string, materialId: string): Specimen => ({
+  id,
+  code: `SPC-${id}`,
+  projectId: 'proj',
+  materialId,
+  dimensions: { shape: 'bar', length: 100, diameter: 10 },
+  cutFrom: { parentPart: null, location: null, direction: null },
+  receivedAt: '2026-03-01',
+  location: 'A-1',
+  status: 'tested',
+  notes: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+const makeTest = (
+  id: string,
+  specimenId: string,
+  testTypeId: string,
+  status: Test['status'] = 'completed'
+): Test => ({
+  id,
+  specimenId,
+  testTypeId,
+  status,
+  performedAt: '2026-04-10T10:00:00Z',
+  condition: { temperature: { value: 23, unit: 'C' }, atmosphere: 'air' },
+  standardIds: [],
+  resultMetrics: [],
+  rawDataRefs: [],
+  observations: [],
+  operatorId: 'u',
+  equipmentId: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-04-10',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+const makeDamage = (
+  id: string,
+  testId: string | null,
+  confidenceLevel: DamageFinding['confidenceLevel']
+): DamageFinding => ({
+  id,
+  reportId: 'rep',
+  testId,
+  type: 'fatigue',
+  location: 'surface',
+  rootCauseHypothesis: '',
+  confidenceLevel,
+  images: [],
+  similarCaseIds: [],
+  tags: [],
+  createdAt: '2026-04-10',
+  updatedAt: '2026-04-10',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+describe('computeAbnormalCellMap', () => {
+  it('(materialId × testTypeId) ごとに異常率を算出', () => {
+    const specimens = [
+      makeSpecimen('spc_a', 'mat_a'),
+      makeSpecimen('spc_b', 'mat_a'),
+      makeSpecimen('spc_c', 'mat_b'),
+    ];
+    const tests = [
+      makeTest('t1', 'spc_a', 'tt_tensile'),
+      makeTest('t2', 'spc_b', 'tt_tensile'),
+      makeTest('t3', 'spc_c', 'tt_tensile'),
+    ];
+    const damages = [
+      makeDamage('d1', 't1', 'high'),   // mat_a × tt_tensile 異常あり
+      makeDamage('d2', 't1', 'medium'), // 同じ test への追加所見（unique testId で 1 件扱い）
+      makeDamage('d3', 't3', 'high'),   // mat_b × tt_tensile 異常あり
+    ];
+
+    const map = computeAbnormalCellMap({ tests, damages, specimens });
+    expect(map.size).toBe(2);
+
+    const cellA = map.get('mat_a__tt_tensile');
+    expect(cellA).toBeDefined();
+    expect(cellA!.totalCount).toBe(2);
+    expect(cellA!.abnormalCount).toBe(1); // t1 のみ
+    expect(cellA!.ratio).toBe(0.5);
+
+    const cellB = map.get('mat_b__tt_tensile');
+    expect(cellB!.totalCount).toBe(1);
+    expect(cellB!.abnormalCount).toBe(1);
+    expect(cellB!.ratio).toBe(1);
+  });
+
+  it('low 確信度の所見は分子から除外', () => {
+    const specimens = [makeSpecimen('spc_a', 'mat_a')];
+    const tests = [makeTest('t1', 'spc_a', 'tt_tensile')];
+    const damages = [makeDamage('d1', 't1', 'low')];
+
+    const map = computeAbnormalCellMap({ tests, damages, specimens });
+    const cell = map.get('mat_a__tt_tensile')!;
+    expect(cell.abnormalCount).toBe(0);
+    expect(cell.ratio).toBe(0);
+  });
+
+  it('completed 以外の試験は分母から除外', () => {
+    const specimens = [makeSpecimen('spc_a', 'mat_a'), makeSpecimen('spc_b', 'mat_a')];
+    const tests = [
+      makeTest('t1', 'spc_a', 'tt_tensile', 'completed'),
+      makeTest('t2', 'spc_b', 'tt_tensile', 'scheduled'),
+    ];
+    const damages = [makeDamage('d1', 't1', 'high')];
+
+    const map = computeAbnormalCellMap({ tests, damages, specimens });
+    const cell = map.get('mat_a__tt_tensile')!;
+    expect(cell.totalCount).toBe(1);
+    expect(cell.abnormalCount).toBe(1);
+  });
+
+  it('specimen 参照が解決できない Test はスキップ', () => {
+    const specimens: Specimen[] = []; // 意図的に空
+    const tests = [makeTest('t1', 'spc_missing', 'tt_tensile')];
+    const damages = [makeDamage('d1', 't1', 'high')];
+
+    const map = computeAbnormalCellMap({ tests, damages, specimens });
+    expect(map.size).toBe(0);
+  });
+
+  it('testId が null の所見は集計対象外', () => {
+    const specimens = [makeSpecimen('spc_a', 'mat_a')];
+    const tests = [makeTest('t1', 'spc_a', 'tt_tensile')];
+    const damages = [makeDamage('d_orphan', null, 'high')];
+
+    const map = computeAbnormalCellMap({ tests, damages, specimens });
+    const cell = map.get('mat_a__tt_tensile')!;
+    expect(cell.totalCount).toBe(1);
+    expect(cell.abnormalCount).toBe(0);
+  });
+});

--- a/src/features/tests/matrix/abnormalRatio.ts
+++ b/src/features/tests/matrix/abnormalRatio.ts
@@ -1,0 +1,75 @@
+// 試験マトリクスの「異常率」セル値計算。
+// 各 (materialId, testTypeId) セルについて、
+// 分母: 完了試験件数（Test.status === 'completed'、dateFrom で絞り込み済みを想定）
+// 分子: 非 low 所見が紐づく testId の unique 数（1 試験に複数所見があっても 1 件として数える）
+
+import type { DamageFinding, Specimen, Test } from '@/domain/types';
+
+export interface AbnormalCell {
+  materialId: string;
+  testTypeId: string;
+  abnormalCount: number;
+  totalCount: number;
+  ratio: number; // 0..1
+}
+
+/**
+ * (materialId, testTypeId) ごとの異常率を計算する。
+ *
+ * tests は事前に dateFrom で絞り込み済みの想定。
+ * specimens は materialId を Test から逆引きするために使う（Test に materialId は無い）。
+ */
+export const computeAbnormalCellMap = (input: {
+  tests: Test[];
+  damages: DamageFinding[];
+  specimens: Specimen[];
+}): Map<string, AbnormalCell> => {
+  const { tests, damages, specimens } = input;
+
+  const specimenById = new Map<string, Specimen>();
+  for (const s of specimens) specimenById.set(s.id, s);
+
+  // testId → materialId の逆引き索引（specimen 経由）
+  // 同時に testId → testTypeId も保持
+  const testMeta = new Map<string, { materialId: string; testTypeId: string }>();
+  for (const t of tests) {
+    if (t.status !== 'completed') continue;
+    const spec = specimenById.get(t.specimenId);
+    if (!spec) continue;
+    testMeta.set(t.id, { materialId: spec.materialId, testTypeId: t.testTypeId });
+  }
+
+  // 非 low 所見の testId を抽出（unique）
+  const abnormalTestIds = new Set<string>();
+  for (const d of damages) {
+    if (d.confidenceLevel === 'low') continue;
+    if (!d.testId) continue;
+    if (!testMeta.has(d.testId)) continue; // 期間外 / 未完了の Test に紐づく所見は無視
+    abnormalTestIds.add(d.testId);
+  }
+
+  // セルごとに totalCount / abnormalCount を積む
+  const cellMap = new Map<string, AbnormalCell>();
+  const keyOf = (materialId: string, testTypeId: string) => `${materialId}__${testTypeId}`;
+
+  for (const [testId, meta] of testMeta) {
+    const key = keyOf(meta.materialId, meta.testTypeId);
+    const cell = cellMap.get(key) ?? {
+      materialId: meta.materialId,
+      testTypeId: meta.testTypeId,
+      abnormalCount: 0,
+      totalCount: 0,
+      ratio: 0,
+    };
+    cell.totalCount += 1;
+    if (abnormalTestIds.has(testId)) cell.abnormalCount += 1;
+    cellMap.set(key, cell);
+  }
+
+  // 比率を最後に計算（ゼロ割回避）
+  for (const cell of cellMap.values()) {
+    cell.ratio = cell.totalCount > 0 ? cell.abnormalCount / cell.totalCount : 0;
+  }
+
+  return cellMap;
+};

--- a/src/features/tests/matrix/api.ts
+++ b/src/features/tests/matrix/api.ts
@@ -7,7 +7,16 @@ export const testMatrixKeys = {
   matrix: (query?: MatrixQuery) => [...testMatrixKeys.all, 'matrix', query] as const,
   testTypes: ['test-types'] as const,
   materials: (filter?: Record<string, unknown>) => ['materials', filter] as const,
+  tests: (query?: Record<string, unknown>) => [...testMatrixKeys.all, 'tests', query] as const,
+  damages: ['test-matrix', 'damages'] as const,
+  specimens: ['test-matrix', 'specimens'] as const,
 };
+
+// マトリクス画面で異常率計算に使う補助データ。
+// dateFrom 付きで tests を絞ることでフロント集計の計算量を減らす。
+const MATRIX_TEST_PAGE_SIZE = 3000;
+const MATRIX_DAMAGE_PAGE_SIZE = 500;
+const MATRIX_SPECIMEN_PAGE_SIZE = 1000;
 
 export const useTestMatrix = (query?: MatrixQuery) => {
   const { tests } = useRepositories();
@@ -33,5 +42,44 @@ export const useMaterials = () => {
     queryKey: testMatrixKeys.materials(),
     queryFn: () => materials.list(),
     staleTime: 5 * 60_000,
+  });
+};
+
+export const useMatrixTests = (dateFrom?: string) => {
+  const { tests } = useRepositories();
+  return useQuery({
+    queryKey: testMatrixKeys.tests({ dateFrom }),
+    queryFn: async () => {
+      const page = await tests.list({
+        filter: dateFrom ? { performedAfter: dateFrom } : undefined,
+        pageSize: MATRIX_TEST_PAGE_SIZE,
+      });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};
+
+export const useMatrixDamages = () => {
+  const { damage } = useRepositories();
+  return useQuery({
+    queryKey: testMatrixKeys.damages,
+    queryFn: async () => {
+      const page = await damage.list({ pageSize: MATRIX_DAMAGE_PAGE_SIZE });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};
+
+export const useMatrixSpecimens = () => {
+  const { specimens } = useRepositories();
+  return useQuery({
+    queryKey: testMatrixKeys.specimens,
+    queryFn: async () => {
+      const page = await specimens.list({ pageSize: MATRIX_SPECIMEN_PAGE_SIZE });
+      return page.items;
+    },
+    staleTime: 60_000,
   });
 };


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 D の後半（セル値切替）。試験マトリクスに **件数 / 異常率** のセル値切替 UI を追加。異常率は完了試験に対する非 low 確信度の損傷所見の割合として計算する。

軸切替（顧客 × 試験種別 / 業種 × 材料 等）は D-3 として別 PR に分離。

## 変更

### 1. 異常率計算（`abnormalRatio.ts`）
- `computeAbnormalCellMap({ tests, damages, specimens })` 純関数
- (materialId × testTypeId) ごとに:
  - **分母**: 完了試験件数（`Test.status === 'completed'`、dateFrom で絞り込み済みを想定）
  - **分子**: 非 low 確信度の所見が紐づく unique testId 数（1 試験に複数所見があっても 1 件として数える）
- Test に直接 `materialId` は無いため、`specimen.materialId` 経由で逆引き

### 2. HeatmapMatrix の拡張
- `valueType?: 'count' | 'abnormalRatio'` prop 追加
- `abnormalMap?: Map<string, AbnormalCell>` prop 追加
- 異常率モードは **赤系グラデーション**で視認性を上げる（件数は青系、異常は赤系と対比）
- aria-label: `"異常率 50%（1 / 2）"` のように分子/分母も含める
- 0 件セル（=未経験）ハイライトは維持

### 3. TestMatrixPage
- header 右に「件数 / 異常率」radiogroup を配置
- 異常率モードのみ `useMatrixTests` / `useMatrixDamages` / `useMatrixSpecimens` の 3 クエリを並列取得
- `useMemo` で `computeAbnormalCellMap` をキャッシュ

### 4. 既存 api.ts との整合
- `MatrixQuery.dateFrom` を `TestFilter.performedAfter` にマップして取得

## テスト

- typecheck pass
- matrix テスト **9/9 pass**（既存 4 + abnormalRatio 5）
- 異常率 5 ケース:
  - 基本集計（同一 test への複数所見は unique testId で 1 件扱い）
  - low 確信度の所見を分子から除外
  - 未完了試験を分母から除外
  - specimen 参照解決できない Test をスキップ
  - testId null の所見を集計外

## Phase 3.5 進捗
- [x] B-1 切削 KPI（PR #85）
- [x] B-2 分布チャート（PR #86）
- [x] D-1 期間フィルタ + 未経験ハイライト（PR #87）
- [x] D-2 セル値切替 件数 / 異常率（本 PR）
- [ ] D-3 軸切替（顧客 × 試験種別 / 業種 × 材料 等）
- [ ] C 案件詳細情報密度
- [ ] A MaiML エクスポート UI 拡張