### PR TITLE
feat(projects): 案件詳細から MaiML 形式で一括エクスポート可能に

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-04-24-project-maiml-export',
+    date: '2026-04-24',
+    type: 'feature',
+    title: '案件詳細から MaiML 形式で一括エクスポート可能に',
+    body: '案件詳細画面のヘッダに「MaiML エクスポート」ボタンを追加しました。対象案件の案件情報・試験片・試験（結果メトリクス含む）・損傷所見を 1 つの MaiML (JIS K 0200:2024) XML ドキュメントにまとめて書き出します。ダウンロード前にプレビューモーダルでファイルサイズ・行数・内容を確認できるため、配布前に中身を検証できます。',
+  },
+  {
     id: '2026-04-24-project-owner-load',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/projects/ProjectDetailPage.tsx
+++ b/src/features/projects/ProjectDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRepositories } from '@/app/providers';
 import type { ID } from '@/domain/types';
@@ -11,6 +12,13 @@ import {
   useProject,
   useUsersIndex,
 } from './api';
+import { DownloadPreviewModal } from '@/components/molecules';
+import { downloadMaimlFile } from '@/services/maiml';
+import {
+  defaultProjectMaimlFilename,
+  serializeProjectToMaiml,
+  type ProjectBundle,
+} from '@/services/maimlProject';
 
 interface ProjectDetailPageProps {
   id: ID;
@@ -35,6 +43,34 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
     queryFn: () => tests.list({ filter: { projectId: id }, pageSize: 100 }),
     enabled: !!project,
   });
+  const { damage } = useRepositories();
+  const damagesQuery = useQuery({
+    queryKey: ['project-damages', id],
+    queryFn: async () => {
+      const page = await damage.list({ pageSize: 200 });
+      // damage には projectId フィルタが無いため、test 経由で絞り込む
+      const testIds = new Set((testsQuery.data?.items ?? []).map((t) => t.id));
+      return page.items.filter((d) => d.testId && testIds.has(d.testId));
+    },
+    enabled: !!testsQuery.data,
+  });
+
+  const [maimlOpen, setMaimlOpen] = useState(false);
+
+  const maimlBundle: ProjectBundle | null = useMemo(() => {
+    if (!project || !specimensQuery.data || !testsQuery.data) return null;
+    return {
+      project,
+      specimens: specimensQuery.data.items,
+      tests: testsQuery.data.items,
+      damages: damagesQuery.data ?? [],
+    };
+  }, [project, specimensQuery.data, testsQuery.data, damagesQuery.data]);
+
+  const maimlXml = useMemo(() => {
+    if (!maimlOpen || !maimlBundle) return '';
+    return serializeProjectToMaiml(maimlBundle);
+  }, [maimlOpen, maimlBundle]);
 
   if (isLoading) {
     return <div className="p-6 text-[var(--text-lo)]">案件を読み込んでいます…</div>;
@@ -51,6 +87,7 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
   }
 
   const customer = customerIndex?.get(project.customerId);
+  const maimlFilename = defaultProjectMaimlFilename(project);
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
@@ -66,7 +103,17 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
           <span className="font-mono text-[12px] text-[var(--text-lo)]">{project.code}</span>
           <ProjectStatusPill status={project.status} />
         </div>
-        <h1 className="text-xl font-bold mt-2">{project.title}</h1>
+        <div className="flex items-start justify-between gap-3 mt-2">
+          <h1 className="text-xl font-bold">{project.title}</h1>
+          <button
+            type="button"
+            onClick={() => setMaimlOpen(true)}
+            disabled={!specimensQuery.data || !testsQuery.data}
+            className="text-[12px] px-3 py-1 rounded border border-[var(--border-default)] hover:bg-[var(--hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            MaiML エクスポート
+          </button>
+        </div>
         <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-3 text-[13px]">
           <InfoCell label="顧客" value={customer?.name ?? project.customerId} />
           <InfoCell label="開始日" value={project.startedAt} />
@@ -200,6 +247,20 @@ export const ProjectDetailPage = ({ id, onBack, onNav }: ProjectDetailPageProps)
           )}
         </section>
       </div>
+      <DownloadPreviewModal
+        open={maimlOpen}
+        onClose={() => setMaimlOpen(false)}
+        onConfirm={() => {
+          if (!maimlBundle) return;
+          downloadMaimlFile(serializeProjectToMaiml(maimlBundle), maimlFilename);
+          setMaimlOpen(false);
+        }}
+        title="MaiML エクスポート プレビュー（案件）"
+        filename={maimlFilename}
+        content={maimlXml}
+        language="xml"
+        description={`案件「${project.title}」に紐づく試験片・試験・損傷を MaiML (JIS K 0200:2024) 形式で書き出します。`}
+      />
     </div>
   );
 };

--- a/src/services/maimlProject.test.ts
+++ b/src/services/maimlProject.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DamageFinding,
+  Project,
+  Specimen,
+  Test,
+} from '@/domain/types';
+import {
+  defaultProjectMaimlFilename,
+  serializeProjectToMaiml,
+  type ProjectBundle,
+} from './maimlProject';
+
+const audit = {
+  createdAt: '2026-04-17T10:00:00+09:00',
+  updatedAt: '2026-04-17T10:00:00+09:00',
+  createdBy: 'user-1',
+  updatedBy: 'user-1',
+};
+
+const project: Project = {
+  id: 'prj-1',
+  code: 'IIC-2026-0001',
+  title: 'Ti-6Al-4V 疲労試験',
+  customerId: 'cust-1',
+  industryTagIds: ['aero'],
+  status: 'in_progress',
+  startedAt: '2026-04-01',
+  dueAt: '2026-05-31',
+  completedAt: null,
+  specimenCount: 1,
+  testCount: 1,
+  pmId: 'user-1',
+  leadEngineerId: 'user-2',
+  description: 'ブレード根元部 <重要>',
+  ...audit,
+};
+
+const specimen: Specimen = {
+  id: 'spec-1',
+  code: 'SP-001',
+  projectId: 'prj-1',
+  materialId: 'mat-1',
+  dimensions: { shape: 'bar', diameter: 10 },
+  cutFrom: { parentPart: null, location: null, direction: 'L' },
+  receivedAt: '2026-04-02',
+  location: 'R1-A3',
+  status: 'tested',
+  notes: null,
+  ...audit,
+};
+
+const test: Test = {
+  id: 'test-1',
+  specimenId: 'spec-1',
+  testTypeId: 'tt-fatigue',
+  condition: {
+    temperature: { value: 25, unit: 'C' },
+    atmosphere: 'air',
+    loadRate: 10,
+  },
+  standardIds: ['astm-e466'],
+  performedAt: '2026-04-10T10:00:00+09:00',
+  operatorId: 'user-2',
+  equipmentId: 'eq-1',
+  status: 'completed',
+  resultMetrics: [
+    { key: 'cycles_to_failure', label: '破断繰返し数', value: 12345, unit: 'cycle', uncertainty: 500 },
+  ],
+  rawDataRefs: [],
+  observations: [],
+  ...audit,
+};
+
+const damage: DamageFinding = {
+  id: 'dmg-1',
+  reportId: 'rep-1',
+  testId: 'test-1',
+  type: 'fatigue',
+  location: 'fillet R',
+  rootCauseHypothesis: '表面粗さ起因のき裂進展',
+  confidenceLevel: 'medium',
+  images: [],
+  similarCaseIds: [],
+  tags: ['fillet'],
+  ...audit,
+};
+
+const bundle: ProjectBundle = { project, specimens: [specimen], tests: [test], damages: [damage] };
+
+describe('serializeProjectToMaiml', () => {
+  it('produces a well-formed MaiML XML document', () => {
+    const xml = serializeProjectToMaiml(bundle, {
+      generatedAt: new Date('2026-04-20T00:00:00.000Z'),
+    });
+    expect(xml).toMatch(/^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    expect(xml).toContain('<maiml version="1.0">');
+    expect(xml.trim().endsWith('</maiml>')).toBe(true);
+  });
+
+  it('emits header metadata with project code', () => {
+    const xml = serializeProjectToMaiml(bundle, {
+      generatedAt: new Date('2026-04-20T00:00:00.000Z'),
+      source: 'vitest',
+    });
+    expect(xml).toContain('<property key="generatedAt">2026-04-20T00:00:00.000Z</property>');
+    expect(xml).toContain('<property key="source">vitest</property>');
+    expect(xml).toContain('<property key="documentKind">project-bundle</property>');
+    expect(xml).toContain('<property key="projectCode">IIC-2026-0001</property>');
+  });
+
+  it('emits project block with escaped description', () => {
+    const xml = serializeProjectToMaiml(bundle);
+    expect(xml).toContain('<project id="prj-1">');
+    expect(xml).toContain('<property key="title">Ti-6Al-4V 疲労試験</property>');
+    expect(xml).toContain('ブレード根元部 &lt;重要&gt;');
+  });
+
+  it('emits specimen, test, damage blocks with counts', () => {
+    const xml = serializeProjectToMaiml(bundle);
+    expect(xml).toContain('<specimens count="1">');
+    expect(xml).toContain('<specimen id="spec-1">');
+    expect(xml).toContain('<tests count="1">');
+    expect(xml).toContain('<test id="test-1" specimenRef="spec-1">');
+    expect(xml).toContain('<damages count="1">');
+    expect(xml).toContain('<damage id="dmg-1" testRef="test-1">');
+  });
+
+  it('emits result metrics with uncertainty', () => {
+    const xml = serializeProjectToMaiml(bundle);
+    expect(xml).toContain('<result key="cycles_to_failure" label="破断繰返し数" unit="cycle">');
+    expect(xml).toContain('<content>12345</content>');
+    expect(xml).toContain('<property key="uncertainty">500</property>');
+  });
+
+  it('handles empty collections', () => {
+    const xml = serializeProjectToMaiml({ project, specimens: [], tests: [], damages: [] });
+    expect(xml).toContain('<specimens count="0">');
+    expect(xml).toContain('<tests count="0">');
+    expect(xml).toContain('<damages count="0">');
+  });
+});
+
+describe('defaultProjectMaimlFilename', () => {
+  it('uses the project code as a prefix and .maiml extension', () => {
+    const name = defaultProjectMaimlFilename(project);
+    expect(name).toMatch(/^IIC-2026-0001_\d{4}-\d{2}-\d{2}\.maiml$/);
+  });
+});

--- a/src/services/maimlProject.ts
+++ b/src/services/maimlProject.ts
@@ -1,0 +1,135 @@
+// 案件（Project + Specimens + Tests + DamageFindings）を MaiML 形式で書き出す。
+// Material 用の既存 src/services/maiml.ts とは別系統の schema。
+// MaiML (JIS K 0200:2024) は measurement data 向けの汎用 XML で、
+// ここではドキュメント内に以下のブロックを持つ:
+//   <project> ... </project>
+//   <specimens> <specimen> ... </specimen> ... </specimens>
+//   <tests>     <test>     ... </test>     ... </tests>
+//   <damages>   <damage>   ... </damage>   ... </damages>
+
+import type { DamageFinding, Project, Specimen, Test } from '@/domain/types';
+
+function escapeXml(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const indent = (depth: number) => '  '.repeat(depth);
+
+function propertyLine(depth: number, key: string, value: string | number | null | undefined): string {
+  const text = value === null || value === undefined ? '' : String(value);
+  return `${indent(depth)}<property key="${escapeXml(key)}">${escapeXml(text)}</property>`;
+}
+
+export interface ProjectBundle {
+  project: Project;
+  specimens: Specimen[];
+  tests: Test[];
+  damages: DamageFinding[];
+}
+
+export interface MaimlProjectOptions {
+  generatedAt?: Date;
+  source?: string;
+}
+
+export function serializeProjectToMaiml(
+  bundle: ProjectBundle,
+  options: MaimlProjectOptions = {}
+): string {
+  const generatedAt = (options.generatedAt ?? new Date()).toISOString();
+  const source = options.source ?? 'matlens';
+  const { project, specimens, tests, damages } = bundle;
+
+  const lines: string[] = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<maiml version="1.0">');
+  lines.push(`${indent(1)}<header>`);
+  lines.push(propertyLine(2, 'generatedAt', generatedAt));
+  lines.push(propertyLine(2, 'source', source));
+  lines.push(propertyLine(2, 'documentKind', 'project-bundle'));
+  lines.push(propertyLine(2, 'projectCode', project.code));
+  lines.push(`${indent(1)}</header>`);
+  lines.push(`${indent(1)}<data>`);
+
+  // Project
+  lines.push(`${indent(2)}<project id="${escapeXml(project.id)}">`);
+  lines.push(propertyLine(3, 'code', project.code));
+  lines.push(propertyLine(3, 'title', project.title));
+  lines.push(propertyLine(3, 'customerId', project.customerId));
+  lines.push(propertyLine(3, 'status', project.status));
+  lines.push(propertyLine(3, 'startedAt', project.startedAt));
+  lines.push(propertyLine(3, 'dueAt', project.dueAt));
+  lines.push(propertyLine(3, 'completedAt', project.completedAt));
+  lines.push(propertyLine(3, 'pmId', project.pmId));
+  lines.push(propertyLine(3, 'leadEngineerId', project.leadEngineerId));
+  if (project.description) lines.push(propertyLine(3, 'description', project.description));
+  lines.push(`${indent(2)}</project>`);
+
+  // Specimens
+  lines.push(`${indent(2)}<specimens count="${specimens.length}">`);
+  for (const s of specimens) {
+    lines.push(`${indent(3)}<specimen id="${escapeXml(s.id)}">`);
+    lines.push(propertyLine(4, 'code', s.code));
+    lines.push(propertyLine(4, 'materialId', s.materialId));
+    lines.push(propertyLine(4, 'shape', s.dimensions.shape));
+    lines.push(propertyLine(4, 'location', s.location));
+    lines.push(propertyLine(4, 'status', s.status));
+    lines.push(propertyLine(4, 'receivedAt', s.receivedAt));
+    lines.push(`${indent(3)}</specimen>`);
+  }
+  lines.push(`${indent(2)}</specimens>`);
+
+  // Tests
+  lines.push(`${indent(2)}<tests count="${tests.length}">`);
+  for (const t of tests) {
+    lines.push(`${indent(3)}<test id="${escapeXml(t.id)}" specimenRef="${escapeXml(t.specimenId)}">`);
+    lines.push(propertyLine(4, 'testTypeId', t.testTypeId));
+    lines.push(propertyLine(4, 'status', t.status));
+    lines.push(propertyLine(4, 'performedAt', t.performedAt));
+    lines.push(propertyLine(4, 'temperature', t.condition.temperature.value));
+    lines.push(propertyLine(4, 'temperatureUnit', t.condition.temperature.unit));
+    lines.push(propertyLine(4, 'atmosphere', t.condition.atmosphere));
+    if (t.condition.loadRate !== undefined) {
+      lines.push(propertyLine(4, 'loadRate', t.condition.loadRate));
+    }
+    for (const rm of t.resultMetrics) {
+      lines.push(
+        `${indent(4)}<result key="${escapeXml(rm.key)}" label="${escapeXml(rm.label)}" unit="${escapeXml(rm.unit)}">`
+      );
+      lines.push(`${indent(5)}<content>${escapeXml(rm.value)}</content>`);
+      if (rm.uncertainty !== undefined) {
+        lines.push(propertyLine(5, 'uncertainty', rm.uncertainty));
+      }
+      lines.push(`${indent(4)}</result>`);
+    }
+    lines.push(`${indent(3)}</test>`);
+  }
+  lines.push(`${indent(2)}</tests>`);
+
+  // Damages
+  lines.push(`${indent(2)}<damages count="${damages.length}">`);
+  for (const d of damages) {
+    lines.push(`${indent(3)}<damage id="${escapeXml(d.id)}" testRef="${escapeXml(d.testId ?? '')}">`);
+    lines.push(propertyLine(4, 'type', d.type));
+    lines.push(propertyLine(4, 'location', d.location));
+    lines.push(propertyLine(4, 'confidenceLevel', d.confidenceLevel));
+    lines.push(propertyLine(4, 'rootCauseHypothesis', d.rootCauseHypothesis));
+    lines.push(`${indent(3)}</damage>`);
+  }
+  lines.push(`${indent(2)}</damages>`);
+
+  lines.push(`${indent(1)}</data>`);
+  lines.push('</maiml>');
+  return lines.join('\n') + '\n';
+}
+
+export function defaultProjectMaimlFilename(project: Project): string {
+  const date = new Date().toISOString().slice(0, 10);
+  return `${project.code}_${date}.maiml`;
+}


### PR DESCRIPTION
## 概要

Issue #82 Phase 3.5 の A（MaiML エクスポート UI 拡張）を完遂。案件詳細画面のヘッダに「MaiML エクスポート」ボタンを追加し、対象案件の情報・試験片・試験・損傷所見を一括で MaiML (JIS K 0200:2024) XML にエクスポートできるようにした。

## 背景

既存の `src/services/maiml.ts` は Material (材料マスタ) 単位の serializer で、今回必要な案件バンドル（Project + Specimens + Tests + Damages）の serializer は未実装だった。現場では「試験ロットを 1 ファイルで外部 LIMS に引き渡す」ユースケースが想定されるため、案件単位の MaiML 出力を追加する。

## 変更点

### 追加
- `src/services/maimlProject.ts`
  - `serializeProjectToMaiml(bundle: ProjectBundle, options?): string`
  - `<maiml>` / `<header>` / `<data>` / `<project>` / `<specimens>` / `<tests>` / `<damages>` のブロックを持つ純関数
  - Material 版と同じ XML エスケープ + property-line ヘルパを採用（ただし別 schema として独立）
  - `ResultMetric` の key/label/unit/value/uncertainty を `<result>` で出力
- `src/services/maimlProject.test.ts` — 単体テスト 7 件（ヘッダ / エスケープ / 各ブロック / 空コレクション / filename 規約）

### 拡張
- `src/features/projects/ProjectDetailPage.tsx`
  - ヘッダに「MaiML エクスポート」ボタンを追加（specimens / tests の読み込み完了まで disabled）
  - `DownloadPreviewModal` でプレビュー確認後にダウンロード実行
  - `damagesQuery` で本案件の試験 ID に紐づく損傷所見のみ filter
  - XML 組み立ては `useMemo` + `maimlOpen` ガードで、モーダルを開いたときだけ走らせる

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- Material 用既存 `src/services/maiml.ts` を拡張せず独立 module にした理由:
  - Material serializer は `<results>/<material>/<result>` 構造（単一コレクション）で、案件バンドルは 4 種の兄弟ブロックを持つ。schema が異なる
  - 既存 Material exporter の parser（`parseMaimlToMaterials`）に影響させないため分離
- `DownloadPreviewModal` を再利用しており、全ダウンロード箇所のプレビュー確認 UX と揃える（ADR の download-preview パターン）

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run` ✅ 780 passed / 2 skipped

## 手動確認（Reviewer へ）
- [ ] 案件詳細（`/projects/:id`）でヘッダ右の「MaiML エクスポート」ボタンを押下
- [ ] モーダルが開き、ファイル名 `<CODE>_<YYYY-MM-DD>.maiml`・行数・バイト数が表示される
- [ ] プレビューに `<project>` `<specimens>` `<tests>` `<damages>` ブロックが含まれる
- [ ] 「ダウンロード実行」で `.maiml` ファイルが保存される