### PR TITLE
fix(types): 結晶構造ページの型抑制をファイル全体から import 一行に縮小

### DIFF
--- a/src/pages/Crystal3D/Crystal3DPage.tsx
+++ b/src/pages/Crystal3D/Crystal3DPage.tsx
@@ -1,6 +1,3 @@
-// @ts-nocheck — three の型が DefinitelyTyped に無く（依存に @types/three を入れると
-// drei の three-mesh-bvh augmentation と競合する）、JSX intrinsic 型解決ができない。
-// このファイルはランタイム挙動のみで動作確認しており、型検査は意図的にスキップする。
 /**
  * 結晶構造 3D ビューア — Scientific Instrument Panel
  * PoC: Three.js + @react-three/fiber / BCC · FCC · HCP 原子配置可視化
@@ -9,6 +6,10 @@
 import { Suspense, useState, useMemo, createContext, useContext } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { OrbitControls } from '@react-three/drei'
+// three は @types/three を導入すると drei が依存する three-mesh-bvh の
+// augmentation 型と競合するため、本リポジトリでは公式型を入れていない。
+// 利用箇所は BufferGeometry / Float32BufferAttribute のみで、any 経由でも安全。
+// @ts-expect-error — 型定義不在のためモジュール解決を抑制する
 import * as THREE from 'three'
 import { useTheme } from '../../hooks/useTheme/useTheme'
 


### PR DESCRIPTION
## 概要

PR #93 のフォローアップ。Crystal3DPage に入れていた `// @ts-nocheck`（ファイル全体スキップ）を、必要最小スコープの `// @ts-expect-error`（import 行 1 行）に置き換えます。

## 背景

PR #93 の self-review および gemini-code-assist から「`// @ts-nocheck` は範囲が広すぎる」という指摘を受けていました。本 PR で根治します。

## 原因

- `three` パッケージは公式に `@types/three` を別配布
- `@types/three` を入れると `@react-three/drei` が依存する `three-mesh-bvh` の augmentation 型と競合し `BufferGeometry` に `computeBoundsTree`/`disposeBoundsTree` が無いと言われる (TS2739)
- 入れない場合は `import * as THREE from 'three'` で TS7016（型定義不在）

## 対応

`Crystal3DPage.tsx` の `import * as THREE from 'three'` 直前に `// @ts-expect-error` を 1 行追加し、TS7016 のみを抑制。`THREE` は any 扱いになるが、実利用は `BufferGeometry` / `Float32BufferAttribute` の 2 箇所のみで実害なし。これで他コードの型検査は通常通り動作する。

## 検証

- `pnpm typecheck` ✅ pass
- `pnpm test` ✅ 793 passed
- `pnpm lint` ✅ 0 errors

## 残課題

将来的に `three-mesh-bvh` の型と整合する形で `@types/three` を入れられるなら、この `@ts-expect-error` も外せます（その時点で TS が「不要な抑制」と教えてくれます）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * TypeScriptの型チェック設定を改善し、より的確な方法で型定義の処理を最適化しました。コード品質向上のための内部改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->