### PR TITLE
feat(dashboard): 受託試験ダッシュボードの KPI カードをクリック遷移可能に

### DIFF
--- a/src/components/molecules/molecules.tsx
+++ b/src/components/molecules/molecules.tsx
@@ -41,6 +41,9 @@ interface KpiCardProps {
   delta?: string;
   deltaUp?: boolean;
   color?: string;
+  onClick?: () => void;
+  /** クリック時に読み上げられる aria-label。省略時は label を使う */
+  ariaLabel?: string;
 }
 
 interface SearchBoxProps {
@@ -159,13 +162,32 @@ export const VecCard = ({ children, className = '' }: VecCardProps) => (
   </div>
 );
 
-export const KpiCard = ({ label, value, delta, deltaUp, color }: KpiCardProps) => (
-  <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3.5">
-    <div className="text-[11px] font-semibold text-text-lo tracking-[.04em] uppercase mb-1">{label}</div>
-    <div className="text-2xl font-bold tracking-tight leading-none" style={color ? { color } : {}}>{value}</div>
-    {delta && <div className={`text-[12px] mt-1 ${deltaUp === false ? 'text-err' : deltaUp ? 'text-ok' : 'text-vec'}`}>{delta}</div>}
-  </div>
-);
+export const KpiCard = ({ label, value, delta, deltaUp, color, onClick, ariaLabel }: KpiCardProps) => {
+  const inner = (
+    <>
+      <div className="text-[11px] font-semibold text-text-lo tracking-[.04em] uppercase mb-1">{label}</div>
+      <div className="text-2xl font-bold tracking-tight leading-none" style={color ? { color } : {}}>{value}</div>
+      {delta && <div className={`text-[12px] mt-1 ${deltaUp === false ? 'text-err' : deltaUp ? 'text-ok' : 'text-vec'}`}>{delta}</div>}
+    </>
+  );
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel ?? `${label} の詳細へ`}
+        className="text-left bg-raised border border-[var(--border-faint)] rounded-md p-3.5 hover:bg-[var(--hover)] focus:outline focus:outline-2 focus:outline-[var(--accent,#2563eb)] transition-colors cursor-pointer"
+      >
+        {inner}
+      </button>
+    );
+  }
+  return (
+    <div className="bg-raised border border-[var(--border-faint)] rounded-md p-3.5">
+      {inner}
+    </div>
+  );
+};
 
 export const SearchBox = ({ value, onChange, placeholder = '検索...', className = '' }: SearchBoxProps) => (
   <div className={`relative flex-1 ${className}`}>

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-ops-dashboard-kpi-navigation',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '受託試験ダッシュボードの KPI カードがクリックで該当画面に遷移',
+    body: '受託試験ダッシュボードの 6 種類の KPI カード（進行中案件 / 要アクション試験片 / 過去 30 日完了試験 / 異常所見比率 / 工具寿命アラート / びびり検出率）にクリック遷移を追加しました。それぞれ案件一覧 / 試験片トラッカー / 試験マトリクス / 損傷ギャラリー / 工具ライフトラッカー / 切削条件エクスプローラへ移動します。KPI を見て気になった指標から、対応する詳細画面へ 1 クリックで降りられます。',
+  },
+  {
     id: '2026-04-24-project-maiml-export',
     date: '2026-04-24',
     type: 'feature',

--- a/src/features/dashboard/OpsDashboardPage.tsx
+++ b/src/features/dashboard/OpsDashboardPage.tsx
@@ -150,16 +150,22 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
               label="進行中案件"
               value={kpi.activeProjects}
               delta={`全 ${kpi.totalProjects} 件中`}
+              onClick={onNav ? () => onNav('pjlist') : undefined}
+              ariaLabel="進行中案件の一覧へ移動"
             />
             <KpiCard
               label="要アクションの試験片"
               value={kpi.pendingSpecimens}
               delta="進行中案件の 受入 / 準備 中"
               color="var(--accent, #2563eb)"
+              onClick={onNav ? () => onNav('specimens') : undefined}
+              ariaLabel="試験片トラッカーへ移動"
             />
             <KpiCard
               label="過去 30 日の完了試験"
               value={kpi.completedTestsLast30Days}
+              onClick={onNav ? () => onNav('matrix') : undefined}
+              ariaLabel="試験マトリクスへ移動"
             />
             <KpiCard
               label="異常所見比率"
@@ -170,6 +176,8 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
                   ? 'var(--err, #dc2626)'
                   : 'var(--ok, #22c55e)'
               }
+              onClick={onNav ? () => onNav('damage') : undefined}
+              ariaLabel="損傷ギャラリーへ移動"
             />
             {cuttingKpi && (
               <>
@@ -182,6 +190,8 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
                       ? 'var(--warn, #d97706)'
                       : 'var(--ok, #22c55e)'
                   }
+                  onClick={onNav ? () => onNav('tools') : undefined}
+                  ariaLabel="工具ライフトラッカーへ移動"
                 />
                 <KpiCard
                   label="びびり検出率 (30日)"
@@ -196,6 +206,8 @@ export const OpsDashboardPage = ({ onNav, referenceNow }: OpsDashboardPageProps)
                       ? 'var(--warn, #d97706)'
                       : 'var(--ok, #22c55e)'
                   }
+                  onClick={onNav ? () => onNav('cutting-conditions') : undefined}
+                  ariaLabel="切削条件エクスプローラへ移動"
                 />
               </>
             )}


### PR DESCRIPTION
## 概要

Issue #82 の B-5（KPI カードのクリックで該当絞込画面への遷移）を実装。受託試験ダッシュボードの 6 種類の KPI カードに onClick を配線し、対応する詳細画面へ 1 クリックで降りられるようにした。

## 変更点

### 拡張
- `src/components/molecules/molecules.tsx` (`KpiCard`)
  - optional な `onClick` / `ariaLabel` prop を追加
  - `onClick` が渡された場合は `<button>` 要素として描画し、focus outline + hover bg + cursor pointer を付与（キーボード操作可能）
  - `ariaLabel` 未指定時は「<label> の詳細へ」をデフォルトに
  - 既存呼び出し側は影響なし（onClick 省略時は `<div>` のままで挙動不変）
- `src/features/dashboard/OpsDashboardPage.tsx`
  - 既存の onNav prop を使い、6 KPI を遷移先に紐付け
    - 進行中案件 → `pjlist`
    - 要アクション試験片 → `specimens`
    - 過去 30 日完了試験 → `matrix`
    - 異常所見比率 → `damage`
    - 工具寿命アラート → `tools`
    - びびり検出率 → `cutting-conditions`

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run src/features/dashboard` ✅ 21 passed

## 手動確認
- [ ] /ops-dash で 6 KPI それぞれをクリック → 期待先に遷移
- [ ] キーボード Tab + Enter でも遷移できる
- [ ] onNav 未配線時（テスト環境等）はクリック不可（disabled）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードのKPIカードがクリック可能になりました。進行中案件、要アクション試験片、過去30日の完了試験、異常所見比率、工具寿命アラート、びびり検出率の各カードをクリックするとそれぞれの詳細ページへナビゲーションします。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->