### PR TITLE
feat(damage): 損傷ギャラリーの検索範囲を拡大し類似度を重み付きスコアに

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-damage-gallery-search-similarity',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '損傷ギャラリーの検索とサジェスト精度を向上',
+    body: 'キーワード検索の対象に「タグ」を追加し、部位・原因仮説・タグを横断して引けるようにしました。類似事例サジェストも、これまでの「同じ損傷タイプから順に取得」から、損傷タイプ・タグ・部位・確信度の重み付きスコアで上位 5 件を返す方式に変更しています。スコア計算は純関数 `damageSimilarity` として独立しており、後から embedding ベースに差し替えやすい構造です。Lightbox にもタグ表示を追加しました。',
+  },
+  {
     id: '2026-05-02-matrix-cell-maiml',
     date: '2026-05-02',
     type: 'feature',

--- a/src/features/damage/DamageGalleryPage.tsx
+++ b/src/features/damage/DamageGalleryPage.tsx
@@ -55,8 +55,8 @@ export const DamageGalleryPage = () => {
           type="search"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="キーワード検索（部位・原因仮説）"
-          aria-label="損傷所見 キーワード検索"
+          placeholder="キーワード検索（部位・原因仮説・タグ）"
+          aria-label="損傷所見 キーワード検索（部位・原因仮説・タグを横断検索）"
           className="w-full max-w-lg px-3 py-1.5 rounded border border-[var(--border-faint)] bg-transparent text-[13px]"
         />
         <div className="flex items-center gap-1.5 flex-wrap">
@@ -197,6 +197,18 @@ const DamageLightbox = ({ damages, id, onClose }: DamageLightboxProps) => {
             <span className="font-semibold">確信度: </span>
             {target.confidenceLevel}
           </div>
+          {target.tags.length > 0 && (
+            <div className="mt-2 flex gap-1 flex-wrap">
+              {target.tags.map((t) => (
+                <span
+                  key={t}
+                  className="px-2 py-0.5 text-[10px] rounded-full border border-[var(--border-faint)] text-[var(--text-md)]"
+                >
+                  #{t}
+                </span>
+              ))}
+            </div>
+          )}
 
           {similar && similar.length > 0 && (
             <section className="mt-6">

--- a/src/features/damage/api.ts
+++ b/src/features/damage/api.ts
@@ -33,7 +33,8 @@ export const useSimilarDamages = (id: ID | null) => {
   const { damage } = useRepositories();
   return useQuery({
     queryKey: id ? damageKeys.similar(id) : [...damageKeys.all, 'similar', 'none'],
-    queryFn: () => (id ? damage.findSimilar(id, 8) : Promise.resolve([])),
+    // Issue #82 で「類似事例 上位 5 件」が要件。サジェストの認知負荷を抑える。
+    queryFn: () => (id ? damage.findSimilar(id, 5) : Promise.resolve([])),
     enabled: !!id,
   });
 };

--- a/src/features/damage/similarity.test.ts
+++ b/src/features/damage/similarity.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import type { DamageFinding } from '@/domain/types';
+import { damageSimilarity, rankSimilarDamages } from './similarity';
+
+const audit = {
+  createdAt: '2026-04-17T10:00:00+09:00',
+  updatedAt: '2026-04-17T10:00:00+09:00',
+  createdBy: 'u',
+  updatedBy: 'u',
+};
+
+const make = (over: Partial<DamageFinding> = {}): DamageFinding => ({
+  id: over.id ?? 'd-base',
+  reportId: 'r-1',
+  testId: 't-1',
+  type: 'fatigue',
+  location: 'fillet R',
+  rootCauseHypothesis: '',
+  confidenceLevel: 'medium',
+  images: [],
+  similarCaseIds: [],
+  tags: [],
+  ...audit,
+  ...over,
+});
+
+describe('damageSimilarity', () => {
+  it('returns 0 for the same id', () => {
+    const a = make({ id: 'x' });
+    expect(damageSimilarity(a, a)).toBe(0);
+  });
+
+  it('rewards same type with 0.5', () => {
+    const a = make({ id: 'a', type: 'fatigue', tags: [], location: '', confidenceLevel: 'low' });
+    const b = make({ id: 'b', type: 'fatigue', tags: [], location: '', confidenceLevel: 'high' });
+    expect(damageSimilarity(a, b)).toBeCloseTo(0.5, 5);
+  });
+
+  it('rewards tag overlap up to 0.25 (Jaccard)', () => {
+    // 異なる type / 異なる location トークン / 異なる conf にして、tag 寄与だけ残す
+    const a = make({
+      id: 'a',
+      tags: ['fillet', 'high-cycle'],
+      type: 'creep',
+      location: 'A',
+      confidenceLevel: 'low',
+    });
+    const b = make({
+      id: 'b',
+      tags: ['fillet', 'high-cycle'],
+      type: 'fatigue',
+      location: 'B',
+      confidenceLevel: 'high',
+    });
+    // 完全 tag overlap → +0.25
+    expect(damageSimilarity(a, b)).toBeCloseTo(0.25, 5);
+  });
+
+  it('rewards location token overlap', () => {
+    const a = make({ id: 'a', location: 'fillet R' });
+    const b = make({ id: 'b', location: 'fillet near R' });
+    // same type 0.5 + location tokens "fillet"+"r" vs "fillet"+"near"+"r" => 2/3 overlap
+    // same conf medium => 0.1
+    const s = damageSimilarity(a, b);
+    expect(s).toBeGreaterThan(0.5 + 0.1);
+    expect(s).toBeLessThan(1);
+  });
+
+  it('caps the score at 1', () => {
+    const a = make({ id: 'a', tags: ['x'], location: 'foo bar' });
+    const b = make({ id: 'b', tags: ['x'], location: 'foo bar' });
+    expect(damageSimilarity(a, b)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('rankSimilarDamages', () => {
+  const target = make({ id: 'target', type: 'fatigue', tags: ['fillet'], location: 'fillet R' });
+  const exact = make({ id: 'exact', type: 'fatigue', tags: ['fillet'], location: 'fillet R' });
+  const sameType = make({ id: 'same-type', type: 'fatigue', tags: [], location: 'tip' });
+  const otherType = make({ id: 'other', type: 'creep', tags: ['fillet'], location: 'fillet R' });
+  const unrelated = make({
+    id: 'unrelated',
+    type: 'wear',
+    tags: [],
+    location: 'completely different',
+    confidenceLevel: 'low',
+  });
+
+  it('sorts by score desc and drops the target itself', () => {
+    const out = rankSimilarDamages(target, [target, exact, sameType, otherType, unrelated], 5);
+    const ids = out.map((r) => r.damage.id);
+    expect(ids[0]).toBe('exact');
+    // target itself is filtered
+    expect(ids).not.toContain('target');
+  });
+
+  it('limits to N', () => {
+    const out = rankSimilarDamages(target, [exact, sameType, otherType, unrelated], 2);
+    expect(out).toHaveLength(2);
+  });
+
+  it('drops zero-score candidates', () => {
+    const target2 = make({
+      id: 'target2',
+      type: 'fatigue',
+      tags: [],
+      location: 'A',
+      confidenceLevel: 'high',
+    });
+    const zero = make({
+      id: 'zero',
+      type: 'thermal',
+      tags: [],
+      location: 'B',
+      confidenceLevel: 'low',
+    });
+    const out = rankSimilarDamages(target2, [zero], 5);
+    expect(out).toHaveLength(0);
+  });
+});

--- a/src/features/damage/similarity.ts
+++ b/src/features/damage/similarity.ts
@@ -1,0 +1,59 @@
+// 損傷所見の類似度スコアリング（純関数）。
+//
+// 「過去の類似事例を上位 N 件」のサジェスト用途。スコアは 0..1 の範囲で、
+// 重み付きの加点で算出する。透明性を優先しているため数式は単純：
+//
+//   sameType         : 0.50 (同一の damage type)
+//   tagJaccard       : 0.25 * |共通タグ| / |いずれかのタグ|
+//   locationOverlap  : 0.15 * 共通する 1 文字以上のトークン比
+//   sameConfidence   : 0.10 (確信度が一致)
+//
+// 高度な ML を使わない理由は、PoC で説明可能性を担保しつつ、後から
+// embedding 等に差し替える際にもインタフェース（純関数）が崩れないため。
+
+import type { DamageFinding } from '@/domain/types';
+
+const tokenize = (text: string): string[] =>
+  text
+    .toLowerCase()
+    .split(/[\s,;/／、。・()\[\]【】]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+
+function jaccard(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) return 0;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  let intersection = 0;
+  for (const x of setA) if (setB.has(x)) intersection += 1;
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function damageSimilarity(target: DamageFinding, candidate: DamageFinding): number {
+  if (target.id === candidate.id) return 0;
+  let score = 0;
+  if (target.type === candidate.type) score += 0.5;
+  score += 0.25 * jaccard(target.tags, candidate.tags);
+  score += 0.15 * jaccard(tokenize(target.location), tokenize(candidate.location));
+  if (target.confidenceLevel === candidate.confidenceLevel) score += 0.1;
+  return Math.min(score, 1);
+}
+
+export interface RankedDamage {
+  damage: DamageFinding;
+  score: number;
+}
+
+export function rankSimilarDamages(
+  target: DamageFinding,
+  candidates: DamageFinding[],
+  limit: number,
+): RankedDamage[] {
+  return candidates
+    .filter((d) => d.id !== target.id)
+    .map((d) => ({ damage: d, score: damageSimilarity(target, d) }))
+    .filter((r) => r.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+}

--- a/src/infra/repositories/mock/damage.mock.repo.ts
+++ b/src/infra/repositories/mock/damage.mock.repo.ts
@@ -1,6 +1,7 @@
 import type { DamageFinding, ID } from '@/domain/types';
 import { delay, paginate } from '@/shared/utils';
 import { getMockDatabase } from '@/mocks/database';
+import { rankSimilarDamages } from '@/features/damage/similarity';
 import type {
   DamageQuery,
   DamageRepository,
@@ -30,10 +31,12 @@ const matchFilter = (
   }
   if (f.search) {
     const q = f.search.toLowerCase();
-    if (
-      !damage.location.toLowerCase().includes(q) &&
-      !damage.rootCauseHypothesis.toLowerCase().includes(q)
-    ) {
+    const haystacks = [
+      damage.location,
+      damage.rootCauseHypothesis,
+      ...damage.tags,
+    ];
+    if (!haystacks.some((h) => h.toLowerCase().includes(q))) {
       return false;
     }
   }
@@ -73,15 +76,13 @@ export const createMockDamageRepository = (): DamageRepository => ({
     return getMockDatabase().damages.getById(id);
   },
 
-  async findSimilar(id, limit = 8) {
+  async findSimilar(id, limit = 5) {
     await delay(150);
     const db = getMockDatabase();
     const target = db.damages.getById(id);
     if (!target) return [];
-    // 単純に同一typeから近傍を返すモック
-    return db.damages
-      .getAll()
-      .filter((d) => d.id !== id && d.type === target.type)
-      .slice(0, limit);
+    // similarity.ts の純関数で重み付きスコアリング → 上位 N。
+    const ranked = rankSimilarDamages(target, db.damages.getAll(), limit);
+    return ranked.map((r) => r.damage);
   },
 });


### PR DESCRIPTION
## 概要

Issue #82 E-1（自由テキスト検索 + 類似事例 上位 5 件）を実装。

## 変更点

### 追加（純関数として独立）
- `src/features/damage/similarity.ts`
  - `damageSimilarity(target, candidate): number` — 0..1 の重み付きスコア
    - sameType: +0.5
    - tag Jaccard: +0.25
    - location トークン Jaccard: +0.15
    - sameConfidenceLevel: +0.1
  - `rankSimilarDamages(target, candidates, limit): RankedDamage[]`
- `src/features/damage/similarity.test.ts` — 8 件の単体テスト

### 拡張
- `src/infra/repositories/mock/damage.mock.repo.ts`
  - `matchFilter.search` の対象に `tags` を追加（部位・原因仮説・タグ横断）
  - `findSimilar` を similarity.ts ベースに置換
- `src/features/damage/api.ts` — `useSimilarDamages` の limit を 5 に
- `src/features/damage/DamageGalleryPage.tsx`
  - 検索 placeholder / aria-label にタグ対象を明示
  - Lightbox に target.tags の chip 表示

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- 類似度ロジックを純関数として feature ディレクトリに置き、mock repo は呼ぶだけにした。後から embedding 等に差し替える際もインタフェース（DamageFinding × DamageFinding → number）は不変
- スコアの重みは「説明可能性」を優先した小さな数。フロントエンド非専門の読み手にも追いやすい

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run` ✅ 815 passed / 2 skipped

## 手動確認
- [ ] /damage で部位・原因・タグのいずれにマッチするキーワード検索が動作
- [ ] 損傷を開くと類似事例が上位 5 件、より関連性が高い順に並ぶ
- [ ] Lightbox にタグが表示される