### PR TITLE
feat(cutting): 切削条件エクスプローラに軸切替・色分け切替・特殊冷却マーカー

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-cutting-explorer-axis-color',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '切削条件エクスプローラに軸切替・色分け切替・特殊冷却マーカーを追加',
+    body: '散布図の X / Y 軸を Vc / f / ap から自由に組合せられるようにしました。色分けは「びびり有無」「工具摩耗 VB」「表面粗さ Ra」の 3 モードで切替可能です。冷却方式が MQL の点は◇、cryogenic（極低温）の点は△ で表示し、特殊加工を一目で識別できます。Stability Lobe のオーバーレイ曲線は意味の通る Vc × f 軸時のみ表示します。',
+  },
+  {
     id: '2026-05-02-damage-gallery-search-similarity',
     date: '2026-05-02',
     type: 'feature',

--- a/src/features/cutting/CuttingConditionsExplorerPage.tsx
+++ b/src/features/cutting/CuttingConditionsExplorerPage.tsx
@@ -11,6 +11,10 @@ import type {
 } from '@/domain/types';
 import type { CuttingProcessQuery } from '@/infra/repositories/interfaces';
 import { ConditionScatter } from './components/ConditionScatter';
+import type {
+  ScatterAxisKey,
+  ScatterColorMode,
+} from './components/scatterMappings';
 import { KcEstimatePanel } from './components/KcEstimatePanel';
 import { StabilityLobePanel } from './components/StabilityLobePanel';
 import { WaveformViewer } from './components/WaveformViewer';
@@ -40,12 +44,27 @@ const TOOL_TYPE_OPTIONS: { value: ToolType; label: string }[] = [
 
 type ChatterFilter = 'any' | 'chatter' | 'stable';
 
+const AXIS_OPTIONS: { value: ScatterAxisKey; label: string }[] = [
+  { value: 'cuttingSpeed', label: 'Vc' },
+  { value: 'feed', label: 'f' },
+  { value: 'depthOfCut', label: 'ap' },
+];
+
+const COLOR_MODE_OPTIONS: { value: ScatterColorMode; label: string }[] = [
+  { value: 'chatter', label: 'びびり有無' },
+  { value: 'toolWear', label: '工具摩耗 VB' },
+  { value: 'surfaceRoughness', label: '表面粗さ Ra' },
+];
+
 export const CuttingConditionsExplorerPage = () => {
   const [materialId, setMaterialId] = useState<string | ''>('');
   const [opSet, setOpSet] = useState<Set<MachiningOperation>>(new Set());
   const [toolTypeSet, setToolTypeSet] = useState<Set<ToolType>>(new Set());
   const [chatter, setChatter] = useState<ChatterFilter>('any');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [xAxisKey, setXAxisKey] = useState<ScatterAxisKey>('cuttingSpeed');
+  const [yAxisKey, setYAxisKey] = useState<ScatterAxisKey>('feed');
+  const [colorMode, setColorMode] = useState<ScatterColorMode>('chatter');
 
   const query = useMemo<CuttingProcessQuery>(() => {
     const filter: CuttingProcessQuery['filter'] = {};
@@ -252,10 +271,49 @@ export const CuttingConditionsExplorerPage = () => {
 
         {/* 中央: 散布図 */}
         <section className="flex-1 overflow-auto p-4" aria-label="散布図">
-          <div className="mb-2 flex items-center gap-4 text-[12px] text-[var(--text-lo)]">
+          <div className="mb-3 flex items-center gap-3 flex-wrap text-[12px] text-[var(--text-lo)]">
             <span>
               表示中 {filteredProcesses.length} 件 / びびり {chatterCount} 件
             </span>
+            <div className="flex items-center gap-1">
+              <span>X 軸:</span>
+              <select
+                value={xAxisKey}
+                onChange={(e) => setXAxisKey(e.target.value as ScatterAxisKey)}
+                aria-label="散布図 X 軸"
+                className="px-1.5 py-0.5 rounded border border-[var(--border-faint)] bg-transparent"
+              >
+                {AXIS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-1">
+              <span>Y 軸:</span>
+              <select
+                value={yAxisKey}
+                onChange={(e) => setYAxisKey(e.target.value as ScatterAxisKey)}
+                aria-label="散布図 Y 軸"
+                className="px-1.5 py-0.5 rounded border border-[var(--border-faint)] bg-transparent"
+              >
+                {AXIS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center gap-1">
+              <span>色分け:</span>
+              <select
+                value={colorMode}
+                onChange={(e) => setColorMode(e.target.value as ScatterColorMode)}
+                aria-label="散布図 色分けモード"
+                className="px-1.5 py-0.5 rounded border border-[var(--border-faint)] bg-transparent"
+              >
+                {COLOR_MODE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
             {selected && (
               <button
                 type="button"
@@ -275,6 +333,9 @@ export const CuttingConditionsExplorerPage = () => {
               processes={filteredProcesses}
               selectedId={selectedId}
               onSelect={setSelectedId}
+              xAxisKey={xAxisKey}
+              yAxisKey={yAxisKey}
+              colorMode={colorMode}
             />
           )}
         </section>

--- a/src/features/cutting/components/ConditionScatter.tsx
+++ b/src/features/cutting/components/ConditionScatter.tsx
@@ -1,17 +1,34 @@
-// Vc × f 散布図。純 SVG 自作 (依存ゼロ) で描画する。
-// - びびり検出ありは赤系 / なしは青系で色分け
+// 切削条件 散布図。純 SVG 自作 (依存ゼロ) で描画する。
+// - 軸: Vc / f / ap の組合せを切替可能（デフォルト Vc × f で互換維持）
+// - 色: びびり / 工具摩耗 VB / 表面粗さ Ra の 3 モードで切替
+// - 形状: 冷却方式 MQL → ◇、cryogenic → △、それ以外は ○
 // - 選択中の点は強調
-// - Stability Lobe の簡易プレースホルダ曲線をオーバーレイ（Tlusty 系の定性近似）
+// - Stability Lobe の簡易プレースホルダ曲線をオーバーレイ（Vc × f 軸時のみ）
 
 import { useMemo, useRef, useState } from 'react';
 import type { CuttingProcess } from '@/domain/types';
+import {
+  COLOR_MODE_LABEL,
+  SCATTER_AXES,
+  colorForProcess,
+  markerPathD,
+  markerShapeFor,
+  type ScatterAxisKey,
+  type ScatterColorMode,
+} from './scatterMappings';
 
 export interface ConditionScatterProps {
   processes: CuttingProcess[];
   selectedId: string | null;
   onSelect: (id: string | null) => void;
-  /** true のとき Stability Lobe プレースホルダ曲線を重ねる */
+  /** true のとき Stability Lobe プレースホルダ曲線を重ねる（Vc × f のときのみ有効） */
   showStabilityLobe?: boolean;
+  /** X 軸キー（デフォルト Vc）。cuttingSpeed / feed / depthOfCut */
+  xAxisKey?: ScatterAxisKey;
+  /** Y 軸キー（デフォルト f）。cuttingSpeed / feed / depthOfCut */
+  yAxisKey?: ScatterAxisKey;
+  /** 色分けモード（デフォルト chatter）。chatter / toolWear / surfaceRoughness */
+  colorMode?: ScatterColorMode;
 }
 
 const PADDING = { top: 16, right: 24, bottom: 40, left: 56 };
@@ -56,6 +73,9 @@ export const ConditionScatter = ({
   selectedId,
   onSelect,
   showStabilityLobe = true,
+  xAxisKey = 'cuttingSpeed',
+  yAxisKey = 'feed',
+  colorMode = 'chatter',
 }: ConditionScatterProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [hoverId, setHoverId] = useState<string | null>(null);
@@ -66,28 +86,35 @@ export const ConditionScatter = ({
   const plotY0 = PADDING.top;
   const plotY1 = height - PADDING.bottom;
 
+  const xAxis = SCATTER_AXES[xAxisKey];
+  const yAxis = SCATTER_AXES[yAxisKey];
+
   const { xScale, yScale } = useMemo(() => {
     const x = makeScale(
-      processes.map((p) => p.condition.cuttingSpeed),
+      processes.map((p) => xAxis.get(p)),
       [plotX0, plotX1]
     );
     const y = makeScale(
-      processes.map((p) => p.condition.feed),
+      processes.map((p) => yAxis.get(p)),
       [plotY1, plotY0] // y は上下反転
     );
     return { xScale: x, yScale: y };
-  }, [processes, plotX0, plotX1, plotY0, plotY1]);
+  }, [processes, xAxis, yAxis, plotX0, plotX1, plotY0, plotY1]);
+
+  // Stability Lobe は Vc × f 平面でのみ意味があるため、それ以外の軸では描画しない。
+  const stabilityLobeApplicable =
+    xAxisKey === 'cuttingSpeed' && yAxisKey === 'feed';
 
   // Stability Lobe プレースホルダ: 送りが高いほど許容 Vc が下がる、
   // という定性的な曲線（log 近似）。実装は後続 PR で厳密化する。
   const lobePath = useMemo(() => {
-    if (!showStabilityLobe) return null;
+    if (!showStabilityLobe || !stabilityLobeApplicable) return null;
     const samples = 80;
     const vcMin = xScale.min;
     const vcMax = xScale.max;
     const fMin = yScale.min;
     const fMax = yScale.max;
-    if (vcMax <= vcMin || fMax <= fMin) return null;
+    if (vcMax <= vcMin || fMax <= fMin || !stabilityLobeApplicable) return null;
     const parts: string[] = [];
     for (let i = 0; i <= samples; i++) {
       const t = i / samples;
@@ -99,7 +126,7 @@ export const ConditionScatter = ({
       parts.push(`${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`);
     }
     return parts.join(' ');
-  }, [xScale, yScale, showStabilityLobe]);
+  }, [xScale, yScale, showStabilityLobe, stabilityLobeApplicable]);
 
   return (
     <div ref={containerRef} className="w-full overflow-auto">
@@ -181,7 +208,7 @@ export const ConditionScatter = ({
           fontSize={12}
           fill="var(--text-md, #cbd5e1)"
         >
-          切削速度 Vc (m/min)
+          {xAxis.label} ({xAxis.unit})
         </text>
         <text
           x={14}
@@ -191,7 +218,7 @@ export const ConditionScatter = ({
           fill="var(--text-md, #cbd5e1)"
           transform={`rotate(-90 14 ${(plotY0 + plotY1) / 2})`}
         >
-          送り f (mm/rev or mm/tooth)
+          {yAxis.label} ({yAxis.unit})
         </text>
 
         {/* Stability Lobe プレースホルダ曲線 */}
@@ -218,66 +245,106 @@ export const ConditionScatter = ({
           </g>
         )}
 
-        {/* 点群 */}
+        {/* 点群 — 形状（円 / ◇ / △）と色（colorMode）を分離して描画 */}
         {processes.map((p) => {
-          const cx = xScale.toPx(p.condition.cuttingSpeed);
-          const cy = yScale.toPx(p.condition.feed);
+          const cx = xScale.toPx(xAxis.get(p));
+          const cy = yScale.toPx(yAxis.get(p));
           const isSelected = p.id === selectedId;
           const isHovered = p.id === hoverId;
-          const chatter = p.chatterDetected === true;
-          const fill = chatter
-            ? 'rgba(239, 68, 68, 0.78)' // red-500
-            : 'rgba(37, 99, 235, 0.72)'; // blue-600
+          const fill = colorForProcess(p, colorMode);
           const stroke = isSelected
             ? 'var(--accent, #2563eb)'
             : isHovered
               ? 'rgba(148, 163, 184, 0.9)'
               : 'transparent';
           const r = isSelected ? 6 : isHovered ? 5 : 3.6;
+          const shape = markerShapeFor(p);
+          const eventHandlers = {
+            tabIndex: 0,
+            onMouseEnter: () => setHoverId(p.id),
+            onMouseLeave: () => setHoverId(null),
+            onFocus: () => setHoverId(p.id),
+            onBlur: () => setHoverId(null),
+            onClick: () => onSelect(isSelected ? null : p.id),
+            onKeyDown: (e: React.KeyboardEvent<SVGElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelect(isSelected ? null : p.id);
+              }
+            },
+            style: { cursor: 'pointer', outline: 'none' },
+          };
+          const titleEl = (
+            <title>{`${p.code}\n${xAxis.label}=${xAxis.get(p).toFixed(3)} ${xAxis.unit}\n${yAxis.label}=${yAxis.get(p).toFixed(3)} ${yAxis.unit}\nap=${p.condition.depthOfCut.toFixed(2)} mm\n冷却=${p.condition.coolant}${p.chatterDetected === true ? '\nびびり検出' : ''}`}</title>
+          );
+          const ariaLabel = `プロセス ${p.code} ${xAxis.label}=${xAxis.get(p).toFixed(3)} ${yAxis.label}=${yAxis.get(p).toFixed(3)}`;
+          if (shape === 'circle') {
+            return (
+              <circle
+                key={p.id}
+                cx={cx}
+                cy={cy}
+                r={r}
+                fill={fill}
+                stroke={stroke}
+                strokeWidth={isSelected ? 2 : 1}
+                aria-label={ariaLabel}
+                {...eventHandlers}
+              >
+                {titleEl}
+              </circle>
+            );
+          }
           return (
-            <circle
+            <path
               key={p.id}
-              cx={cx}
-              cy={cy}
-              r={r}
+              d={markerPathD(shape, cx, cy, r + 0.5)}
               fill={fill}
               stroke={stroke}
               strokeWidth={isSelected ? 2 : 1}
-              tabIndex={0}
-              onMouseEnter={() => setHoverId(p.id)}
-              onMouseLeave={() => setHoverId(null)}
-              onFocus={() => setHoverId(p.id)}
-              onBlur={() => setHoverId(null)}
-              onClick={() => onSelect(isSelected ? null : p.id)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  onSelect(isSelected ? null : p.id);
-                }
-              }}
-              style={{ cursor: 'pointer', outline: 'none' }}
-              aria-label={`プロセス ${p.code} Vc=${p.condition.cuttingSpeed.toFixed(1)} f=${p.condition.feed.toFixed(3)}${chatter ? ' (びびり検出)' : ''}`}
+              aria-label={ariaLabel}
+              {...eventHandlers}
             >
-              <title>{`${p.code}\nVc=${p.condition.cuttingSpeed.toFixed(1)} m/min\nf=${p.condition.feed.toFixed(3)} ${p.condition.feedUnit}\nap=${p.condition.depthOfCut.toFixed(2)} mm\n${chatter ? 'びびり検出' : '安定'}`}</title>
-            </circle>
+              {titleEl}
+            </path>
           );
         })}
 
-        {/* 凡例 */}
-        <g transform={`translate(${plotX1 - 140}, ${plotY1 - 36})`}>
+        {/* 凡例 — 色モードに応じてラベルを切替、特殊冷却マーカーも併記 */}
+        <g transform={`translate(${plotX1 - 230}, ${plotY1 - 56})`}>
           <rect
-            width={132}
-            height={28}
+            width={222}
+            height={48}
             fill="var(--bg-raised, rgba(15, 23, 42, 0.7))"
             stroke="var(--border-faint, #334155)"
           />
-          <circle cx={12} cy={14} r={4} fill="rgba(37, 99, 235, 0.72)" />
-          <text x={22} y={17} fontSize={11} fill="var(--text-md, #cbd5e1)">
-            安定
+          <text x={8} y={14} fontSize={10} fill="var(--text-lo, #94a3b8)">
+            色: {COLOR_MODE_LABEL[colorMode]}
           </text>
-          <circle cx={66} cy={14} r={4} fill="rgba(239, 68, 68, 0.78)" />
-          <text x={76} y={17} fontSize={11} fill="var(--text-md, #cbd5e1)">
-            びびり
+          {colorMode === 'chatter' && (
+            <>
+              <circle cx={20} cy={28} r={4} fill="rgba(37, 99, 235, 0.72)" />
+              <text x={28} y={31} fontSize={11} fill="var(--text-md, #cbd5e1)">
+                安定
+              </text>
+              <circle cx={80} cy={28} r={4} fill="rgba(239, 68, 68, 0.78)" />
+              <text x={88} y={31} fontSize={11} fill="var(--text-md, #cbd5e1)">
+                びびり
+              </text>
+            </>
+          )}
+          {colorMode === 'toolWear' && (
+            <text x={8} y={31} fontSize={11} fill="var(--text-md, #cbd5e1)">
+              緑: VB&lt;0.3 / 黄: 0.3-0.6 / 赤: &gt;0.6
+            </text>
+          )}
+          {colorMode === 'surfaceRoughness' && (
+            <text x={8} y={31} fontSize={11} fill="var(--text-md, #cbd5e1)">
+              青: Ra&lt;1.6 / 紫: ~3.2 / 赤: &gt;3.2
+            </text>
+          )}
+          <text x={8} y={44} fontSize={10} fill="var(--text-lo, #94a3b8)">
+            形状: ○通常 / ◇MQL / △cryogenic
           </text>
         </g>
       </svg>

--- a/src/features/cutting/components/scatterMappings.test.ts
+++ b/src/features/cutting/components/scatterMappings.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { CuttingProcess } from '@/domain/types';
+import {
+  colorForProcess,
+  markerPathD,
+  markerShapeFor,
+  SCATTER_AXES,
+} from './scatterMappings';
+
+const audit = {
+  createdAt: '2026-04-17T10:00:00+09:00',
+  updatedAt: '2026-04-17T10:00:00+09:00',
+  createdBy: 'u',
+  updatedBy: 'u',
+};
+
+const baseProcess: CuttingProcess = {
+  id: 'cp-1',
+  code: 'CUT-2026-0001',
+  specimenId: null,
+  materialId: 'm-1',
+  toolId: 'tool-1',
+  operation: 'turning',
+  condition: {
+    cuttingSpeed: 120,
+    feed: 0.15,
+    feedUnit: 'mm/rev',
+    depthOfCut: 1.0,
+    widthOfCut: null,
+    spindleSpeed: 1500,
+    coolant: 'flood',
+    notes: null,
+  },
+  machiningTimeSec: 60,
+  cuttingDistanceMm: 1000,
+  surfaceRoughnessRa: 1.0,
+  toolWearVB: 0.2,
+  chatterDetected: false,
+  cuttingForceFc: 200,
+  cuttingTemperatureC: 60,
+  waveformIds: [],
+  operatorId: 'op-1',
+  machine: 'M-1',
+  performedAt: '2026-04-17T10:00:00+09:00',
+  notes: null,
+  ...audit,
+};
+
+describe('SCATTER_AXES', () => {
+  it('exposes accessors that read the matching condition field', () => {
+    expect(SCATTER_AXES.cuttingSpeed.get(baseProcess)).toBe(120);
+    expect(SCATTER_AXES.feed.get(baseProcess)).toBeCloseTo(0.15, 5);
+    expect(SCATTER_AXES.depthOfCut.get(baseProcess)).toBe(1.0);
+  });
+});
+
+describe('colorForProcess', () => {
+  it('chatter mode: chatter→red, stable→blue, null→gray', () => {
+    expect(colorForProcess({ ...baseProcess, chatterDetected: true }, 'chatter')).toContain('239, 68, 68');
+    expect(colorForProcess({ ...baseProcess, chatterDetected: false }, 'chatter')).toContain('37, 99, 235');
+    expect(colorForProcess({ ...baseProcess, chatterDetected: null }, 'chatter')).toContain('148, 163, 184');
+  });
+
+  it('toolWear mode: gray when VB is null, red when VB exceeds 0.6', () => {
+    expect(colorForProcess({ ...baseProcess, toolWearVB: null }, 'toolWear')).toContain('148, 163, 184');
+    const high = colorForProcess({ ...baseProcess, toolWearVB: 0.7 }, 'toolWear');
+    expect(high).toMatch(/^rgba\((23\d|2[3-5][0-9]),/); // 赤領域
+  });
+
+  it('surfaceRoughness mode: gray when Ra is null', () => {
+    expect(colorForProcess({ ...baseProcess, surfaceRoughnessRa: null }, 'surfaceRoughness')).toContain('148, 163, 184');
+  });
+});
+
+describe('markerShapeFor', () => {
+  it('returns diamond for MQL and triangle for cryogenic', () => {
+    const mql = { ...baseProcess, condition: { ...baseProcess.condition, coolant: 'MQL' as const } };
+    const cryo = { ...baseProcess, condition: { ...baseProcess.condition, coolant: 'cryogenic' as const } };
+    expect(markerShapeFor(mql)).toBe('diamond');
+    expect(markerShapeFor(cryo)).toBe('triangle');
+    expect(markerShapeFor(baseProcess)).toBe('circle');
+  });
+});
+
+describe('markerPathD', () => {
+  it('produces a closed diamond path', () => {
+    const d = markerPathD('diamond', 10, 10, 4);
+    expect(d).toMatch(/^M /);
+    expect(d).toMatch(/Z$/);
+  });
+
+  it('produces a closed triangle path', () => {
+    const d = markerPathD('triangle', 10, 10, 4);
+    expect(d).toMatch(/^M /);
+    expect(d).toMatch(/Z$/);
+  });
+});

--- a/src/features/cutting/components/scatterMappings.ts
+++ b/src/features/cutting/components/scatterMappings.ts
@@ -1,0 +1,131 @@
+// 切削条件 散布図の軸 / 色 / マーカー形状を定義する純データ。
+// ConditionScatter の SVG ロジックから「どの値を / どう色付けするか」の
+// 知識を切り出してテスト可能にする。
+
+import type { CoolantType, CuttingProcess } from '@/domain/types';
+
+// ---------------------------------------------------------------------------
+// 軸（Vc / f / ap）
+// ---------------------------------------------------------------------------
+
+export type ScatterAxisKey = 'cuttingSpeed' | 'feed' | 'depthOfCut';
+
+export interface ScatterAxisDef {
+  key: ScatterAxisKey;
+  label: string;
+  unit: string;
+  /** プロセスから値を取り出す（null になり得る場合は number | null） */
+  get: (p: CuttingProcess) => number;
+}
+
+export const SCATTER_AXES: Record<ScatterAxisKey, ScatterAxisDef> = {
+  cuttingSpeed: {
+    key: 'cuttingSpeed',
+    label: '切削速度 Vc',
+    unit: 'm/min',
+    get: (p) => p.condition.cuttingSpeed,
+  },
+  feed: {
+    key: 'feed',
+    label: '送り f',
+    unit: 'mm/rev or mm/tooth',
+    get: (p) => p.condition.feed,
+  },
+  depthOfCut: {
+    key: 'depthOfCut',
+    label: '切込み ap',
+    unit: 'mm',
+    get: (p) => p.condition.depthOfCut,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 色分けモード
+// ---------------------------------------------------------------------------
+
+export type ScatterColorMode = 'chatter' | 'toolWear' | 'surfaceRoughness';
+
+export const COLOR_MODE_LABEL: Record<ScatterColorMode, string> = {
+  chatter: 'びびり有無',
+  toolWear: '工具摩耗 VB',
+  surfaceRoughness: '表面粗さ Ra',
+};
+
+const STABLE_BLUE = 'rgba(37, 99, 235, 0.72)'; // blue-600
+const CHATTER_RED = 'rgba(239, 68, 68, 0.78)'; // red-500
+const NEUTRAL_GRAY = 'rgba(148, 163, 184, 0.55)'; // slate-400
+
+/**
+ * 工具摩耗 VB を 0..0.6 mm 想定で緑→黄→赤に補間。
+ * 0.3 mm（ISO 3685 仕上げ限界）で黄、0.6 mm（荒加工限界）で赤に到達。
+ */
+function colorByVB(vb: number): string {
+  if (vb < 0.3) {
+    const t = vb / 0.3;
+    // 緑 #22c55e → 黄 #eab308
+    return `rgba(${Math.round(34 + (234 - 34) * t)}, ${Math.round(197 + (179 - 197) * t)}, ${Math.round(94 + (8 - 94) * t)}, 0.78)`;
+  }
+  const t = Math.min((vb - 0.3) / 0.3, 1);
+  // 黄 → 赤 #ef4444
+  return `rgba(${Math.round(234 + (239 - 234) * t)}, ${Math.round(179 + (68 - 179) * t)}, ${Math.round(8 + (68 - 8) * t)}, 0.85)`;
+}
+
+/**
+ * 表面粗さ Ra を 0..3.2 µm 想定で青→紫→赤に補間。
+ * Ra > 3.2 は仕上げ品質要件を超過している扱い。
+ */
+function colorByRa(ra: number): string {
+  const t = Math.min(ra / 3.2, 1);
+  // 青 #2563eb → 紫 #a855f7 → 赤 #ef4444
+  if (t < 0.5) {
+    const u = t / 0.5;
+    return `rgba(${Math.round(37 + (168 - 37) * u)}, ${Math.round(99 + (85 - 99) * u)}, ${Math.round(235 + (247 - 235) * u)}, 0.78)`;
+  }
+  const u = (t - 0.5) / 0.5;
+  return `rgba(${Math.round(168 + (239 - 168) * u)}, ${Math.round(85 + (68 - 85) * u)}, ${Math.round(247 + (68 - 247) * u)}, 0.78)`;
+}
+
+export function colorForProcess(
+  process: CuttingProcess,
+  mode: ScatterColorMode,
+): string {
+  if (mode === 'chatter') {
+    if (process.chatterDetected === true) return CHATTER_RED;
+    if (process.chatterDetected === false) return STABLE_BLUE;
+    return NEUTRAL_GRAY;
+  }
+  if (mode === 'toolWear') {
+    if (process.toolWearVB === null) return NEUTRAL_GRAY;
+    return colorByVB(process.toolWearVB);
+  }
+  if (process.surfaceRoughnessRa === null) return NEUTRAL_GRAY;
+  return colorByRa(process.surfaceRoughnessRa);
+}
+
+// ---------------------------------------------------------------------------
+// 特殊加工フラグ → マーカー形状
+// ---------------------------------------------------------------------------
+
+export type MarkerShape = 'circle' | 'diamond' | 'triangle';
+
+const SPECIAL_COOLANT_SHAPE: Partial<Record<CoolantType, MarkerShape>> = {
+  MQL: 'diamond',
+  cryogenic: 'triangle',
+};
+
+export function markerShapeFor(process: CuttingProcess): MarkerShape {
+  return SPECIAL_COOLANT_SHAPE[process.condition.coolant] ?? 'circle';
+}
+
+/**
+ * 与えた中心座標と半径から指定形状の SVG path d を返す。
+ * 円は <circle> を直接描画する想定なので path には含まれず、ここでは多角形のみ。
+ */
+export function markerPathD(shape: 'diamond' | 'triangle', cx: number, cy: number, r: number): string {
+  if (shape === 'diamond') {
+    return `M ${cx} ${cy - r} L ${cx + r} ${cy} L ${cx} ${cy + r} L ${cx - r} ${cy} Z`;
+  }
+  // triangle (上向き)
+  const h = r * 1.1;
+  return `M ${cx} ${cy - h} L ${cx + r} ${cy + r * 0.7} L ${cx - r} ${cy + r * 0.7} Z`;
+}


### PR DESCRIPTION
## 概要

Issue #82 F（切削条件エクスプローラの軸切替）を実装。

## 範囲
- ✅ 軸切替: Vc / f / ap の組合せを X / Y で自由選択
- ✅ 色分け切替: びびり / 工具摩耗 VB / 表面粗さ Ra の 3 モード
- ✅ 特殊冷却マーカー: MQL → ◇、cryogenic → △
- ⏭ 残留応力オーバーレイ: ドメインに該当フィールド（残留応力測定値）がまだ無いため見送り。データ追加後に別 PR で対応

## 変更点

### 純データ層（テスト容易性 + 可読性）
- `src/features/cutting/components/scatterMappings.ts`
  - `SCATTER_AXES` — Vc / f / ap の accessor + label + unit
  - `colorForProcess(p, mode)` — 0..1 線形補間で 3 モードの色を返す
    - 工具摩耗は **ISO 3685** の 0.3 / 0.6 mm 閾値で緑→黄→赤
    - 表面粗さ Ra は 1.6 / 3.2 µm を境に青→紫→赤
  - `markerShapeFor(p)` / `markerPathD(shape, cx, cy, r)` — 形状判定 + path 生成
- `src/features/cutting/components/scatterMappings.test.ts` — 単体テスト 6 件

### Scatter コンポーネントの拡張
- `src/features/cutting/components/ConditionScatter.tsx`
  - `xAxisKey` / `yAxisKey` / `colorMode` を optional prop として追加（既存呼び出し側の挙動は不変）
  - 軸ラベル / 凡例 / Stability Lobe 表示が軸モードに連動
  - データ点描画は `colorForProcess` + `markerShapeFor` を組合せ

### ページ UI
- `src/features/cutting/CuttingConditionsExplorerPage.tsx`
  - 中央ペイン上部に X 軸 / Y 軸 / 色分けの 3 セレクタを追加

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- 「色 / 形状 / 軸」をプレゼンテーションから分離して `scatterMappings.ts` に純関数で配置。後から色スケール（例: viridis）を差し替える場合もここを直すだけ
- `ScatterAxisKey` / `ScatterColorMode` は文字列リテラル合併型なので、追加（例: `widthOfCut`）が容易
- Stability Lobe は Vc × f 平面でのみ意味があるため、それ以外の軸では非表示に切替

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run src/features/cutting` ✅ 59 passed

## 手動確認
- [ ] /cutting-conditions の中央上部で X / Y 軸を変更 → 散布図軸とラベルが追従
- [ ] 色分けを 3 モード切替 → 凡例も追従
- [ ] MQL / cryogenic 工程が ◇ / △ で描画される