### PR TITLE
feat(projects): 案件詳細に納期タイムラインと試験片ステータスミニ Kanban を追加（Phase 3.5 C-1）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-project-detail-density',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '案件詳細に納期タイムラインと試験片ステータスミニ Kanban を追加',
+    body: '案件詳細画面の情報密度を高める 2 ブロックを追加しました。納期タイムラインは開始日・今日・納期・完了日を横バーで可視化し、残日数 / 納期超過日数を色分けで表示します。試験片ステータスは 6 列の Kanban ミニで（受入 / 準備 / 試験中 / 試験済 / 保管 / 廃棄）、件数と比率バーを一目で把握できます。いずれも純 SVG / 純 CSS で実装。',
+  },
+  {
     id: '2026-04-24-matrix-row-axis-switching',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useRepositories } from '@/app/providers';
 import type { ID } from '@/domain/types';
 import { ProjectStatusPill } from './components/ProjectStatusPill';
+import { DueTimeline } from './components/DueTimeline';
+import { SpecimenKanbanMini } from './components/SpecimenKanbanMini';
 import { useCustomersIndex, useProject } from './api';
 
 interface ProjectDetailPageProps {
@@ -68,6 +70,26 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
         </div>
       </header>
       <div className="flex-1 overflow-auto px-6 py-4">
+        <section className="mb-6">
+          <h2 className="font-semibold mb-2 text-[14px]">納期タイムライン</h2>
+          <div className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-3">
+            <DueTimeline
+              startedAt={project.startedAt}
+              dueAt={project.dueAt}
+              completedAt={project.completedAt}
+            />
+          </div>
+        </section>
+
+        <section className="mb-6">
+          <h2 className="font-semibold mb-2 text-[14px]">試験片ステータス</h2>
+          {specimensQuery.data ? (
+            <SpecimenKanbanMini specimens={specimensQuery.data.items} />
+          ) : (
+            <div className="text-[12px] text-[var(--text-lo)]">読み込み中…</div>
+          )}
+        </section>
+
         <section className="mb-8">
           <div className="flex items-center justify-between mb-2">
             <h2 className="font-semibold">試験片 ({project.specimenCount})</h2>

--- a/src/features/projects/components/DueTimeline.test.tsx
+++ b/src/features/projects/components/DueTimeline.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DueTimeline } from './DueTimeline';
+
+describe('DueTimeline', () => {
+  const NOW = new Date('2026-04-15T00:00:00+09:00');
+
+  it('納期未超過では「残り N 日」を表示', () => {
+    render(
+      <DueTimeline
+        startedAt="2026-04-01"
+        dueAt="2026-04-20"
+        completedAt={null}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByRole('img', { name: '納期タイムライン' })).toBeInTheDocument();
+    // 残 5 日（04-15 → 04-20）
+    expect(screen.getByText('残り 5 日')).toBeInTheDocument();
+  });
+
+  it('納期超過では「納期超過 N 日」を表示', () => {
+    render(
+      <DueTimeline
+        startedAt="2026-03-01"
+        dueAt="2026-04-10"
+        completedAt={null}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText('納期超過 5 日')).toBeInTheDocument();
+  });
+
+  it('completedAt がある場合は残日数表示は出さない', () => {
+    render(
+      <DueTimeline
+        startedAt="2026-03-01"
+        dueAt="2026-04-20"
+        completedAt="2026-04-10"
+        now={NOW}
+      />,
+    );
+    expect(screen.queryByText(/残り.*日/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/納期超過/)).not.toBeInTheDocument();
+  });
+
+  it('startedAt が解釈不能なら「開始日情報なし」を表示', () => {
+    render(
+      <DueTimeline
+        startedAt="invalid"
+        dueAt="2026-04-20"
+        completedAt={null}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText('開始日情報なし')).toBeInTheDocument();
+  });
+
+  it('dueAt が null でもレンダリングできる（開始日以降のバーのみ描画）', () => {
+    render(
+      <DueTimeline
+        startedAt="2026-03-01"
+        dueAt={null}
+        completedAt={null}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByRole('img', { name: '納期タイムライン' })).toBeInTheDocument();
+    // 残日数表示は出ない（dueAt なし）
+    expect(screen.queryByText(/残り.*日/)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/projects/components/DueTimeline.tsx
+++ b/src/features/projects/components/DueTimeline.tsx
@@ -1,0 +1,191 @@
+// 納期タイムライン。純 SVG で startedAt → 今日 → dueAt の位置関係を可視化。
+// ADR-009 純 SVG 方針。
+
+interface DueTimelineProps {
+  startedAt: string; // YYYY-MM-DD or ISO
+  dueAt: string | null;
+  completedAt: string | null;
+  now?: Date;
+}
+
+const parseDate = (s: string | null | undefined): Date | null => {
+  if (!s) return null;
+  const isoDateOnly = /^\d{4}-\d{2}-\d{2}$/.test(s);
+  const d = new Date(isoDateOnly ? `${s}T00:00:00+09:00` : s);
+  return Number.isNaN(d.getTime()) ? null : d;
+};
+
+const formatDate = (d: Date): string =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+
+export const DueTimeline = ({ startedAt, dueAt, completedAt, now }: DueTimelineProps) => {
+  const start = parseDate(startedAt);
+  const due = parseDate(dueAt);
+  const completed = parseDate(completedAt);
+  const today = now ?? new Date();
+
+  if (!start) {
+    return (
+      <div className="text-[12px] text-[var(--text-lo)]">開始日情報なし</div>
+    );
+  }
+
+  // 全体レンジ: start 〜 (due または completed または today のうち最新)
+  const endRef = [due, completed, today].filter((d): d is Date => d !== null).sort(
+    (a, b) => b.getTime() - a.getTime()
+  )[0]!;
+  const totalMs = endRef.getTime() - start.getTime();
+  if (totalMs <= 0) {
+    return (
+      <div className="text-[12px] text-[var(--text-lo)]">
+        タイムラインの表示に必要な期間情報が不足しています
+      </div>
+    );
+  }
+
+  const width = 640;
+  const height = 80;
+  const barY = 40;
+  const barHeight = 10;
+  const barLeft = 40;
+  const barRight = width - 40;
+  const barWidth = barRight - barLeft;
+
+  const posFor = (d: Date) => {
+    const ratio = Math.max(0, Math.min(1, (d.getTime() - start.getTime()) / totalMs));
+    return barLeft + ratio * barWidth;
+  };
+
+  const todayX = posFor(today);
+  const dueX = due ? posFor(due) : null;
+  const completedX = completed ? posFor(completed) : null;
+
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const daysLeft = due
+    ? Math.floor((due.getTime() - today.getTime()) / msPerDay)
+    : null;
+  const overdue = daysLeft !== null && daysLeft < 0;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label="納期タイムライン"
+      className="max-w-full h-auto"
+    >
+      <title>納期タイムライン</title>
+
+      {/* 背景バー（経過期間） */}
+      <rect
+        x={barLeft}
+        y={barY}
+        width={barWidth}
+        height={barHeight}
+        rx={barHeight / 2}
+        fill="var(--border-faint,#e5e7eb)"
+      />
+
+      {/* 経過部（start → today） */}
+      <rect
+        x={barLeft}
+        y={barY}
+        width={Math.max(0, todayX - barLeft)}
+        height={barHeight}
+        rx={barHeight / 2}
+        fill="var(--accent,#2563eb)"
+        opacity={0.8}
+      />
+
+      {/* 開始マーカー */}
+      <g>
+        <circle cx={barLeft} cy={barY + barHeight / 2} r={5} fill="var(--accent,#2563eb)" />
+        <text
+          x={barLeft}
+          y={barY - 8}
+          fontSize={10}
+          fill="var(--text-lo)"
+          textAnchor="start"
+        >
+          開始 {formatDate(start)}
+        </text>
+      </g>
+
+      {/* 今日マーカー */}
+      <g>
+        <line
+          x1={todayX}
+          x2={todayX}
+          y1={barY - 6}
+          y2={barY + barHeight + 6}
+          stroke="var(--ok,#22c55e)"
+          strokeWidth={2}
+        />
+        <text
+          x={todayX}
+          y={barY + barHeight + 20}
+          fontSize={10}
+          fill="var(--ok,#22c55e)"
+          textAnchor="middle"
+          fontWeight={600}
+        >
+          今日
+        </text>
+      </g>
+
+      {/* 納期マーカー */}
+      {due && dueX !== null && (
+        <g>
+          <circle
+            cx={dueX}
+            cy={barY + barHeight / 2}
+            r={6}
+            fill={overdue ? 'var(--err,#dc2626)' : 'var(--warn,#d97706)'}
+            stroke="var(--bg-raised,#fff)"
+            strokeWidth={2}
+          />
+          <text
+            x={dueX}
+            y={barY - 8}
+            fontSize={10}
+            fill={overdue ? 'var(--err,#dc2626)' : 'var(--warn,#d97706)'}
+            textAnchor="end"
+            fontWeight={600}
+          >
+            納期 {formatDate(due)}
+          </text>
+        </g>
+      )}
+
+      {/* 完了マーカー */}
+      {completed && completedX !== null && (
+        <g>
+          <rect
+            x={completedX - 5}
+            y={barY - 1}
+            width={10}
+            height={barHeight + 2}
+            fill="var(--ok,#22c55e)"
+            stroke="var(--bg-raised,#fff)"
+            strokeWidth={1}
+          />
+        </g>
+      )}
+
+      {/* 残日数 / 遅延日数テキスト */}
+      {daysLeft !== null && !completed && (
+        <text
+          x={width / 2}
+          y={height - 6}
+          fontSize={11}
+          textAnchor="middle"
+          fill={overdue ? 'var(--err,#dc2626)' : 'var(--text-md)'}
+          fontWeight={overdue ? 700 : 400}
+        >
+          {overdue ? `納期超過 ${Math.abs(daysLeft)} 日` : `残り ${daysLeft} 日`}
+        </text>
+      )}
+    </svg>
+  );
+};

--- a/src/features/projects/components/SpecimenKanbanMini.test.tsx
+++ b/src/features/projects/components/SpecimenKanbanMini.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SpecimenKanbanMini } from './SpecimenKanbanMini';
+import type { Specimen } from '@/domain/types';
+
+const makeSpecimen = (id: string, status: Specimen['status']): Specimen => ({
+  id,
+  code: `SPC-${id}`,
+  projectId: 'proj',
+  materialId: 'mat',
+  dimensions: { shape: 'bar', length: 100, diameter: 10 },
+  cutFrom: { parentPart: null, location: null, direction: null },
+  receivedAt: '2026-03-01',
+  location: 'A-1',
+  status,
+  notes: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+describe('SpecimenKanbanMini', () => {
+  it('6 ステータス列を常に描画し、ステータスごとの件数を表示', () => {
+    const specimens = [
+      makeSpecimen('a1', 'received'),
+      makeSpecimen('a2', 'received'),
+      makeSpecimen('b1', 'testing'),
+      makeSpecimen('c1', 'stored'),
+      makeSpecimen('c2', 'stored'),
+      makeSpecimen('c3', 'stored'),
+    ];
+    render(<SpecimenKanbanMini specimens={specimens} />);
+    // 6 列のラベル
+    expect(screen.getByText('受入')).toBeInTheDocument();
+    expect(screen.getByText('準備')).toBeInTheDocument();
+    expect(screen.getByText('試験中')).toBeInTheDocument();
+    expect(screen.getByText('試験済')).toBeInTheDocument();
+    expect(screen.getByText('保管')).toBeInTheDocument();
+    expect(screen.getByText('廃棄')).toBeInTheDocument();
+    // 件数
+    expect(screen.getByRole('group', { name: '試験片ステータス別件数' })).toBeInTheDocument();
+  });
+
+  it('specimens 空でも 6 列 0 件で描画する（破綻しない）', () => {
+    render(<SpecimenKanbanMini specimens={[]} />);
+    // 受入ラベルの下に 0 があることを確認
+    const group = screen.getByRole('group', { name: '試験片ステータス別件数' });
+    expect(group.querySelectorAll('.text-\\[11px\\]').length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/projects/components/SpecimenKanbanMini.tsx
+++ b/src/features/projects/components/SpecimenKanbanMini.tsx
@@ -1,0 +1,64 @@
+// 試験片のステータス別件数を横並びカラムで表示するミニ Kanban。
+// 案件詳細画面に埋めて「今どの工程に何件滞留しているか」を一目で把握する。
+
+import type { Specimen } from '@/domain/types';
+
+interface SpecimenKanbanMiniProps {
+  specimens: Specimen[];
+}
+
+const STATUS_DEFS: {
+  status: Specimen['status'];
+  label: string;
+  color: string;
+}[] = [
+  { status: 'received', label: '受入', color: 'var(--accent,#2563eb)' },
+  { status: 'prepared', label: '準備', color: 'var(--vec,#0ea5e9)' },
+  { status: 'testing', label: '試験中', color: 'var(--warn,#d97706)' },
+  { status: 'tested', label: '試験済', color: 'var(--ai-col,#a855f7)' },
+  { status: 'stored', label: '保管', color: 'var(--ok,#22c55e)' },
+  { status: 'discarded', label: '廃棄', color: 'var(--text-lo,#94a3b8)' },
+];
+
+export const SpecimenKanbanMini = ({ specimens }: SpecimenKanbanMiniProps) => {
+  const counts = new Map<Specimen['status'], number>();
+  for (const s of specimens) {
+    counts.set(s.status, (counts.get(s.status) ?? 0) + 1);
+  }
+  const total = specimens.length;
+
+  return (
+    <div
+      role="group"
+      aria-label="試験片ステータス別件数"
+      className="grid gap-2"
+      style={{ gridTemplateColumns: `repeat(${STATUS_DEFS.length}, 1fr)` }}
+    >
+      {STATUS_DEFS.map(({ status, label, color }) => {
+        const count = counts.get(status) ?? 0;
+        const ratio = total > 0 ? count / total : 0;
+        return (
+          <div
+            key={status}
+            className="flex flex-col gap-1 px-2 py-1.5 rounded border border-[var(--border-faint)] bg-[var(--bg-raised)]"
+          >
+            <div className="flex items-baseline justify-between gap-1">
+              <span className="text-[11px] text-[var(--text-lo)]">{label}</span>
+              <span className="text-[14px] font-mono font-semibold tabular-nums text-[var(--text-hi)]">
+                {count}
+              </span>
+            </div>
+            {/* 比率バー */}
+            <div className="h-1 rounded-sm bg-[var(--border-faint)] overflow-hidden">
+              <div
+                aria-hidden="true"
+                className="h-full rounded-sm transition-all"
+                style={{ width: `${(ratio * 100).toFixed(1)}%`, background: color }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 C の前半（納期タイムライン + Kanban ミニ）。案件詳細画面の情報密度を上げ、PM が進捗を一目で把握できるようにする。

## 追加コンポーネント

### `DueTimeline`（純 SVG）
- ADR-009 純 SVG 方針
- 横バーで startedAt → 今日 → dueAt の位置関係を可視化
- 開始マーカー / 今日マーカー（緑縦線）/ 納期マーカー（丸、警告色）/ 完了マーカー（矩形）
- 残日数表示: `残り N 日` or `納期超過 N 日`（色分け: warn / err）
- completedAt あるときは残日数非表示

### `SpecimenKanbanMini`
- 6 ステータス列（受入 / 準備 / 試験中 / 試験済 / 保管 / 廃棄）
- 各列に件数 + 比率バー（ステータス別カラー）
- 空リストでも 6 列 0 件を描画（破綻しない）

## ProjectDetailPage への組込
- header 下に 2 セクション（納期タイムライン / 試験片ステータス）を追加
- 既存の試験片リスト / 試験実績テーブルは維持

## テスト
- typecheck pass
- projects テスト 9/9 pass（既存 2 + DueTimeline 5 + SpecimenKanbanMini 2）
- DueTimeline:
  - 納期未超過で「残り N 日」
  - 納期超過で「納期超過 N 日」
  - completedAt ありで残日数非表示
  - startedAt 不正で情報なし表示
  - dueAt null でもレンダ可能

## Phase 3.5 進捗
- [x] B-1 / B-2 ダッシュボード（#85 / #86）
- [x] D-1 / D-2 / D-3 マトリクス（#87 / #88 / #89）
- [x] C-1 納期タイムライン + Kanban ミニ（本 PR）
- [ ] C-2 担当者別負荷サマリ
- [ ] A MaiML エクスポート UI 拡張