### PR TITLE
feat(projects): 案件詳細に担当者負荷サマリを追加（Phase 3.5 C-2）

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-project-owner-load',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '案件詳細に担当者の負荷サマリを追加',
+    body: '案件詳細画面に「担当者の負荷」セクションを追加しました。PM / リードエンジニアそれぞれが現在抱えている進行中案件数（本案件を含む）を表示し、負荷が高い担当者の案件には色分けで警告を出します（3 案件で warn、5 案件で err）。他案件への影響を踏まえた工数調整の判断材料になります。User Repository を新設して ADR-001 レイヤードアーキテクチャに整合させています。',
+  },
+  {
     id: '2026-04-24-project-detail-density',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -4,7 +4,13 @@ import type { ID } from '@/domain/types';
 import { ProjectStatusPill } from './components/ProjectStatusPill';
 import { DueTimeline } from './components/DueTimeline';
 import { SpecimenKanbanMini } from './components/SpecimenKanbanMini';
-import { useCustomersIndex, useProject } from './api';
+import { OwnerLoadSummary } from './components/OwnerLoadSummary';
+import {
+  useAllProjectsForLoad,
+  useCustomersIndex,
+  useProject,
+  useUsersIndex,
+} from './api';
 
 interface ProjectDetailPageProps {
   id: ID;
@@ -15,6 +21,8 @@ interface ProjectDetailPageProps {
 export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps) => {
   const { data: project, isLoading } = useProject(id);
   const { data: customerIndex } = useCustomersIndex();
+  const { data: usersIndex } = useUsersIndex();
+  const { data: allProjects } = useAllProjectsForLoad();
   const { specimens, tests } = useRepositories();
 
   const specimensQuery = useQuery({
@@ -85,6 +93,15 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
           <h2 className="font-semibold mb-2 text-[14px]">試験片ステータス</h2>
           {specimensQuery.data ? (
             <SpecimenKanbanMini specimens={specimensQuery.data.items} />
+          ) : (
+            <div className="text-[12px] text-[var(--text-lo)]">読み込み中…</div>
+          )}
+        </section>
+
+        <section className="mb-6">
+          <h2 className="font-semibold mb-2 text-[14px]">担当者の負荷</h2>
+          {allProjects && usersIndex ? (
+            <OwnerLoadSummary project={project} allProjects={allProjects} users={usersIndex} />
           ) : (
             <div className="text-[12px] text-[var(--text-lo)]">読み込み中…</div>
           )}

--- a/src/features/projects/api.ts
+++ b/src/features/projects/api.ts
@@ -40,3 +40,27 @@ export const useCustomersIndex = () => {
     staleTime: 5 * 60_000,
   });
 };
+
+export const useUsersIndex = () => {
+  const { users } = useRepositories();
+  return useQuery({
+    queryKey: ['users', 'index'],
+    queryFn: async () => {
+      const page = await users.list();
+      return new Map(page.items.map((u) => [u.id, u]));
+    },
+    staleTime: 5 * 60_000,
+  });
+};
+
+export const useAllProjectsForLoad = () => {
+  const { projects } = useRepositories();
+  return useQuery({
+    queryKey: ['projects', 'all-for-load'],
+    queryFn: async () => {
+      const page = await projects.list({ pageSize: 500 });
+      return page.items;
+    },
+    staleTime: 60_000,
+  });
+};

--- a/src/features/projects/components/OwnerLoadSummary.test.tsx
+++ b/src/features/projects/components/OwnerLoadSummary.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { OwnerLoadSummary } from './OwnerLoadSummary';
+import type { Project, User } from '@/domain/types';
+
+const makeProject = (
+  id: string,
+  status: Project['status'],
+  pmId: string,
+  leadEngineerId: string
+): Project => ({
+  id,
+  code: `IIC-${id}`,
+  title: 'test',
+  customerId: 'cst',
+  industryTagIds: [],
+  status,
+  startedAt: '2026-03-01',
+  dueAt: null,
+  completedAt: null,
+  specimenCount: 0,
+  testCount: 0,
+  pmId,
+  leadEngineerId,
+  description: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+  createdBy: 'u',
+  updatedBy: 'u',
+});
+
+const makeUser = (id: string, name: string): User => ({
+  id,
+  name,
+  email: 'x@x',
+  role: 'pm',
+  avatarUrl: null,
+  createdAt: '2026-03-01',
+  updatedAt: '2026-03-01',
+});
+
+describe('OwnerLoadSummary', () => {
+  it('PM / リードエンジニア それぞれの進行中案件数を表示', () => {
+    const current = makeProject('p1', 'in_progress', 'u_pm', 'u_eng');
+    const allProjects = [
+      current,
+      makeProject('p2', 'in_progress', 'u_pm', 'u_other'),
+      makeProject('p3', 'reviewing', 'u_other', 'u_eng'),
+      makeProject('p4', 'completed', 'u_pm', 'u_eng'), // completed は含めない
+    ];
+    const users = new Map<string, User>([
+      ['u_pm', makeUser('u_pm', '佐藤 隆志')],
+      ['u_eng', makeUser('u_eng', '鈴木 誠')],
+    ]);
+
+    render(<OwnerLoadSummary project={current} allProjects={allProjects} users={users} />);
+
+    expect(screen.getByText('PM')).toBeInTheDocument();
+    expect(screen.getByText('リードエンジニア')).toBeInTheDocument();
+    expect(screen.getByText('佐藤 隆志')).toBeInTheDocument();
+    expect(screen.getByText('鈴木 誠')).toBeInTheDocument();
+    // PM: p1 + p2 = 2 案件
+    // Eng: p1 + p3 = 2 案件
+    expect(screen.getAllByText('2').length).toBe(2);
+  });
+
+  it('PM = リードエンジニアなら同一カウント', () => {
+    const current = makeProject('p1', 'in_progress', 'u_same', 'u_same');
+    const allProjects = [
+      current,
+      makeProject('p2', 'in_progress', 'u_same', 'u_same'),
+    ];
+    const users = new Map<string, User>([['u_same', makeUser('u_same', '田中 一郎')]]);
+    render(<OwnerLoadSummary project={current} allProjects={allProjects} users={users} />);
+    // 両カードに 2 が表示される（同一ユーザー）
+    expect(screen.getAllByText('2').length).toBe(2);
+    expect(screen.getAllByText('田中 一郎').length).toBe(2);
+  });
+
+  it('users index に無い担当者は ID のまま表示', () => {
+    const current = makeProject('p1', 'in_progress', 'u_missing', 'u_also_missing');
+    render(
+      <OwnerLoadSummary project={current} allProjects={[current]} users={new Map()} />,
+    );
+    expect(screen.getByText('u_missing')).toBeInTheDocument();
+    expect(screen.getByText('u_also_missing')).toBeInTheDocument();
+  });
+});

--- a/src/features/projects/components/OwnerLoadSummary.tsx
+++ b/src/features/projects/components/OwnerLoadSummary.tsx
@@ -1,0 +1,93 @@
+// 案件詳細の担当者負荷サマリ。PM / リードエンジニアそれぞれが抱える
+// 進行中案件の件数を表示し、「この担当者は他にも案件を持っている」ことを可視化する。
+
+import type { Project, User } from '@/domain/types';
+
+interface OwnerLoadSummaryProps {
+  project: Project;
+  allProjects: Project[];
+  users: Map<string, User>;
+}
+
+const ACTIVE_STATUSES: Project['status'][] = [
+  'inquiry',
+  'quoting',
+  'in_progress',
+  'reviewing',
+];
+
+const countActiveForUser = (projects: Project[], userId: string): number => {
+  return projects.filter(
+    (p) =>
+      ACTIVE_STATUSES.includes(p.status) &&
+      (p.pmId === userId || p.leadEngineerId === userId)
+  ).length;
+};
+
+export const OwnerLoadSummary = ({ project, allProjects, users }: OwnerLoadSummaryProps) => {
+  const pm = users.get(project.pmId);
+  const eng = users.get(project.leadEngineerId);
+  const pmLoad = countActiveForUser(allProjects, project.pmId);
+  const engLoad =
+    project.leadEngineerId === project.pmId
+      ? pmLoad
+      : countActiveForUser(allProjects, project.leadEngineerId);
+
+  // 軽い負荷警告閾値（3 案件以上で warn、5 以上で err）
+  const toneForLoad = (count: number): string => {
+    if (count >= 5) return 'var(--err,#dc2626)';
+    if (count >= 3) return 'var(--warn,#d97706)';
+    return 'var(--text-hi)';
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label="担当者別負荷"
+      className="grid gap-3"
+      style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}
+    >
+      <OwnerCard
+        roleLabel="PM"
+        userId={project.pmId}
+        userName={pm?.name ?? null}
+        activeCount={pmLoad}
+        color={toneForLoad(pmLoad)}
+      />
+      <OwnerCard
+        roleLabel="リードエンジニア"
+        userId={project.leadEngineerId}
+        userName={eng?.name ?? null}
+        activeCount={engLoad}
+        color={toneForLoad(engLoad)}
+      />
+    </div>
+  );
+};
+
+interface OwnerCardProps {
+  roleLabel: string;
+  userId: string;
+  userName: string | null;
+  activeCount: number;
+  color: string;
+}
+
+const OwnerCard = ({ roleLabel, userId, userName, activeCount, color }: OwnerCardProps) => (
+  <div className="rounded border border-[var(--border-faint)] bg-[var(--bg-raised)] px-3 py-2 flex flex-col gap-1">
+    <div className="text-[11px] text-[var(--text-lo)]">{roleLabel}</div>
+    <div className="text-[13px] font-semibold text-[var(--text-hi)]">
+      {userName ?? <span className="font-mono text-[12px]">{userId}</span>}
+    </div>
+    <div className="text-[12px] text-[var(--text-md)] mt-0.5">
+      進行中案件{' '}
+      <span
+        className="font-mono font-bold tabular-nums text-[14px]"
+        style={{ color }}
+      >
+        {activeCount}
+      </span>{' '}
+      件（本案件を含む）
+    </div>
+  </div>
+);

--- a/src/infra/repositories/container.ts
+++ b/src/infra/repositories/container.ts
@@ -15,6 +15,7 @@ import type {
   TestRepository,
   TestTypeRepository,
   ToolRepository,
+  UserRepository,
 } from './interfaces';
 
 import {
@@ -30,6 +31,7 @@ import {
   createMockToolRepository,
   createMockCuttingProcessRepository,
   createMockReportRepository,
+  createMockUserRepository,
 } from './mock';
 
 export type BackendMode = 'mock' | 'rest' | 'graphql';
@@ -47,6 +49,7 @@ export interface RepositoryContainer {
   tools: ToolRepository;
   cuttingProcesses: CuttingProcessRepository;
   reports: ReportRepository;
+  users: UserRepository;
 }
 
 const createMockRepositories = (): RepositoryContainer => ({
@@ -62,6 +65,7 @@ const createMockRepositories = (): RepositoryContainer => ({
   tools: createMockToolRepository(),
   cuttingProcesses: createMockCuttingProcessRepository(),
   reports: createMockReportRepository(),
+  users: createMockUserRepository(),
 });
 
 export const createRepositories = (mode: BackendMode): RepositoryContainer => {

--- a/src/infra/repositories/interfaces/index.ts
+++ b/src/infra/repositories/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from './project.repo';
+export * from './user.repo';
 export * from './specimen.repo';
 export * from './test.repo';
 export * from './master.repo';

--- a/src/infra/repositories/interfaces/user.repo.ts
+++ b/src/infra/repositories/interfaces/user.repo.ts
@@ -1,0 +1,7 @@
+import type { ID, Paginated, User } from '@/domain/types';
+
+export interface UserRepository {
+  /** 全ユーザー一覧。現状はページング不要な規模のみを扱う。 */
+  list(): Promise<Paginated<User>>;
+  findById(id: ID): Promise<User | null>;
+}

--- a/src/infra/repositories/mock/index.ts
+++ b/src/infra/repositories/mock/index.ts
@@ -14,3 +14,4 @@ export { createMockSearchRepository } from './search.mock.repo';
 export { createMockToolRepository } from './tool.mock.repo';
 export { createMockCuttingProcessRepository } from './cuttingProcess.mock.repo';
 export { createMockReportRepository } from './report.mock.repo';
+export { createMockUserRepository } from './user.mock.repo';

--- a/src/infra/repositories/mock/user.mock.repo.ts
+++ b/src/infra/repositories/mock/user.mock.repo.ts
@@ -1,0 +1,15 @@
+import { delay, paginate } from '@/shared/utils';
+import { getMockDatabase } from '@/mocks/database';
+import type { UserRepository } from '../interfaces/user.repo';
+
+export const createMockUserRepository = (): UserRepository => ({
+  async list() {
+    await delay(60);
+    const items = getMockDatabase().users.getAll();
+    return paginate(items, 1, 100);
+  },
+  async findById(id) {
+    await delay(30);
+    return getMockDatabase().users.getById(id);
+  },
+});


### PR DESCRIPTION
## 概要
Issue #82 Phase 3.5 C の後半（担当者負荷サマリ）。案件詳細画面に PM / リードエンジニアの負荷を表示し、工数調整判断を支援する。これで C は完遂（C-1 + C-2）。案件メモは後続 issue に繰越。

## 追加

### User Repository 新設（ADR-001 準拠）
- `interfaces/user.repo.ts`: `UserRepository`（list / findById）
- `mock/user.mock.repo.ts`: `getMockDatabase().users` をラップ
- `container.ts`: `users: UserRepository` を追加

features 層から直接 mocks/seeds を import せず、既存 Repository パターンを踏襲。

### OwnerLoadSummary コンポーネント
- PM / リードエンジニアの進行中案件数（本案件含む）をカード表示
- 色分け: 3 件で warn (#d97706) / 5 件で err (#dc2626)
- users index に無い担当者は ID をそのまま表示（フォールバック）
- 同一担当者（PM = リードエンジニア）でも両カードに同件数を表示

### ProjectDetailPage
- Kanban ミニ直下に「担当者の負荷」セクションを配置
- `useUsersIndex` + `useAllProjectsForLoad` で必要データを取得
- データ揃うまではローディング表示

## テスト
- typecheck pass
- projects テスト **12/12 pass**（既存 9 + OwnerLoadSummary 3）
- OwnerLoadSummary:
  - 複数担当者で正しいカウント
  - 同一担当者（PM = Eng）で両カードに同値
  - users index 未登録で ID 表示（フォールバック）

## Phase 3.5 進捗
- [x] B-1 / B-2 ダッシュボード（#85 / #86）
- [x] D-1 / D-2 / D-3 マトリクス（#87 / #88 / #89）
- [x] C-1 納期タイムライン + Kanban ミニ（#90）
- [x] C-2 担当者負荷サマリ（本 PR）
- [ ] A MaiML エクスポート UI 拡張（次）

案件メモ（C 4 項目目）は別 issue 繰越。