### PR TITLE
feat(matrix): 試験マトリクスのセルから単一・一括 MaiML エクスポート

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-matrix-cell-maiml',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '試験マトリクスのセルから単一・一括 MaiML エクスポート可能に',
+    body: '試験マトリクスの右サイドバーで、選択したセルに含まれる試験の一覧を表示するようにしました。各試験の右に「MaiML」ボタンが付き、単一試験の MaiML エクスポートに対応します。一覧の上部「全件 MaiML」ボタンを押すと、選択セル内の全試験を 1 ファイルに束ねて書き出します。書き出しは MaiML (JIS K 0200:2024) で、案件単位の出力と共通スキーマです。マトリクスから試験を抜き出して外部 LIMS に渡す導線になります。',
+  },
+  {
     id: '2026-05-02-project-memo-markdown',
     date: '2026-05-02',
     type: 'feature',

--- a/src/features/tests/matrix/TestMatrixPage.tsx
+++ b/src/features/tests/matrix/TestMatrixPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { ID } from '@/domain/types';
+import type { ID, Test } from '@/domain/types';
 import { HeatmapMatrix, materialsToRows, type MatrixValueType, type RowEntry } from './HeatmapMatrix';
 import {
   useMaterials,
@@ -13,6 +13,8 @@ import {
 } from './api';
 import { computeAbnormalCellMap } from './abnormalRatio';
 import { computeCustomerTestTypeCells } from './customerMatrix';
+import { CellTestList } from './components/CellTestList';
+import { MaimlExportModal } from './components/MaimlExportModal';
 
 type RowAxis = 'material' | 'customer';
 
@@ -89,6 +91,31 @@ export const TestMatrixPage = () => {
   }, [rowAxis, matrixTestsQ.data, matrixSpecimensQ.data, matrixProjectsQ.data]);
 
   const [selected, setSelected] = useState<SelectedCell | null>(null);
+  const [exportTests, setExportTests] = useState<Test[] | null>(null);
+  const [exportLabel, setExportLabel] = useState('');
+
+  // 選択セルに含まれる試験を抽出（材料軸 / 顧客軸 共通の前計算）
+  // - 材料軸: specimen.materialId === selectedRowId
+  // - 顧客軸: specimen.projectId → project.customerId === selectedRowId
+  const selectedCellTests = useMemo<Test[]>(() => {
+    if (!selected) return [];
+    if (!matrixTestsQ.data || !matrixSpecimensQ.data) return [];
+    const specimensById = new Map(matrixSpecimensQ.data.map((s) => [s.id, s]));
+    const projectsById = matrixProjectsQ.data
+      ? new Map(matrixProjectsQ.data.map((p) => [p.id, p]))
+      : null;
+    return matrixTestsQ.data.filter((t) => {
+      if (t.testTypeId !== selected.testTypeId) return false;
+      const sp = specimensById.get(t.specimenId);
+      if (!sp) return false;
+      if (rowAxis === 'material') {
+        return sp.materialId === selected.rowId;
+      }
+      if (!projectsById) return false;
+      const project = projectsById.get(sp.projectId);
+      return project?.customerId === selected.rowId;
+    });
+  }, [selected, rowAxis, matrixTestsQ.data, matrixSpecimensQ.data, matrixProjectsQ.data]);
 
   if (matrixError || testTypesError || materialsError) {
     return (
@@ -326,10 +353,40 @@ export const TestMatrixPage = () => {
                   この組合せの過去試験はまだありません。新規提案の機会です。
                 </div>
               )}
+              {selectedCell && selectedCell.count > 0 && (
+                <div className="border-t border-[var(--border-faint)] pt-3">
+                  <CellTestList
+                    tests={selectedCellTests}
+                    specimens={matrixSpecimensQ.data ?? []}
+                    damages={matrixDamagesQ.data ?? []}
+                    onExportSingle={(testId) => {
+                      const t = selectedCellTests.find((x) => x.id === testId);
+                      if (!t) return;
+                      setExportTests([t]);
+                      setExportLabel(
+                        `${selectedRow.primaryLabel} × ${selectedTestType.name} / ${testId}`,
+                      );
+                    }}
+                    onExportAll={() => {
+                      setExportTests(selectedCellTests);
+                      setExportLabel(
+                        `${selectedRow.primaryLabel} × ${selectedTestType.name} (${selectedCellTests.length} 件)`,
+                      );
+                    }}
+                  />
+                </div>
+              )}
             </div>
           )}
         </aside>
       </div>
+      <MaimlExportModal
+        tests={exportTests}
+        label={exportLabel}
+        allSpecimens={matrixSpecimensQ.data ?? []}
+        allDamages={matrixDamagesQ.data ?? []}
+        onClose={() => setExportTests(null)}
+      />
     </div>
   );
 };

--- a/src/features/tests/matrix/components/CellTestList.test.tsx
+++ b/src/features/tests/matrix/components/CellTestList.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CellTestList } from './CellTestList';
+import type { DamageFinding, Specimen, Test } from '@/domain/types';
+
+const audit = {
+  createdAt: '2026-04-17T10:00:00+09:00',
+  updatedAt: '2026-04-17T10:00:00+09:00',
+  createdBy: 'u',
+  updatedBy: 'u',
+};
+
+const specimen: Specimen = {
+  id: 'spec-1',
+  code: 'SP-001',
+  projectId: 'p-1',
+  materialId: 'm-1',
+  dimensions: { shape: 'bar', diameter: 10 },
+  cutFrom: { parentPart: null, location: null, direction: null },
+  receivedAt: '2026-04-01',
+  location: 'R1',
+  status: 'tested',
+  notes: null,
+  ...audit,
+};
+
+const test1: Test = {
+  id: 'test-1',
+  specimenId: 'spec-1',
+  testTypeId: 'tt-tensile',
+  condition: { temperature: { value: 25, unit: 'C' }, atmosphere: 'air' },
+  standardIds: [],
+  performedAt: '2026-04-10T10:00:00+09:00',
+  operatorId: 'u',
+  equipmentId: null,
+  status: 'completed',
+  resultMetrics: [],
+  rawDataRefs: [],
+  observations: [],
+  ...audit,
+};
+
+const test2: Test = { ...test1, id: 'test-2', performedAt: '2026-04-12T10:00:00+09:00' };
+
+const damage: DamageFinding = {
+  id: 'd-1',
+  reportId: 'r-1',
+  testId: 'test-1',
+  type: 'fatigue',
+  location: 'fillet',
+  rootCauseHypothesis: '',
+  confidenceLevel: 'medium',
+  images: [],
+  similarCaseIds: [],
+  tags: [],
+  ...audit,
+};
+
+describe('CellTestList', () => {
+  it('renders "no tests" message when empty', () => {
+    render(
+      <CellTestList
+        tests={[]}
+        specimens={[]}
+        damages={[]}
+        onExportSingle={vi.fn()}
+        onExportAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/過去試験はまだありません/)).toBeInTheDocument();
+  });
+
+  it('lists each test with its specimen code and damage count', () => {
+    render(
+      <CellTestList
+        tests={[test1, test2]}
+        specimens={[specimen]}
+        damages={[damage]}
+        onExportSingle={vi.fn()}
+        onExportAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('test-1')).toBeInTheDocument();
+    expect(screen.getByText('test-2')).toBeInTheDocument();
+    expect(screen.getAllByText(/試験片 SP-001/).length).toBeGreaterThan(0);
+    expect(screen.getByText('損傷 1 件')).toBeInTheDocument();
+  });
+
+  it('invokes onExportSingle with the row test id', () => {
+    const onExportSingle = vi.fn();
+    render(
+      <CellTestList
+        tests={[test1, test2]}
+        specimens={[specimen]}
+        damages={[]}
+        onExportSingle={onExportSingle}
+        onExportAll={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('test-2 を MaiML エクスポート'));
+    expect(onExportSingle).toHaveBeenCalledWith('test-2');
+  });
+
+  it('invokes onExportAll on the bulk button', () => {
+    const onExportAll = vi.fn();
+    render(
+      <CellTestList
+        tests={[test1]}
+        specimens={[specimen]}
+        damages={[]}
+        onExportSingle={vi.fn()}
+        onExportAll={onExportAll}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '全件 MaiML' }));
+    expect(onExportAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/tests/matrix/components/CellTestList.tsx
+++ b/src/features/tests/matrix/components/CellTestList.tsx
@@ -1,0 +1,101 @@
+// CellTestList — マトリクスのセル選択時に、その組合せに含まれる試験を
+// 一覧表示し、個別 / 一括の MaiML エクスポートを起点とするコンポーネント。
+//
+// 設計方針:
+// - 試験データ（Test / Specimen / DamageFinding）は親から受け取る（DI）。
+// - エクスポート確認モーダル本体は親が表示する。本コンポーネントはコールバックで
+//   「この試験集合を出力したい」イベントだけを返す（描画の関心分離）。
+// - 表示量は「セルの試験 N 件」想定なので仮想スクロール等は不要。
+
+import type { DamageFinding, ID, Specimen, Test } from '@/domain/types';
+
+interface CellTestListProps {
+  tests: Test[];
+  specimens: Specimen[];
+  damages: DamageFinding[];
+  /** 単一テストを MaiML エクスポート要求として親に通知する */
+  onExportSingle: (testId: ID) => void;
+  /** セル内の全テストをまとめて MaiML エクスポート要求 */
+  onExportAll: () => void;
+}
+
+const formatDate = (iso: string) => iso.slice(0, 10);
+
+export const CellTestList = ({
+  tests,
+  specimens,
+  damages,
+  onExportSingle,
+  onExportAll,
+}: CellTestListProps) => {
+  if (tests.length === 0) {
+    return (
+      <div className="text-[12px] text-[var(--text-lo)] italic">
+        この組合せの過去試験はまだありません。
+      </div>
+    );
+  }
+
+  const specimenByTestId = new Map<ID, Specimen | undefined>();
+  for (const t of tests) {
+    specimenByTestId.set(t.id, specimens.find((s) => s.id === t.specimenId));
+  }
+
+  // 損傷所見は test に紐づくため、testId → 件数 で前計算
+  const damageCountByTestId = new Map<ID, number>();
+  for (const d of damages) {
+    if (!d.testId) continue;
+    damageCountByTestId.set(d.testId, (damageCountByTestId.get(d.testId) ?? 0) + 1);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="text-[11px] text-[var(--text-lo)]">
+          このセルの試験 ({tests.length} 件)
+        </div>
+        <button
+          type="button"
+          onClick={onExportAll}
+          className="text-[11px] px-2 py-1 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+        >
+          全件 MaiML
+        </button>
+      </div>
+
+      <ul className="flex flex-col gap-1">
+        {tests.map((t) => {
+          const sp = specimenByTestId.get(t.id);
+          const dmgCount = damageCountByTestId.get(t.id) ?? 0;
+          return (
+            <li
+              key={t.id}
+              className="rounded border border-[var(--border-faint)] bg-[var(--bg-sunken)] p-2 text-[11px] flex items-center gap-2"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="font-mono truncate">{t.id}</div>
+                <div className="text-[10px] text-[var(--text-lo)] flex gap-2 flex-wrap">
+                  <span>{formatDate(t.performedAt)}</span>
+                  {sp && <span>試験片 {sp.code}</span>}
+                  <span>{t.condition.temperature.value}{t.condition.temperature.unit === 'C' ? '℃' : 'K'}</span>
+                  <span>{t.condition.atmosphere}</span>
+                  {dmgCount > 0 && (
+                    <span className="text-[var(--warn,#d97706)]">損傷 {dmgCount} 件</span>
+                  )}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => onExportSingle(t.id)}
+                aria-label={`${t.id} を MaiML エクスポート`}
+                className="text-[10px] px-2 py-0.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)] whitespace-nowrap"
+              >
+                MaiML
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/tests/matrix/components/MaimlExportModal.tsx
+++ b/src/features/tests/matrix/components/MaimlExportModal.tsx
@@ -1,0 +1,70 @@
+// MaimlExportModal — 試験集合（1〜N 件）を MaiML 形式で出力する確認モーダル。
+// マトリクスのセル選択ドリルから単独 / 一括の両用途で使う。
+//
+// `tests === null` の間は何も描画しない。表示時のみ XML を組み立てる。
+
+import { useMemo } from 'react';
+import type { DamageFinding, Specimen, Test } from '@/domain/types';
+import { DownloadPreviewModal } from '@/components/molecules';
+import { downloadMaimlFile } from '@/services/maiml';
+import {
+  defaultTestSetMaimlFilename,
+  serializeTestSetToMaiml,
+} from '@/services/maimlProject';
+
+interface MaimlExportModalProps {
+  /** null のときはモーダル非表示。配列のときに開く */
+  tests: Test[] | null;
+  /** ドキュメント識別ラベル。ファイル名 slug にも使われる */
+  label: string;
+  /** 試験から逆引き対象となる試験片マスタ（全件渡しても OK） */
+  allSpecimens: Specimen[];
+  /** 試験に紐づく損傷所見マスタ（全件渡しても OK） */
+  allDamages: DamageFinding[];
+  onClose: () => void;
+}
+
+export const MaimlExportModal = ({
+  tests,
+  label,
+  allSpecimens,
+  allDamages,
+  onClose,
+}: MaimlExportModalProps) => {
+  const open = tests !== null;
+
+  // モーダルが開いている時だけ XML を組み立てる（重い処理を避ける）。
+  const bundle = useMemo(() => {
+    if (!tests) return null;
+    const specimenIds = new Set(tests.map((t) => t.specimenId));
+    const testIds = new Set(tests.map((t) => t.id));
+    const specimens = allSpecimens.filter((s) => specimenIds.has(s.id));
+    const damages = allDamages.filter((d) => d.testId && testIds.has(d.testId));
+    return { label, specimens, tests, damages };
+  }, [tests, label, allSpecimens, allDamages]);
+
+  const xml = useMemo(() => {
+    if (!open || !bundle) return '';
+    return serializeTestSetToMaiml(bundle);
+  }, [open, bundle]);
+
+  const filename = useMemo(() => defaultTestSetMaimlFilename(label || 'test-set'), [label]);
+
+  if (!open || !bundle) return null;
+
+  return (
+    <DownloadPreviewModal
+      open={open}
+      onClose={onClose}
+      onConfirm={() => {
+        downloadMaimlFile(serializeTestSetToMaiml(bundle), filename);
+        onClose();
+      }}
+      title={`MaiML エクスポート プレビュー（${tests?.length === 1 ? '単一試験' : '試験集合'}）`}
+      filename={filename}
+      content={xml}
+      language="xml"
+      description={`「${label}」に含まれる ${tests?.length ?? 0} 件の試験を MaiML (JIS K 0200:2024) 形式で書き出します。`}
+    />
+  );
+};

--- a/src/services/maimlProject.test.ts
+++ b/src/services/maimlProject.test.ts
@@ -7,8 +7,11 @@ import type {
 } from '@/domain/types';
 import {
   defaultProjectMaimlFilename,
+  defaultTestSetMaimlFilename,
   serializeProjectToMaiml,
+  serializeTestSetToMaiml,
   type ProjectBundle,
+  type TestSetBundle,
 } from './maimlProject';
 
 const audit = {
@@ -145,5 +148,58 @@ describe('defaultProjectMaimlFilename', () => {
   it('uses the project code as a prefix and .maiml extension', () => {
     const name = defaultProjectMaimlFilename(project);
     expect(name).toMatch(/^IIC-2026-0001_\d{4}-\d{2}-\d{2}\.maiml$/);
+  });
+});
+
+describe('serializeTestSetToMaiml', () => {
+  const setBundle: TestSetBundle = {
+    label: 'matrix-cell SUS304 引張',
+    specimens: [specimen],
+    tests: [test],
+    damages: [damage],
+  };
+
+  it('produces a test-set document without project block', () => {
+    const xml = serializeTestSetToMaiml(setBundle, {
+      generatedAt: new Date('2026-05-02T00:00:00.000Z'),
+    });
+    expect(xml).toContain('<property key="documentKind">test-set</property>');
+    expect(xml).toContain('<property key="label">matrix-cell SUS304 引張</property>');
+    expect(xml).toContain('<property key="testCount">1</property>');
+    // Project block must NOT appear
+    expect(xml).not.toContain('<project ');
+    // Same blocks as project bundle
+    expect(xml).toContain('<specimens count="1">');
+    expect(xml).toContain('<test id="test-1" specimenRef="spec-1">');
+    expect(xml).toContain('<damages count="1">');
+  });
+
+  it('handles single test with no damages or specimens', () => {
+    const xml = serializeTestSetToMaiml({
+      label: 'single test',
+      specimens: [],
+      tests: [test],
+      damages: [],
+    });
+    expect(xml).toContain('<specimens count="0">');
+    expect(xml).toContain('<tests count="1">');
+    expect(xml).toContain('<damages count="0">');
+  });
+});
+
+describe('defaultTestSetMaimlFilename', () => {
+  it('slugifies the label and adds the date and extension', () => {
+    const name = defaultTestSetMaimlFilename('SUS304 × 引張');
+    expect(name).toMatch(/^tests_SUS304_\d{4}-\d{2}-\d{2}\.maiml$/);
+  });
+
+  it('keeps inner ascii-safe segments separated by single dashes', () => {
+    const name = defaultTestSetMaimlFilename('part-A_B (test)');
+    expect(name).toMatch(/^tests_part-A_B-test_\d{4}-\d{2}-\d{2}\.maiml$/);
+  });
+
+  it('falls back to test-set when label has no ascii-safe chars', () => {
+    const name = defaultTestSetMaimlFilename('！？');
+    expect(name).toMatch(/^tests_test-set_\d{4}-\d{2}-\d{2}\.maiml$/);
   });
 });

--- a/src/services/maimlProject.ts
+++ b/src/services/maimlProject.ts
@@ -1,13 +1,28 @@
-// 案件（Project + Specimens + Tests + DamageFindings）を MaiML 形式で書き出す。
-// Material 用の既存 src/services/maiml.ts とは別系統の schema。
-// MaiML (JIS K 0200:2024) は measurement data 向けの汎用 XML で、
-// ここではドキュメント内に以下のブロックを持つ:
-//   <project> ... </project>
-//   <specimens> <specimen> ... </specimen> ... </specimens>
-//   <tests>     <test>     ... </test>     ... </tests>
-//   <damages>   <damage>   ... </damage>   ... </damages>
+// 案件バンドル / 試験集合を MaiML (JIS K 0200:2024) XML で書き出すシリアライザ。
+//
+// Material 単位の serializer は `src/services/maiml.ts` 側にあり、こちらは
+// 「案件 + 試験 + 損傷所見」のような複合バンドル向けの別 schema。
+//
+// 出力ドキュメントは以下のブロックで構成される:
+//   <maiml>
+//     <header> ... </header>
+//     <data>
+//       <project>     ... </project>     -- 案件バンドル時のみ
+//       <specimens>   ... </specimens>
+//       <tests>       ... </tests>
+//       <damages>     ... </damages>
+//     </data>
+//   </maiml>
+//
+// 試験集合 (TestSetBundle) では <project> ブロックを省略する。これにより
+// 「マトリクスのセルから抜き出した試験群」のように案件をまたぐ集合も
+// 共通の reader で読める。
 
 import type { DamageFinding, Project, Specimen, Test } from '@/domain/types';
+
+// ---------------------------------------------------------------------------
+// 内部ヘルパ
+// ---------------------------------------------------------------------------
 
 function escapeXml(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return '';
@@ -21,43 +36,16 @@ function escapeXml(value: string | number | null | undefined): string {
 
 const indent = (depth: number) => '  '.repeat(depth);
 
-function propertyLine(depth: number, key: string, value: string | number | null | undefined): string {
+function propertyLine(
+  depth: number,
+  key: string,
+  value: string | number | null | undefined,
+): string {
   const text = value === null || value === undefined ? '' : String(value);
   return `${indent(depth)}<property key="${escapeXml(key)}">${escapeXml(text)}</property>`;
 }
 
-export interface ProjectBundle {
-  project: Project;
-  specimens: Specimen[];
-  tests: Test[];
-  damages: DamageFinding[];
-}
-
-export interface MaimlProjectOptions {
-  generatedAt?: Date;
-  source?: string;
-}
-
-export function serializeProjectToMaiml(
-  bundle: ProjectBundle,
-  options: MaimlProjectOptions = {}
-): string {
-  const generatedAt = (options.generatedAt ?? new Date()).toISOString();
-  const source = options.source ?? 'matlens';
-  const { project, specimens, tests, damages } = bundle;
-
-  const lines: string[] = [];
-  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
-  lines.push('<maiml version="1.0">');
-  lines.push(`${indent(1)}<header>`);
-  lines.push(propertyLine(2, 'generatedAt', generatedAt));
-  lines.push(propertyLine(2, 'source', source));
-  lines.push(propertyLine(2, 'documentKind', 'project-bundle'));
-  lines.push(propertyLine(2, 'projectCode', project.code));
-  lines.push(`${indent(1)}</header>`);
-  lines.push(`${indent(1)}<data>`);
-
-  // Project
+function writeProjectBlock(lines: string[], project: Project): void {
   lines.push(`${indent(2)}<project id="${escapeXml(project.id)}">`);
   lines.push(propertyLine(3, 'code', project.code));
   lines.push(propertyLine(3, 'title', project.title));
@@ -70,8 +58,9 @@ export function serializeProjectToMaiml(
   lines.push(propertyLine(3, 'leadEngineerId', project.leadEngineerId));
   if (project.description) lines.push(propertyLine(3, 'description', project.description));
   lines.push(`${indent(2)}</project>`);
+}
 
-  // Specimens
+function writeSpecimensBlock(lines: string[], specimens: Specimen[]): void {
   lines.push(`${indent(2)}<specimens count="${specimens.length}">`);
   for (const s of specimens) {
     lines.push(`${indent(3)}<specimen id="${escapeXml(s.id)}">`);
@@ -84,11 +73,14 @@ export function serializeProjectToMaiml(
     lines.push(`${indent(3)}</specimen>`);
   }
   lines.push(`${indent(2)}</specimens>`);
+}
 
-  // Tests
+function writeTestsBlock(lines: string[], tests: Test[]): void {
   lines.push(`${indent(2)}<tests count="${tests.length}">`);
   for (const t of tests) {
-    lines.push(`${indent(3)}<test id="${escapeXml(t.id)}" specimenRef="${escapeXml(t.specimenId)}">`);
+    lines.push(
+      `${indent(3)}<test id="${escapeXml(t.id)}" specimenRef="${escapeXml(t.specimenId)}">`,
+    );
     lines.push(propertyLine(4, 'testTypeId', t.testTypeId));
     lines.push(propertyLine(4, 'status', t.status));
     lines.push(propertyLine(4, 'performedAt', t.performedAt));
@@ -100,7 +92,7 @@ export function serializeProjectToMaiml(
     }
     for (const rm of t.resultMetrics) {
       lines.push(
-        `${indent(4)}<result key="${escapeXml(rm.key)}" label="${escapeXml(rm.label)}" unit="${escapeXml(rm.unit)}">`
+        `${indent(4)}<result key="${escapeXml(rm.key)}" label="${escapeXml(rm.label)}" unit="${escapeXml(rm.unit)}">`,
       );
       lines.push(`${indent(5)}<content>${escapeXml(rm.value)}</content>`);
       if (rm.uncertainty !== undefined) {
@@ -111,11 +103,14 @@ export function serializeProjectToMaiml(
     lines.push(`${indent(3)}</test>`);
   }
   lines.push(`${indent(2)}</tests>`);
+}
 
-  // Damages
+function writeDamagesBlock(lines: string[], damages: DamageFinding[]): void {
   lines.push(`${indent(2)}<damages count="${damages.length}">`);
   for (const d of damages) {
-    lines.push(`${indent(3)}<damage id="${escapeXml(d.id)}" testRef="${escapeXml(d.testId ?? '')}">`);
+    lines.push(
+      `${indent(3)}<damage id="${escapeXml(d.id)}" testRef="${escapeXml(d.testId ?? '')}">`,
+    );
     lines.push(propertyLine(4, 'type', d.type));
     lines.push(propertyLine(4, 'location', d.location));
     lines.push(propertyLine(4, 'confidenceLevel', d.confidenceLevel));
@@ -123,7 +118,96 @@ export function serializeProjectToMaiml(
     lines.push(`${indent(3)}</damage>`);
   }
   lines.push(`${indent(2)}</damages>`);
+}
 
+function writeHeader(
+  lines: string[],
+  documentKind: string,
+  generatedAt: string,
+  source: string,
+  extraProperties: Record<string, string | number> = {},
+): void {
+  lines.push(`${indent(1)}<header>`);
+  lines.push(propertyLine(2, 'generatedAt', generatedAt));
+  lines.push(propertyLine(2, 'source', source));
+  lines.push(propertyLine(2, 'documentKind', documentKind));
+  for (const [key, value] of Object.entries(extraProperties)) {
+    lines.push(propertyLine(2, key, value));
+  }
+  lines.push(`${indent(1)}</header>`);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ProjectBundle {
+  project: Project;
+  specimens: Specimen[];
+  tests: Test[];
+  damages: DamageFinding[];
+}
+
+export interface TestSetBundle {
+  /** ドキュメント識別用のラベル。例: 「マトリクス選択: SUS304 × 引張」 */
+  label: string;
+  specimens: Specimen[];
+  tests: Test[];
+  damages: DamageFinding[];
+}
+
+export interface MaimlSerializeOptions {
+  generatedAt?: Date;
+  source?: string;
+}
+
+export function serializeProjectToMaiml(
+  bundle: ProjectBundle,
+  options: MaimlSerializeOptions = {},
+): string {
+  const generatedAt = (options.generatedAt ?? new Date()).toISOString();
+  const source = options.source ?? 'matlens';
+  const { project, specimens, tests, damages } = bundle;
+
+  const lines: string[] = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<maiml version="1.0">');
+  writeHeader(lines, 'project-bundle', generatedAt, source, {
+    projectCode: project.code,
+  });
+  lines.push(`${indent(1)}<data>`);
+  writeProjectBlock(lines, project);
+  writeSpecimensBlock(lines, specimens);
+  writeTestsBlock(lines, tests);
+  writeDamagesBlock(lines, damages);
+  lines.push(`${indent(1)}</data>`);
+  lines.push('</maiml>');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * 試験集合（特定セル抽出・任意の試験 N 件）を MaiML 形式で書き出す。
+ * <project> ブロックは持たず、ドキュメント識別は header.label で行う。
+ */
+export function serializeTestSetToMaiml(
+  bundle: TestSetBundle,
+  options: MaimlSerializeOptions = {},
+): string {
+  const generatedAt = (options.generatedAt ?? new Date()).toISOString();
+  const source = options.source ?? 'matlens';
+  const { label, specimens, tests, damages } = bundle;
+
+  const lines: string[] = [];
+  lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+  lines.push('<maiml version="1.0">');
+  writeHeader(lines, 'test-set', generatedAt, source, {
+    label,
+    testCount: tests.length,
+  });
+  lines.push(`${indent(1)}<data>`);
+  writeSpecimensBlock(lines, specimens);
+  writeTestsBlock(lines, tests);
+  writeDamagesBlock(lines, damages);
   lines.push(`${indent(1)}</data>`);
   lines.push('</maiml>');
   return lines.join('\n') + '\n';
@@ -132,4 +216,19 @@ export function serializeProjectToMaiml(
 export function defaultProjectMaimlFilename(project: Project): string {
   const date = new Date().toISOString().slice(0, 10);
   return `${project.code}_${date}.maiml`;
+}
+
+/**
+ * 試験集合用のファイル名生成。`tests_<slug>_<date>.maiml`。
+ * slug は label をアスキーセーフ + 30 字程度に縮める。
+ */
+export function defaultTestSetMaimlFilename(label: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const slug =
+    label
+      .normalize('NFKC')
+      .replace(/[^A-Za-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 30) || 'test-set';
+  return `tests_${slug}_${date}.maiml`;
 }


### PR DESCRIPTION
## 概要

Issue #82 の A-1（試験詳細から単一 Test を MaiML 出力）と A-3（マトリクスのセル選択時に該当 Tests を一括 MaiML 出力）を統合実装。試験詳細画面が現状未整備のため、マトリクスの「セル選択 → 試験一覧ドリル」を一本化した導線として実現。

## 変更点

### serializer のリファクタ + 新 API
- `src/services/maimlProject.ts`
  - 内部ヘルパ（`writeProjectBlock` / `writeSpecimensBlock` / `writeTestsBlock` / `writeDamagesBlock` / `writeHeader`）を抽出して重複を排除
  - 既存 `serializeProjectToMaiml` はこのヘルパを使う形にリファクタ
  - 新規 `serializeTestSetToMaiml(bundle: TestSetBundle, options?)` を追加。`<project>` ブロックを省略し `documentKind="test-set"` で書き出す
  - 新規 `defaultTestSetMaimlFilename(label)` — label を ASCII セーフに slugify
- `src/services/maimlProject.test.ts` — 新 API のテスト 4 件追加（合計 12 件）

### マトリクス UI
- `src/features/tests/matrix/components/CellTestList.tsx` — セル試験一覧（試験片コード / 損傷件数 / 個別 + 一括エクスポートボタン）
- `src/features/tests/matrix/components/CellTestList.test.tsx` — 4 件
- `src/features/tests/matrix/components/MaimlExportModal.tsx` — `DownloadPreviewModal` に bundle 計算 + xml 組立をまとめた薄いラッパ。`tests===null` の間は何も描画しない
- `src/features/tests/matrix/TestMatrixPage.tsx` — 行軸（材料軸 / 顧客軸）に応じた `selectedCellTests` を計算し、CellTestList と MaimlExportModal を配線

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- 既存 `serializeProjectToMaiml` を変更せず、内部実装を抽出して `serializeTestSetToMaiml` と共有することで「案件バンドル」と「試験集合」両方の出力 schema を 1 module で管理
- `MaimlExportModal` をプレゼンテーションから分離。マトリクス以外の場所からも再利用しやすい形に
- テスト集合 export では `<project>` 不在を明示するため `documentKind="test-set"` ヘッダで識別

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run` ✅ 807 passed / 2 skipped

## 手動確認
- [ ] /matrix でセル選択 → 右サイドバーに試験一覧が表示
- [ ] 各試験の「MaiML」ボタンで単一エクスポートのプレビュー → 保存
- [ ] 「全件 MaiML」ボタンでセル全試験の一括エクスポート
- [ ] 顧客軸でも同様に動作する