### PR TITLE
feat(matrix): 試験マトリクスに行軸切替（材料軸 / 顧客軸）を追加（Phase 3.5 D-3）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-matrix-row-axis-switching',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '試験マトリクスに行軸切替（材料軸 / 顧客軸）を追加',
+    body: 'マトリクスのヘッダ左端に「材料軸 / 顧客軸」のトグルを追加しました。顧客軸を選ぶと、顧客 × 試験種別で過去完了試験を集計したヒートマップを表示します。PM が顧客ごとの試験実績の濃淡や未経験領域を把握し、次の提案機会を見つける支援になります。期間フィルタ・セル値切替（件数 / 異常率）・0 件ハイライトは両軸で共通動作します。',
+  },
+  {
     id: '2026-04-24-matrix-cell-value-switching',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/tests/matrix/HeatmapMatrix.test.tsx
+++ b/src/features/tests/matrix/HeatmapMatrix.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { HeatmapMatrix } from './HeatmapMatrix';
+import { HeatmapMatrix, materialsToRows } from './HeatmapMatrix';
 import type { Material, TestType } from '@/domain/types';
 import type { MatrixCell } from '@/infra/repositories/interfaces';
 
@@ -63,7 +63,7 @@ const cells: MatrixCell[] = [
 
 describe('HeatmapMatrix', () => {
   it('材料行・試験種別列・合計列をレンダリングする', () => {
-    render(<HeatmapMatrix materials={materials} testTypes={testTypes} cells={cells} />);
+    render(<HeatmapMatrix rows={materialsToRows(materials)} testTypes={testTypes} cells={cells} />);
     expect(screen.getByText('SUS304')).toBeInTheDocument();
     expect(screen.getByText('S45C')).toBeInTheDocument();
     expect(screen.getByText('引張試験')).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe('HeatmapMatrix', () => {
   });
 
   it('件数が 0 のセルは中黒表示、件数ありは数値表示', () => {
-    render(<HeatmapMatrix materials={materials} testTypes={testTypes} cells={cells} />);
+    render(<HeatmapMatrix rows={materialsToRows(materials)} testTypes={testTypes} cells={cells} />);
     expect(screen.getByLabelText('SUS304 × 引張試験: 5件')).toHaveTextContent('5');
     // 0 件セルは新規提案候補として専用ラベルでアクセス可能
     expect(
@@ -80,7 +80,7 @@ describe('HeatmapMatrix', () => {
   });
 
   it('0 件セルは data-empty-cell="true" で識別でき、視覚的強調用の破線が当たる', () => {
-    render(<HeatmapMatrix materials={materials} testTypes={testTypes} cells={cells} />);
+    render(<HeatmapMatrix rows={materialsToRows(materials)} testTypes={testTypes} cells={cells} />);
     const emptyCell = screen.getByLabelText('SUS304 × 疲労試験: 未経験の組合せ（新規提案候補）');
     expect(emptyCell.getAttribute('data-empty-cell')).toBe('true');
     // 破線強調 class
@@ -91,7 +91,7 @@ describe('HeatmapMatrix', () => {
     const handler = vi.fn();
     render(
       <HeatmapMatrix
-        materials={materials}
+        rows={materialsToRows(materials)}
         testTypes={testTypes}
         cells={cells}
         onCellClick={handler}

--- a/src/features/tests/matrix/HeatmapMatrix.tsx
+++ b/src/features/tests/matrix/HeatmapMatrix.tsx
@@ -4,16 +4,36 @@ import type { AbnormalCell } from './abnormalRatio';
 
 export type MatrixValueType = 'count' | 'abnormalRatio';
 
+/** 行の表示項目。material / customer 等を汎用的に受ける。 */
+export interface RowEntry {
+  id: ID;
+  primaryLabel: string; // 主表示（例: SUS304 / 株式会社 ABC）
+  secondaryLabel?: string; // 副表示（例: stainless / 業種タグ）
+  /** 行軸種別をアリアラベル組立に使う */
+  axisLabel: string; // 'material' | '顧客' 等
+}
+
 export interface HeatmapMatrixProps {
-  materials: Material[];
+  rows: RowEntry[];
   testTypes: TestType[];
   cells: MatrixCell[];
-  onCellClick?: (materialId: ID, testTypeId: ID) => void;
+  onCellClick?: (rowId: ID, testTypeId: ID) => void;
   /** セル値の表示モード。既定 'count'。 */
   valueType?: MatrixValueType;
   /** 異常率モード時の補助マップ。count モードでは不要。 */
   abnormalMap?: Map<string, AbnormalCell>;
+  /** 左上ヘッダセルのラベル（例: "材料 \ 試験種別" / "顧客 \ 試験種別"） */
+  rowHeaderLabel?: string;
 }
+
+/** Material 配列を RowEntry[] に変換するヘルパ。 */
+export const materialsToRows = (materials: Material[]): RowEntry[] =>
+  materials.map((m) => ({
+    id: m.id,
+    primaryLabel: m.designation,
+    secondaryLabel: m.category,
+    axisLabel: '材料',
+  }));
 
 const cellKey = (materialId: ID, testTypeId: ID) => `${materialId}__${testTypeId}`;
 
@@ -46,12 +66,13 @@ const textColorForRatio = (ratio: number): string => {
 const formatRatio = (ratio: number): string => `${(ratio * 100).toFixed(0)}%`;
 
 export const HeatmapMatrix = ({
-  materials,
+  rows,
   testTypes,
   cells,
   onCellClick,
   valueType = 'count',
   abnormalMap,
+  rowHeaderLabel = '材料 \\ 試験種別',
 }: HeatmapMatrixProps) => {
   const cellMap = new Map<string, MatrixCell>();
   cells.forEach((c) => cellMap.set(cellKey(c.materialId, c.testTypeId), c));
@@ -74,7 +95,7 @@ export const HeatmapMatrix = ({
               className="sticky left-0 top-0 z-20 bg-[var(--bg-raised)] border-b border-r border-[var(--border-faint)] px-3 py-2 text-left font-semibold"
               style={{ minWidth: 180 }}
             >
-              材料 \ 試験種別
+              {rowHeaderLabel}
             </th>
             {testTypes.map((tt) => (
               <th
@@ -97,22 +118,24 @@ export const HeatmapMatrix = ({
           </tr>
         </thead>
         <tbody>
-          {materials.map((mat) => (
-            <tr key={mat.id}>
+          {rows.map((row) => (
+            <tr key={row.id}>
               <th
                 scope="row"
                 className="sticky left-0 z-10 bg-[var(--bg-raised)] border-b border-r border-[var(--border-faint)] px-3 py-2 text-left font-medium whitespace-nowrap"
               >
                 <div className="flex flex-col">
-                  <span className="font-mono text-[12px]">{mat.designation}</span>
-                  <span className="text-[10px] text-[var(--text-lo)]">{mat.category}</span>
+                  <span className="font-mono text-[12px]">{row.primaryLabel}</span>
+                  {row.secondaryLabel && (
+                    <span className="text-[10px] text-[var(--text-lo)]">{row.secondaryLabel}</span>
+                  )}
                 </div>
               </th>
               {testTypes.map((tt) => {
-                const cell = cellMap.get(cellKey(mat.id, tt.id));
+                const cell = cellMap.get(cellKey(row.id, tt.id));
                 const count = cell?.count ?? 0;
                 const isEmpty = count === 0;
-                const abnormal = abnormalMap?.get(cellKey(mat.id, tt.id));
+                const abnormal = abnormalMap?.get(cellKey(row.id, tt.id));
                 const isAbnormalMode = valueType === 'abnormalRatio';
                 const ratio = abnormal?.ratio ?? 0;
 
@@ -133,10 +156,10 @@ export const HeatmapMatrix = ({
                   : textColorForCount(count, maxCount);
 
                 const ariaLabel = isEmpty
-                  ? `${mat.designation} × ${tt.name}: 未経験の組合せ（新規提案候補）`
+                  ? `${row.primaryLabel} × ${tt.name}: 未経験の組合せ（新規提案候補）`
                   : isAbnormalMode && abnormal
-                    ? `${mat.designation} × ${tt.name}: 異常率 ${formatRatio(ratio)}（${abnormal.abnormalCount} / ${abnormal.totalCount}）`
-                    : `${mat.designation} × ${tt.name}: ${count}件`;
+                    ? `${row.primaryLabel} × ${tt.name}: 異常率 ${formatRatio(ratio)}（${abnormal.abnormalCount} / ${abnormal.totalCount}）`
+                    : `${row.primaryLabel} × ${tt.name}: ${count}件`;
 
                 return (
                   <td
@@ -145,7 +168,7 @@ export const HeatmapMatrix = ({
                   >
                     <button
                       type="button"
-                      onClick={() => onCellClick?.(mat.id, tt.id)}
+                      onClick={() => onCellClick?.(row.id, tt.id)}
                       aria-label={ariaLabel}
                       data-empty-cell={isEmpty ? 'true' : undefined}
                       className={
@@ -165,7 +188,7 @@ export const HeatmapMatrix = ({
                 );
               })}
               <td className="sticky right-0 bg-[var(--bg-raised)] border-b border-l border-[var(--border-faint)] px-2 py-2 text-right font-mono tabular-nums font-semibold">
-                {rowTotals.get(mat.id) ?? 0}
+                {rowTotals.get(row.id) ?? 0}
               </td>
             </tr>
           ))}

--- a/src/features/tests/matrix/TestMatrixPage.tsx
+++ b/src/features/tests/matrix/TestMatrixPage.tsx
@@ -1,18 +1,23 @@
 import { useMemo, useState } from 'react';
 import type { ID } from '@/domain/types';
-import { HeatmapMatrix, type MatrixValueType } from './HeatmapMatrix';
+import { HeatmapMatrix, materialsToRows, type MatrixValueType, type RowEntry } from './HeatmapMatrix';
 import {
   useMaterials,
+  useMatrixCustomers,
   useMatrixDamages,
+  useMatrixProjects,
   useMatrixSpecimens,
   useMatrixTests,
   useTestMatrix,
   useTestTypes,
 } from './api';
 import { computeAbnormalCellMap } from './abnormalRatio';
+import { computeCustomerTestTypeCells } from './customerMatrix';
+
+type RowAxis = 'material' | 'customer';
 
 interface SelectedCell {
-  materialId: ID;
+  rowId: ID;
   testTypeId: ID;
 }
 
@@ -35,10 +40,12 @@ const dateFromForPreset = (preset: PeriodPreset, now: Date = new Date()): string
 export const TestMatrixPage = () => {
   const [period, setPeriod] = useState<PeriodPreset>('all');
   const [valueType, setValueType] = useState<MatrixValueType>('count');
+  const [rowAxis, setRowAxis] = useState<RowAxis>('material');
+
+  const dateFrom = useMemo(() => dateFromForPreset(period), [period]);
   const query = useMemo(() => {
-    const dateFrom = dateFromForPreset(period);
     return dateFrom ? { dateFrom } : undefined;
-  }, [period]);
+  }, [dateFrom]);
 
   const { data: matrix, isLoading: matrixLoading, isError: matrixError } = useTestMatrix(query);
   const {
@@ -52,11 +59,13 @@ export const TestMatrixPage = () => {
     isError: materialsError,
   } = useMaterials();
 
-  // 異常率モードのみで必要な補助データ。count モードではクエリ結果が揃っていなくても UI に影響しない。
-  const dateFrom = useMemo(() => dateFromForPreset(period), [period]);
+  // 異常率モード / 顧客行軸モード で共通して使う補助クエリ。
+  // count モードかつ material 行軸では UI をブロックしない設計。
   const matrixTestsQ = useMatrixTests(dateFrom);
   const matrixDamagesQ = useMatrixDamages();
   const matrixSpecimensQ = useMatrixSpecimens();
+  const matrixCustomersQ = useMatrixCustomers();
+  const matrixProjectsQ = useMatrixProjects();
 
   const abnormalMap = useMemo(() => {
     if (valueType !== 'abnormalRatio') return undefined;
@@ -68,6 +77,17 @@ export const TestMatrixPage = () => {
     });
   }, [valueType, matrixTestsQ.data, matrixDamagesQ.data, matrixSpecimensQ.data]);
 
+  // 顧客 × 試験種別のセル集計（顧客行軸モード時のみ使用）
+  const customerCells = useMemo(() => {
+    if (rowAxis !== 'customer') return undefined;
+    if (!matrixTestsQ.data || !matrixSpecimensQ.data || !matrixProjectsQ.data) return undefined;
+    return computeCustomerTestTypeCells({
+      tests: matrixTestsQ.data,
+      specimens: matrixSpecimensQ.data,
+      projects: matrixProjectsQ.data,
+    });
+  }, [rowAxis, matrixTestsQ.data, matrixSpecimensQ.data, matrixProjectsQ.data]);
+
   const [selected, setSelected] = useState<SelectedCell | null>(null);
 
   if (matrixError || testTypesError || materialsError) {
@@ -78,13 +98,18 @@ export const TestMatrixPage = () => {
     );
   }
 
+  // 材料行軸は materials + matrix() で描画可能。顧客行軸は customers + customerCells が揃う必要。
+  const isCustomerAxisReady =
+    rowAxis !== 'customer' || (matrixCustomersQ.data && customerCells);
+
   if (
     matrixLoading ||
     testTypesLoading ||
     materialsLoading ||
     !matrix ||
     !testTypes ||
-    !materials
+    !materials ||
+    !isCustomerAxisReady
   ) {
     return (
       <div className="p-6">
@@ -93,11 +118,26 @@ export const TestMatrixPage = () => {
     );
   }
 
-  const selectedMaterial = selected ? materials.find((m) => m.id === selected.materialId) : null;
+  // 行配列と表示用 cells を行軸で切替
+  const rows: RowEntry[] =
+    rowAxis === 'customer' && matrixCustomersQ.data
+      ? matrixCustomersQ.data.map((c) => ({
+          id: c.id,
+          primaryLabel: c.name,
+          secondaryLabel: undefined,
+          axisLabel: '顧客',
+        }))
+      : materialsToRows(materials);
+
+  const displayCells = rowAxis === 'customer' && customerCells ? customerCells : matrix.cells;
+  const rowHeaderLabel = rowAxis === 'customer' ? '顧客 \\ 試験種別' : '材料 \\ 試験種別';
+
+  // 選択セルの解決を行軸に応じて切替
+  const selectedRow = selected ? rows.find((r) => r.id === selected.rowId) : null;
   const selectedTestType = selected ? testTypes.find((t) => t.id === selected.testTypeId) : null;
   const selectedCell = selected
-    ? matrix.cells.find(
-        (c) => c.materialId === selected.materialId && c.testTypeId === selected.testTypeId
+    ? displayCells.find(
+        (c) => c.materialId === selected.rowId && c.testTypeId === selected.testTypeId
       )
     : null;
 
@@ -113,6 +153,37 @@ export const TestMatrixPage = () => {
             </p>
           </div>
           <div className="flex gap-3 flex-wrap">
+            <div
+              role="radiogroup"
+              aria-label="行軸"
+              className="flex gap-1 rounded-md border border-[var(--border-faint)] bg-[var(--bg-raised)] p-1"
+            >
+              {([
+                { key: 'material' as const, label: '材料軸' },
+                { key: 'customer' as const, label: '顧客軸' },
+              ]).map((a) => {
+                const active = rowAxis === a.key;
+                return (
+                  <button
+                    key={a.key}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => {
+                      setRowAxis(a.key);
+                      setSelected(null);
+                    }}
+                    className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                      active
+                        ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                        : 'text-[var(--text-md)] hover:bg-[var(--hover)]'
+                    }`}
+                  >
+                    {a.label}
+                  </button>
+                );
+              })}
+            </div>
             <div
               role="radiogroup"
               aria-label="集計期間"
@@ -172,18 +243,20 @@ export const TestMatrixPage = () => {
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 p-6 overflow-auto">
           <HeatmapMatrix
-            materials={materials}
+            rows={rows}
             testTypes={testTypes}
-            cells={matrix.cells}
+            cells={displayCells}
             valueType={valueType}
             abnormalMap={abnormalMap}
-            onCellClick={(materialId, testTypeId) => setSelected({ materialId, testTypeId })}
+            rowHeaderLabel={rowHeaderLabel}
+            onCellClick={(rowId, testTypeId) => setSelected({ rowId, testTypeId })}
           />
           <div className="mt-4 flex items-center gap-4 text-[11px] text-[var(--text-lo)]">
-            <span>件数の多寡を青の濃淡で表示。</span>
+            <span>件数の多寡を青の濃淡で表示。異常率モードは赤系。</span>
             <span>
-              合計 {matrix.cells.reduce((sum, c) => sum + c.count, 0)} 件 / 材料 {materials.length}{' '}
-              種 × 試験種別 {testTypes.length} 種
+              合計 {displayCells.reduce((sum, c) => sum + c.count, 0)} 件 /{' '}
+              {rowAxis === 'customer' ? '顧客' : '材料'} {rows.length} 種 × 試験種別{' '}
+              {testTypes.length} 種
             </span>
           </div>
         </div>
@@ -191,18 +264,18 @@ export const TestMatrixPage = () => {
           className="w-80 border-l border-[var(--border-faint)] p-4 overflow-auto bg-[var(--bg-raised)]"
           aria-label="選択セル詳細"
         >
-          {!selected || !selectedMaterial || !selectedTestType ? (
+          {!selected || !selectedRow || !selectedTestType ? (
             <div className="text-[13px] text-[var(--text-lo)]">
               セルをクリックすると、その組合せの実績詳細が表示されます。
             </div>
           ) : (
             <div className="flex flex-col gap-3 text-[13px]">
               <div>
-                <div className="text-[11px] text-[var(--text-lo)]">材料</div>
-                <div className="font-mono font-semibold">{selectedMaterial.designation}</div>
-                <div className="text-[11px] text-[var(--text-lo)]">
-                  {selectedMaterial.category}
-                </div>
+                <div className="text-[11px] text-[var(--text-lo)]">{selectedRow.axisLabel}</div>
+                <div className="font-mono font-semibold">{selectedRow.primaryLabel}</div>
+                {selectedRow.secondaryLabel && (
+                  <div className="text-[11px] text-[var(--text-lo)]">{selectedRow.secondaryLabel}</div>
+                )}
               </div>
               <div>
                 <div className="text-[11px] text-[var(--text-lo)]">試験種別</div>

--- a/src/features/tests/matrix/api.ts
+++ b/src/features/tests/matrix/api.ts
@@ -10,6 +10,8 @@ export const testMatrixKeys = {
   tests: (query?: Record<string, unknown>) => [...testMatrixKeys.all, 'tests', query] as const,
   damages: ['test-matrix', 'damages'] as const,
   specimens: ['test-matrix', 'specimens'] as const,
+  customers: ['test-matrix', 'customers'] as const,
+  projects: ['test-matrix', 'projects'] as const,
 };
 
 // マトリクス画面で異常率計算に使う補助データ。
@@ -78,6 +80,30 @@ export const useMatrixSpecimens = () => {
     queryKey: testMatrixKeys.specimens,
     queryFn: async () => {
       const page = await specimens.list({ pageSize: MATRIX_SPECIMEN_PAGE_SIZE });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};
+
+export const useMatrixCustomers = () => {
+  const { customers } = useRepositories();
+  return useQuery({
+    queryKey: testMatrixKeys.customers,
+    queryFn: async () => {
+      const page = await customers.list();
+      return page.items;
+    },
+    staleTime: 5 * 60_000,
+  });
+};
+
+export const useMatrixProjects = () => {
+  const { projects } = useRepositories();
+  return useQuery({
+    queryKey: testMatrixKeys.projects,
+    queryFn: async () => {
+      const page = await projects.list({ pageSize: 500 });
       return page.items;
     },
     staleTime: 60_000,

--- a/src/features/tests/matrix/customerMatrix.test.ts
+++ b/src/features/tests/matrix/customerMatrix.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { Project, Specimen, Test } from '@/domain/types';
+import { computeCustomerTestTypeCells } from './customerMatrix';
+
+const makeSpecimen = (id: string, projectId: string): Specimen => ({
+  id,
+  code: `SPC-${id}`,
+  projectId,
+  materialId: 'mat',
+  dimensions: { shape: 'bar', length: 100, diameter: 10 },
+  cutFrom: { parentPart: null, location: null, direction: null },
+  receivedAt: '2026-03-01',
+  location: 'A-1',
+  status: 'tested',
+  notes: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+const makeProject = (id: string, customerId: string): Project => ({
+  id,
+  code: `IIC-2026-${id}`,
+  title: 't',
+  customerId,
+  industryTagIds: [],
+  status: 'in_progress',
+  startedAt: '2026-03-01',
+  dueAt: null,
+  completedAt: null,
+  specimenCount: 0,
+  testCount: 0,
+  pmId: 'u',
+  leadEngineerId: 'u',
+  description: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+const makeTest = (
+  id: string,
+  specimenId: string,
+  testTypeId: string,
+  performedAt: string,
+  status: Test['status'] = 'completed'
+): Test => ({
+  id,
+  specimenId,
+  testTypeId,
+  status,
+  performedAt,
+  condition: { temperature: { value: 23, unit: 'C' }, atmosphere: 'air' },
+  standardIds: [],
+  resultMetrics: [],
+  rawDataRefs: [],
+  observations: [],
+  operatorId: 'u',
+  equipmentId: null,
+  createdAt: '2026-03-01',
+  updatedAt: performedAt,
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+describe('computeCustomerTestTypeCells', () => {
+  it('customerId × testTypeId でカウントを集計', () => {
+    const projects = [makeProject('p1', 'cst_a'), makeProject('p2', 'cst_b')];
+    const specimens = [
+      makeSpecimen('spc_1', 'p1'),
+      makeSpecimen('spc_2', 'p1'),
+      makeSpecimen('spc_3', 'p2'),
+    ];
+    const tests = [
+      makeTest('t1', 'spc_1', 'tt_tensile', '2026-04-10T10:00:00Z'),
+      makeTest('t2', 'spc_2', 'tt_tensile', '2026-04-15T10:00:00Z'),
+      makeTest('t3', 'spc_3', 'tt_hardness', '2026-04-12T10:00:00Z'),
+    ];
+    const cells = computeCustomerTestTypeCells({ tests, specimens, projects });
+    expect(cells).toHaveLength(2);
+    const a = cells.find((c) => c.materialId === 'cst_a' && c.testTypeId === 'tt_tensile')!;
+    expect(a.count).toBe(2);
+    expect(a.latestPerformedAt).toBe('2026-04-15T10:00:00Z');
+    const b = cells.find((c) => c.materialId === 'cst_b' && c.testTypeId === 'tt_hardness')!;
+    expect(b.count).toBe(1);
+  });
+
+  it('未完了試験は集計から除外', () => {
+    const projects = [makeProject('p1', 'cst_a')];
+    const specimens = [makeSpecimen('spc_1', 'p1')];
+    const tests = [
+      makeTest('t_done', 'spc_1', 'tt_tensile', '2026-04-10T10:00:00Z', 'completed'),
+      makeTest('t_sched', 'spc_1', 'tt_tensile', '2026-04-12T10:00:00Z', 'scheduled'),
+    ];
+    const cells = computeCustomerTestTypeCells({ tests, specimens, projects });
+    expect(cells).toHaveLength(1);
+    expect(cells[0]!.count).toBe(1);
+  });
+
+  it('specimen / project 参照が解決できない Test は skip', () => {
+    const cells = computeCustomerTestTypeCells({
+      tests: [makeTest('t1', 'spc_missing', 'tt_tensile', '2026-04-10T10:00:00Z')],
+      specimens: [],
+      projects: [],
+    });
+    expect(cells).toHaveLength(0);
+  });
+
+  it('latestPerformedAt は最新のタイムスタンプを保持', () => {
+    const projects = [makeProject('p1', 'cst_a')];
+    const specimens = [makeSpecimen('spc_1', 'p1')];
+    const tests = [
+      makeTest('t1', 'spc_1', 'tt_tensile', '2026-04-10T10:00:00Z'),
+      makeTest('t2', 'spc_1', 'tt_tensile', '2026-04-20T10:00:00Z'),
+      makeTest('t3', 'spc_1', 'tt_tensile', '2026-04-15T10:00:00Z'),
+    ];
+    const cells = computeCustomerTestTypeCells({ tests, specimens, projects });
+    expect(cells[0]!.latestPerformedAt).toBe('2026-04-20T10:00:00Z');
+  });
+});

--- a/src/features/tests/matrix/customerMatrix.ts
+++ b/src/features/tests/matrix/customerMatrix.ts
@@ -1,0 +1,62 @@
+// 顧客 × 試験種別のマトリクスセル集計。
+// Test.specimenId → Specimen.projectId → Project.customerId の 2 段階逆引きで
+// (customerId, testTypeId) ペアのカウントを出す。
+
+import type { MatrixCell } from '@/infra/repositories/interfaces';
+import type { Project, Specimen, Test } from '@/domain/types';
+
+export const computeCustomerTestTypeCells = (input: {
+  tests: Test[];
+  specimens: Specimen[];
+  projects: Project[];
+}): MatrixCell[] => {
+  const { tests, specimens, projects } = input;
+
+  const specimenById = new Map<string, Specimen>();
+  for (const s of specimens) specimenById.set(s.id, s);
+
+  const projectById = new Map<string, Project>();
+  for (const p of projects) projectById.set(p.id, p);
+
+  // (customerId, testTypeId) ごとの集計
+  type CellAgg = {
+    customerId: string;
+    testTypeId: string;
+    count: number;
+    latestPerformedAt: string | null;
+  };
+  const cellMap = new Map<string, CellAgg>();
+
+  for (const t of tests) {
+    if (t.status !== 'completed') continue;
+    const spec = specimenById.get(t.specimenId);
+    if (!spec) continue;
+    const proj = projectById.get(spec.projectId);
+    if (!proj) continue;
+
+    const key = `${proj.customerId}__${t.testTypeId}`;
+    const existing = cellMap.get(key) ?? {
+      customerId: proj.customerId,
+      testTypeId: t.testTypeId,
+      count: 0,
+      latestPerformedAt: null,
+    };
+    existing.count += 1;
+    // 最新 performedAt を ISO 文字列比較で更新
+    if (!existing.latestPerformedAt || t.performedAt > existing.latestPerformedAt) {
+      existing.latestPerformedAt = t.performedAt;
+    }
+    cellMap.set(key, existing);
+  }
+
+  // MatrixCell 形状で返す（materialId フィールドに customerId を入れる）
+  // HeatmapMatrix は (rowId, testTypeId) を見るだけなのでフィールド名は問題ない
+  return Array.from(cellMap.values()).map((a) => ({
+    materialId: a.customerId,
+    testTypeId: a.testTypeId,
+    count: a.count,
+    latestPerformedAt: a.latestPerformedAt,
+    representativeTemperature: null,
+    atmospheres: [],
+  }));
+};


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 D 最終段（行軸切替）。材料 × 試験種別の既定ビューに加え、顧客 × 試験種別のビューを追加する。これで D 完遂。

## 変更

### 1. HeatmapMatrix の汎用化
- `materials: Material[]` → `rows: RowEntry[]` に抽象化
- `RowEntry`: `{ id, primaryLabel, secondaryLabel?, axisLabel }`
- `materialsToRows(materials)` ヘルパで既存呼び出し先は最小変更
- `rowHeaderLabel` prop で左上ヘッダ文言を切替可能に

### 2. 顧客 × 試験種別の集計
- `customerMatrix.ts::computeCustomerTestTypeCells`
- Test.specimenId → Specimen.projectId → Project.customerId の 2 段逆引き
- 最新 `performedAt` を併記
- 未完了試験 / 参照未解決 Test は除外

### 3. TestMatrixPage
- header 左に行軸 radiogroup（材料軸 / 顧客軸）
- 行軸切替時は選択状態をリセット（`setSelected(null)`）
- `useMatrixCustomers` / `useMatrixProjects` を追加、顧客軸モード時に 3 クエリを並列取得
- rows / displayCells / rowHeaderLabel を軸で切替
- SelectedCell を `rowId` ベースに統一、detail pane の軸ラベルを `selectedRow.axisLabel` で動的に

### 4. 共通動作
期間フィルタ・セル値切替（件数 / 異常率）・0 件ハイライトは **両軸で共通動作**。

## テスト

- typecheck pass
- matrix テスト **13/13 pass**（既存 HeatmapMatrix 4 + abnormalRatio 5 + customerMatrix 4）
- customerMatrix 4 ケース:
  - 顧客 × 試験種別の集計
  - 未完了試験除外
  - specimen / project 参照未解決 skip
  - latestPerformedAt が最新日時

## Phase 3.5 進捗
- [x] B-1 切削 KPI（PR #85）
- [x] B-2 分布チャート（PR #86）
- [x] D-1 期間フィルタ + 未経験ハイライト（PR #87）
- [x] D-2 セル値切替 件数 / 異常率（PR #88）
- [x] D-3 行軸切替 材料軸 / 顧客軸（本 PR）
- [ ] C 案件詳細情報密度
- [ ] A MaiML エクスポート UI 拡張

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * テストマトリックスの行軸を「材料」と「顧客」の間で切り替える機能を追加しました

* **改善**
  * ヒートマップマトリックスの表示設定の柔軟性を向上させました
  * テストマトリックスページのデータ処理を最適化しました
  * 新しいお知らせを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->