### PR TITLE
feat(tools): 工具ライフトラッカーに予測信頼区間・残寿命・比較モードを追加

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-tool-life-prediction-and-compare',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '工具ライフトラッカーに予測信頼区間・残寿命・比較モードを追加',
+    body: 'Taylor 工具寿命予測パネルに ±1σ / ±2σ の信頼区間と、累積使用時間に基づく残寿命（残り時間と残り切削距離）を表示するようにしました。工具リストの摩耗バッジは「余裕あり / 残20% / 残10% / 限界超過」の 4 段階に色分けされ、交換タイミングを早期に把握できます。各行のチェックボックスで複数工具を選択し「比較ビューを開く」を押すと、選択した工具の VB 進展を 1 枚のチャートに重ね描きできます。',
+  },
+  {
     id: '2026-05-02-cutting-explorer-axis-color',
     date: '2026-05-02',
     type: 'feature',

--- a/src/features/cutting/utils/taylorTool.test.ts
+++ b/src/features/cutting/utils/taylorTool.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   allowableCuttingSpeed,
   defaultParamsForTool,
+  estimateRemainingLife,
   fitTaylor,
   inferC,
+  predictToolLifeWithBands,
   toolLifeMin,
 } from './taylorTool';
 
@@ -76,6 +78,46 @@ describe('fitTaylor', () => {
     ]);
     expect(fit).not.toBeNull();
     expect(fit!.points).toHaveLength(2);
+  });
+});
+
+describe('predictToolLifeWithBands', () => {
+  it('returns equal bounds when sigma is 0', () => {
+    const r = predictToolLifeWithBands(100, { n: 0.25, C: 200 }, 0);
+    expect(r.T_lower1).toBe(r.T);
+    expect(r.T_upper1).toBe(r.T);
+    expect(r.T_lower2).toBe(r.T);
+    expect(r.T_upper2).toBe(r.T);
+  });
+
+  it('expands ±2σ bounds wider than ±1σ', () => {
+    const r = predictToolLifeWithBands(100, { n: 0.25, C: 200 }, 0.05);
+    expect(r.T_upper2).toBeGreaterThan(r.T_upper1);
+    expect(r.T_lower2).toBeLessThan(r.T_lower1);
+    expect(r.T_lower1).toBeLessThan(r.T);
+    expect(r.T_upper1).toBeGreaterThan(r.T);
+  });
+});
+
+describe('estimateRemainingLife', () => {
+  it('returns positive remaining when usage is below predicted', () => {
+    const r = estimateRemainingLife(60, 20, 100);
+    expect(r.remainingMin).toBe(40);
+    expect(r.remainingDistanceMm).toBe(40 * 100 * 1000);
+    expect(r.usageRatio).toBeCloseTo(20 / 60, 5);
+  });
+
+  it('clamps remaining to 0 when usage exceeds predicted', () => {
+    const r = estimateRemainingLife(60, 90, 100);
+    expect(r.remainingMin).toBe(0);
+    expect(r.remainingDistanceMm).toBe(0);
+    expect(r.usageRatio).toBe(1);
+  });
+
+  it('handles invalid predicted T gracefully', () => {
+    const r = estimateRemainingLife(0, 10, 100);
+    expect(r.remainingMin).toBe(0);
+    expect(r.usageRatio).toBe(0);
   });
 });
 

--- a/src/features/cutting/utils/taylorTool.ts
+++ b/src/features/cutting/utils/taylorTool.ts
@@ -67,8 +67,75 @@ export interface TaylorFitResult {
   n: number;
   C: number;
   r2: number;
+  /**
+   * 対数 V の残差標準偏差 (log m/min)。
+   * 予測 T の信頼区間は T_pred · exp(±k · sigmaLogV / n) で求める
+   * （k=1: ≈68%、k=2: ≈95%）。サンプル数 < 3 のときは 0 になる。
+   */
+  sigmaLogV: number;
   points: Array<{ V: number; T: number }>;
 }
+
+export interface ToolLifePrediction {
+  /** 中央値（最尤推定）の寿命 T (min) */
+  T: number;
+  /** ±1σ の下/上限（min）。回帰不可の場合は T と同値 */
+  T_lower1: number;
+  T_upper1: number;
+  /** ±2σ の下/上限（min）。回帰不可の場合は T と同値 */
+  T_lower2: number;
+  T_upper2: number;
+}
+
+/**
+ * Taylor フィットから予測寿命 T と ±1σ / ±2σ の信頼区間を返す純関数。
+ * fit が null（サンプル不足）のときはデフォルトパラメータで点推定のみ返す。
+ */
+export const predictToolLifeWithBands = (
+  V: number,
+  params: TaylorParams,
+  sigmaLogV: number,
+): ToolLifePrediction => {
+  const T = toolLifeMin(V, params);
+  if (T === 0 || sigmaLogV === 0 || params.n <= 0) {
+    return { T, T_lower1: T, T_upper1: T, T_lower2: T, T_upper2: T };
+  }
+  const sigmaLogT = sigmaLogV / params.n;
+  return {
+    T,
+    T_lower1: T * Math.exp(-sigmaLogT),
+    T_upper1: T * Math.exp(sigmaLogT),
+    T_lower2: T * Math.exp(-2 * sigmaLogT),
+    T_upper2: T * Math.exp(2 * sigmaLogT),
+  };
+};
+
+/**
+ * 残寿命予測。Taylor 式の総予測寿命から、累積使用時間を引いて残時間を返す。
+ * 残時間と現在 Vc から残切削距離 (mm) も併せて返す。
+ */
+export interface RemainingLifeEstimate {
+  /** 残り時間 (min)。0 未満は寿命到達済とみなして 0 にクランプ */
+  remainingMin: number;
+  /** 残り切削距離 (mm) */
+  remainingDistanceMm: number;
+  /** 使用率 0..1 (cumulativeMin / predictedT) */
+  usageRatio: number;
+}
+
+export const estimateRemainingLife = (
+  predictedTotalT: number,
+  cumulativeMin: number,
+  V: number,
+): RemainingLifeEstimate => {
+  if (predictedTotalT <= 0) {
+    return { remainingMin: 0, remainingDistanceMm: 0, usageRatio: 0 };
+  }
+  const remainingMin = Math.max(predictedTotalT - cumulativeMin, 0);
+  const remainingDistanceMm = remainingMin * Math.max(V, 0) * 1000;
+  const usageRatio = Math.min(cumulativeMin / predictedTotalT, 1);
+  return { remainingMin, remainingDistanceMm, usageRatio };
+};
 
 export const fitTaylor = (
   points: Array<{ V: number; T: number }>
@@ -95,7 +162,7 @@ export const fitTaylor = (
   const n = -b;
   const C = Math.exp(a);
 
-  // R^2 (coefficient of determination)
+  // R^2 (coefficient of determination) と残差標準偏差 sigmaLogV を同時に計算
   let ssRes = 0;
   let ssTot = 0;
   for (let i = 0; i < n_size; i++) {
@@ -104,8 +171,10 @@ export const fitTaylor = (
     ssTot += (ys[i]! - yMean) ** 2;
   }
   const r2 = ssTot === 0 ? 1 : 1 - ssRes / ssTot;
+  // 自由度 n_size - 2 (傾き + 切片)。サンプル不足時は 0 とする。
+  const sigmaLogV = n_size > 2 ? Math.sqrt(ssRes / (n_size - 2)) : 0;
 
-  return { n, C, r2, points: valid };
+  return { n, C, r2, sigmaLogV, points: valid };
 };
 
 /**

--- a/src/features/tools/ToolLifeTrackerPage.tsx
+++ b/src/features/tools/ToolLifeTrackerPage.tsx
@@ -1,9 +1,10 @@
 // 工具ライフトラッカー (#/tools) — #48 Should
-// 工具一覧 + 選択工具の VB 推移 + 直近プロセス。
+// 工具一覧 + 選択工具の VB 推移 + 直近プロセス + 比較モード。
 
 import { useMemo, useState } from 'react';
 import type { ID, Tool, ToolType } from '@/domain/types';
 import { VBChart } from './components/VBChart';
+import { VBComparisonChart, type VBComparisonSeries } from './components/VBComparisonChart';
 import { TaylorPredictionPanel } from './components/TaylorPredictionPanel';
 import {
   buildWearSeries,
@@ -12,6 +13,7 @@ import {
   useMaterialsIndex,
   useTools,
 } from './api';
+import { classifyWearStatus, VB_WEAR_LIMIT } from './utils/wearStatus';
 
 const TOOL_TYPE_LABEL: Record<ToolType, string> = {
   end_mill: 'エンドミル',
@@ -35,7 +37,7 @@ const TOOL_TYPE_OPTIONS: ToolType[] = [
   'tap',
 ];
 
-const WEAR_LIMIT = 0.3;
+const WEAR_LIMIT = VB_WEAR_LIMIT;
 
 // TODO(stage2): 工具マスタが数百件に拡大したらページネーション UI または
 // 集計 API（/api/v1/tools/usage-summary）に切り出す。
@@ -45,6 +47,8 @@ export const ToolLifeTrackerPage = () => {
   const [search, setSearch] = useState('');
   const [typeSet, setTypeSet] = useState<Set<ToolType>>(new Set());
   const [selectedId, setSelectedId] = useState<ID | null>(null);
+  const [compareSet, setCompareSet] = useState<Set<ID>>(new Set());
+  const [compareOpen, setCompareOpen] = useState(false);
 
   // TODO(stage2): 工具マスタ全件取得は集計 API / ページネーション対応に置換予定。
   // 現状 fixture 12 件なので 500 でも十分だが、規模拡大時の制約を明示するための定数化。
@@ -105,6 +109,27 @@ export const ToolLifeTrackerPage = () => {
     setSelectedId(null);
   };
 
+  const toggleCompare = (id: ID) => {
+    setCompareSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const compareSeries: VBComparisonSeries[] = useMemo(() => {
+    if (!processesQ.data) return [];
+    return Array.from(compareSet).map((id) => {
+      const tool = toolsQ.data?.items.find((t) => t.id === id);
+      return {
+        toolId: id,
+        toolCode: tool?.code ?? id,
+        points: buildWearSeries(processesQ.data!, id),
+      };
+    });
+  }, [compareSet, processesQ.data, toolsQ.data]);
+
   if (toolsQ.isError || processesQ.isError) {
     return (
       <div className="p-6 text-[var(--err,#dc2626)]">
@@ -162,38 +187,70 @@ export const ToolLifeTrackerPage = () => {
                 </button>
               ))}
             </div>
+            {compareSet.size >= 2 && (
+              <button
+                type="button"
+                onClick={() => setCompareOpen(true)}
+                className="text-[12px] px-2 py-1 rounded bg-[var(--accent,#2563eb)] text-white"
+              >
+                比較ビューを開く ({compareSet.size} 工具)
+              </button>
+            )}
+            {compareSet.size > 0 && (
+              <button
+                type="button"
+                onClick={() => setCompareSet(new Set())}
+                className="text-[11px] underline text-[var(--text-lo)]"
+              >
+                比較選択を解除
+              </button>
+            )}
           </div>
           <ul className="flex flex-col">
             {toolsFiltered.map((t) => {
               const usage = usageByTool.get(t.id);
-              const overLimit =
-                usage && usage.maxVB !== null && usage.maxVB >= WEAR_LIMIT;
+              const wear = classifyWearStatus(usage?.maxVB ?? null);
               const active = selectedId === t.id;
+              const inCompare = compareSet.has(t.id);
               return (
-                <li key={t.id}>
+                <li
+                  key={t.id}
+                  className={`border-b border-[var(--border-faint)] flex items-stretch ${active ? 'bg-[var(--hover)]' : 'hover:bg-[var(--hover)]'}`}
+                >
+                  <label
+                    className="flex items-center px-2 cursor-pointer"
+                    title="比較対象に追加"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={inCompare}
+                      onChange={() => toggleCompare(t.id)}
+                      aria-label={`${t.code} を比較対象に切替`}
+                    />
+                  </label>
                   <button
                     type="button"
                     onClick={() => setSelectedId(t.id)}
                     aria-pressed={active}
-                    className={`w-full text-left px-3 py-2 border-b border-[var(--border-faint)] focus:outline focus:outline-2 focus:outline-[var(--accent,#2563eb)] ${
-                      active
-                        ? 'bg-[var(--hover)]'
-                        : 'hover:bg-[var(--hover)]'
-                    }`}
+                    className="flex-1 text-left px-2 py-2 focus:outline focus:outline-2 focus:outline-[var(--accent,#2563eb)]"
                   >
                     <div className="flex items-center justify-between gap-2">
                       <span className="font-mono text-[12px] font-semibold">
                         {t.code}
                       </span>
-                      {overLimit && (
+                      {wear.status !== 'ok' && wear.label !== '未測定' && (
                         <span
                           className="text-[10px] px-1.5 py-0.5 rounded font-mono"
                           style={{
-                            background: 'rgba(220,38,38,0.14)',
-                            color: 'var(--err, #dc2626)',
+                            background:
+                              wear.status === 'exceeded'
+                                ? 'rgba(220,38,38,0.14)'
+                                : 'rgba(217,119,6,0.14)',
+                            color: wear.color,
                           }}
+                          aria-label={`摩耗状態: ${wear.label}`}
                         >
-                          限界超
+                          {wear.label}
                         </span>
                       )}
                     </div>
@@ -397,6 +454,39 @@ export const ToolLifeTrackerPage = () => {
           )}
         </section>
       </div>
+
+      {compareOpen && compareSet.size >= 2 && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60 flex items-center justify-center p-6"
+          role="dialog"
+          aria-modal="true"
+          aria-label="工具 VB 比較ビュー"
+        >
+          <button
+            type="button"
+            aria-label="閉じる"
+            onClick={() => setCompareOpen(false)}
+            className="absolute inset-0 w-full h-full cursor-default"
+            tabIndex={-1}
+          />
+          <div className="relative bg-[var(--bg-base,#0b0d11)] border border-[var(--border-faint)] rounded-xl max-w-5xl w-full max-h-[90vh] overflow-auto p-5">
+            <div className="flex items-center gap-3 mb-3">
+              <h2 className="text-lg font-bold">工具 VB 比較ビュー</h2>
+              <span className="text-[11px] text-[var(--text-lo)]">
+                {compareSet.size} 工具を 1 枚に重ね描き
+              </span>
+              <button
+                type="button"
+                onClick={() => setCompareOpen(false)}
+                className="ml-auto text-[12px] underline"
+              >
+                閉じる
+              </button>
+            </div>
+            <VBComparisonChart series={compareSeries} limit={WEAR_LIMIT} />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/features/tools/components/TaylorPredictionPanel.tsx
+++ b/src/features/tools/components/TaylorPredictionPanel.tsx
@@ -1,13 +1,15 @@
 // Taylor 工具寿命予測パネル。
 // 工具ごとの過去プロセス (Vc, 到達 VB と累積距離) から V と T を復元し、
-// fitTaylor で (n, C) を推定。現行 Vc での予測寿命を表示する。
+// fitTaylor で (n, C) を推定。現行 Vc での予測寿命と ±1σ / ±2σ
+// 信頼区間 + 残寿命（現在の累積使用時間からの残り）を表示する。
 
 import { useMemo } from 'react';
 import type { CuttingProcess, Tool } from '@/domain/types';
 import {
   defaultParamsForTool,
+  estimateRemainingLife,
   fitTaylor,
-  toolLifeMin,
+  predictToolLifeWithBands,
 } from '../../cutting/utils/taylorTool';
 import { VB_CRITERIA } from '../../cutting/utils/standards';
 
@@ -81,9 +83,13 @@ export const TaylorPredictionPanel = ({
     };
   }, [tool, processes, targetVc]);
 
-  const usedParams = fit ?? { n: defaults.n, C: defaults.C, r2: 0, points: [] };
-  const predictedT = toolLifeMin(referenceVc, usedParams);
+  const usedParams = fit ?? { n: defaults.n, C: defaults.C, r2: 0, sigmaLogV: 0, points: [] };
+  const prediction = predictToolLifeWithBands(referenceVc, usedParams, usedParams.sigmaLogV);
+  const predictedT = prediction.T;
   const predictedDistanceMm = predictedT * referenceVc * 1000;
+  // 現在の累積使用時間 = samples の最終 T
+  const cumulativeMin = samples.length > 0 ? samples[samples.length - 1]!.T : 0;
+  const remaining = estimateRemainingLife(predictedT, cumulativeMin, referenceVc);
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -113,6 +119,38 @@ export const TaylorPredictionPanel = ({
         <dt className="text-[var(--text-lo)]">予測切削距離</dt>
         <dd className="font-mono text-right">
           {predictedDistanceMm.toLocaleString(undefined, {
+            maximumFractionDigits: 0,
+          })}{' '}
+          mm
+        </dd>
+        {usedParams.sigmaLogV > 0 && (
+          <>
+            <dt className="text-[var(--text-lo)]">±1σ 区間 T</dt>
+            <dd className="font-mono text-right">
+              {prediction.T_lower1.toFixed(1)} – {prediction.T_upper1.toFixed(1)} min
+            </dd>
+            <dt className="text-[var(--text-lo)]">±2σ 区間 T</dt>
+            <dd className="font-mono text-right">
+              {prediction.T_lower2.toFixed(1)} – {prediction.T_upper2.toFixed(1)} min
+            </dd>
+          </>
+        )}
+        <dt className="text-[var(--text-lo)]">累積使用時間</dt>
+        <dd className="font-mono text-right">{cumulativeMin.toFixed(1)} min</dd>
+        <dt className="text-[var(--text-lo)]">残寿命（推定）</dt>
+        <dd
+          className="font-mono text-right"
+          style={{
+            color:
+              remaining.usageRatio >= 1
+                ? 'var(--err, #dc2626)'
+                : remaining.usageRatio >= 0.8
+                  ? 'var(--warn, #d97706)'
+                  : undefined,
+          }}
+        >
+          {remaining.remainingMin.toFixed(1)} min ／{' '}
+          {remaining.remainingDistanceMm.toLocaleString(undefined, {
             maximumFractionDigits: 0,
           })}{' '}
           mm

--- a/src/features/tools/components/VBComparisonChart.tsx
+++ b/src/features/tools/components/VBComparisonChart.tsx
@@ -1,0 +1,225 @@
+// 複数工具の VB 進展を 1 枚に重ね描きする比較チャート（純 SVG）。
+// 軸スケールは全シリーズの最大値で統一し、シリーズごとに色を割り当てる。
+//
+// VBChart と分けた理由:
+// - VBChart は単一シリーズ専用で軸ロジックが内包されている
+// - 比較は色凡例 + 軸スケール統一が必須なので、別コンポーネントの方が
+//   読み手にとって責務が明確になる
+
+import type { WearPoint } from '../api';
+
+export interface VBComparisonSeries {
+  toolId: string;
+  toolCode: string;
+  points: WearPoint[];
+}
+
+export interface VBComparisonChartProps {
+  series: VBComparisonSeries[];
+  /** VB 摩耗限界。横破線で表示 */
+  limit?: number;
+}
+
+const PAD = { top: 12, right: 12, bottom: 36, left: 48 };
+
+// 緑/橙/紫/ピンク/青緑/青 の 6 色サイクル。色覚多様性に配慮しつつ十分な差をつける。
+const SERIES_COLORS = [
+  '#22c55e', // green-500
+  '#f97316', // orange-500
+  '#a855f7', // purple-500
+  '#ec4899', // pink-500
+  '#14b8a6', // teal-500
+  '#3b82f6', // blue-500
+];
+
+export const VBComparisonChart = ({ series, limit = 0.3 }: VBComparisonChartProps) => {
+  const allPoints = series.flatMap((s) => s.points);
+  const width = 720;
+  const height = 320;
+  const plotX0 = PAD.left;
+  const plotX1 = width - PAD.right;
+  const plotY0 = PAD.top;
+  const plotY1 = height - PAD.bottom;
+
+  if (allPoints.length === 0) {
+    return (
+      <div className="text-[12px] text-[var(--text-lo)] p-4">
+        比較対象の VB 測定データがありません。
+      </div>
+    );
+  }
+
+  const xMax = Math.max(...allPoints.map((p) => p.cumulativeDistanceMm), 1);
+  const yMax = Math.max(...allPoints.map((p) => p.toolWearVB), limit) * 1.1;
+  const xScale = (v: number) => plotX0 + (v / xMax) * (plotX1 - plotX0);
+  const yScale = (v: number) => plotY1 - (v / yMax) * (plotY1 - plotY0);
+
+  const xTicks = Array.from({ length: 5 }, (_, i) => (xMax / 4) * i);
+  const yTicks = Array.from({ length: 5 }, (_, i) => (yMax / 4) * i);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        width="100%"
+        role="img"
+        aria-label="複数工具の VB 進展比較チャート"
+        style={{ maxHeight: 380 }}
+      >
+        <rect
+          x={plotX0}
+          y={plotY0}
+          width={plotX1 - plotX0}
+          height={plotY1 - plotY0}
+          fill="var(--bg-base, transparent)"
+          stroke="var(--border-faint, #334155)"
+        />
+
+        {/* y 軸グリッド + ラベル */}
+        {yTicks.map((t, i) => (
+          <g key={`gy-${i}`}>
+            <line
+              x1={plotX0}
+              y1={yScale(t)}
+              x2={plotX1}
+              y2={yScale(t)}
+              stroke="var(--border-faint, #1e293b)"
+              strokeDasharray="2 3"
+              opacity={0.35}
+            />
+            <text
+              x={plotX0 - 6}
+              y={yScale(t) + 4}
+              textAnchor="end"
+              fontSize={11}
+              fill="var(--text-lo, #94a3b8)"
+            >
+              {t.toFixed(2)}
+            </text>
+          </g>
+        ))}
+
+        {/* x 軸グリッド + ラベル */}
+        {xTicks.map((t, i) => {
+          const x = xScale(t);
+          const label = t >= 10000 ? `${(t / 1000).toFixed(0)}k` : t.toFixed(0);
+          return (
+            <g key={`gx-${i}`}>
+              <line
+                x1={x}
+                y1={plotY0}
+                x2={x}
+                y2={plotY1}
+                stroke="var(--border-faint, #1e293b)"
+                strokeDasharray="2 3"
+                opacity={0.35}
+              />
+              <text
+                x={x}
+                y={plotY1 + 14}
+                textAnchor="middle"
+                fontSize={11}
+                fill="var(--text-lo, #94a3b8)"
+              >
+                {label}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* 軸ラベル */}
+        <text
+          x={(plotX0 + plotX1) / 2}
+          y={height - 4}
+          textAnchor="middle"
+          fontSize={12}
+          fill="var(--text-md, #cbd5e1)"
+        >
+          累積加工距離 (mm)
+        </text>
+        <text
+          x={12}
+          y={(plotY0 + plotY1) / 2}
+          textAnchor="middle"
+          fontSize={12}
+          fill="var(--text-md, #cbd5e1)"
+          transform={`rotate(-90 12 ${(plotY0 + plotY1) / 2})`}
+        >
+          工具摩耗 VB (mm)
+        </text>
+
+        {/* 摩耗限界 */}
+        {limit > 0 && limit < yMax && (
+          <g>
+            <line
+              x1={plotX0}
+              y1={yScale(limit)}
+              x2={plotX1}
+              y2={yScale(limit)}
+              stroke="var(--err, #dc2626)"
+              strokeDasharray="6 3"
+              opacity={0.8}
+            />
+            <text
+              x={plotX1 - 6}
+              y={yScale(limit) - 4}
+              textAnchor="end"
+              fontSize={11}
+              fill="var(--err, #dc2626)"
+              opacity={0.9}
+            >
+              摩耗限界 VB={limit.toFixed(2)} mm
+            </text>
+          </g>
+        )}
+
+        {/* 各シリーズの折れ線 + 点 */}
+        {series.map((s, sIdx) => {
+          const color = SERIES_COLORS[sIdx % SERIES_COLORS.length]!;
+          if (s.points.length === 0) return null;
+          const d = s.points
+            .map(
+              (p, i) =>
+                `${i === 0 ? 'M' : 'L'} ${xScale(p.cumulativeDistanceMm).toFixed(1)} ${yScale(p.toolWearVB).toFixed(1)}`,
+            )
+            .join(' ');
+          return (
+            <g key={s.toolId} aria-label={`${s.toolCode} の VB シリーズ`}>
+              <path d={d} stroke={color} strokeWidth={1.5} fill="none" opacity={0.85} />
+              {s.points.map((p) => (
+                <circle
+                  key={p.processId}
+                  cx={xScale(p.cumulativeDistanceMm)}
+                  cy={yScale(p.toolWearVB)}
+                  r={3}
+                  fill={color}
+                  opacity={0.9}
+                >
+                  <title>{`${s.toolCode}\n${p.processId}\nVB=${p.toolWearVB.toFixed(3)} mm @ ${p.cumulativeDistanceMm.toFixed(0)} mm`}</title>
+                </circle>
+              ))}
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* 凡例 */}
+      <ul className="flex gap-3 flex-wrap text-[11px]" aria-label="工具シリーズ凡例">
+        {series.map((s, sIdx) => {
+          const color = SERIES_COLORS[sIdx % SERIES_COLORS.length]!;
+          return (
+            <li key={s.toolId} className="flex items-center gap-1.5">
+              <span
+                aria-hidden
+                className="inline-block w-3 h-3 rounded-sm"
+                style={{ background: color }}
+              />
+              <span className="font-mono">{s.toolCode}</span>
+              <span className="text-[var(--text-lo)]">({s.points.length} 点)</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/src/features/tools/utils/wearStatus.test.ts
+++ b/src/features/tools/utils/wearStatus.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { classifyWearStatus, VB_WEAR_LIMIT } from './wearStatus';
+
+describe('classifyWearStatus', () => {
+  it('returns "未測定" when VB is null', () => {
+    const r = classifyWearStatus(null);
+    expect(r.status).toBe('ok');
+    expect(r.label).toBe('未測定');
+    expect(r.remainingRatio).toBe(1);
+  });
+
+  it('returns ok when ratio < 0.7', () => {
+    const r = classifyWearStatus(VB_WEAR_LIMIT * 0.5);
+    expect(r.status).toBe('ok');
+    expect(r.remainingRatio).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns warn at 70-80% (残 20%)', () => {
+    const r = classifyWearStatus(VB_WEAR_LIMIT * 0.75);
+    expect(r.status).toBe('warn');
+    expect(r.remainingRatio).toBeCloseTo(0.25, 5);
+  });
+
+  it('returns alert at 80-100% (残 10%)', () => {
+    const r = classifyWearStatus(VB_WEAR_LIMIT * 0.9);
+    expect(r.status).toBe('alert');
+    expect(r.remainingRatio).toBeCloseTo(0.1, 5);
+  });
+
+  it('returns exceeded at or above limit', () => {
+    const r = classifyWearStatus(VB_WEAR_LIMIT * 1.2);
+    expect(r.status).toBe('exceeded');
+    expect(r.remainingRatio).toBe(0);
+  });
+});

--- a/src/features/tools/utils/wearStatus.ts
+++ b/src/features/tools/utils/wearStatus.ts
@@ -1,0 +1,63 @@
+// 工具摩耗 VB から残寿命カテゴリと色を返す純関数。
+//
+// VB_CRITERIA.finishing.average (= 0.3 mm / ISO 3685) を寿命基準に取り、
+// 余裕の比率でアラートを 4 段階に分類する。
+//
+//   ratio = vb / limit
+//   ratio < 0.7   → ok      （残 30% 超）
+//   ratio < 0.8   → warn    （残 20%）
+//   ratio < 1.0   → alert   （残 10%）
+//   ratio >= 1.0  → exceeded（限界超過）
+
+import { VB_CRITERIA } from '@/features/cutting/utils/standards';
+
+export const VB_WEAR_LIMIT = VB_CRITERIA.finishing.average; // 0.3 mm
+
+export type WearStatus = 'ok' | 'warn' | 'alert' | 'exceeded';
+
+export interface WearStatusInfo {
+  status: WearStatus;
+  /** 0..1 の残寿命率（1 - vb/limit）。負値はクランプ。 */
+  remainingRatio: number;
+  /** 表示用ラベル */
+  label: string;
+  /** 表示用色（CSS color value、--err / --warn / --ok 系） */
+  color: string;
+}
+
+const COLOR: Record<WearStatus, string> = {
+  ok: 'var(--ok, #22c55e)',
+  warn: 'var(--warn, #d97706)',
+  alert: 'var(--warn, #ea580c)', // やや濃い橙
+  exceeded: 'var(--err, #dc2626)',
+};
+
+const LABEL: Record<WearStatus, string> = {
+  ok: '余裕あり',
+  warn: '残 20%',
+  alert: '残 10%',
+  exceeded: '限界超過',
+};
+
+export function classifyWearStatus(vbMm: number | null): WearStatusInfo {
+  if (vbMm === null || vbMm <= 0) {
+    return {
+      status: 'ok',
+      remainingRatio: 1,
+      label: '未測定',
+      color: 'var(--text-lo, #94a3b8)',
+    };
+  }
+  const ratio = vbMm / VB_WEAR_LIMIT;
+  let status: WearStatus;
+  if (ratio < 0.7) status = 'ok';
+  else if (ratio < 0.8) status = 'warn';
+  else if (ratio < 1.0) status = 'alert';
+  else status = 'exceeded';
+  return {
+    status,
+    remainingRatio: Math.max(1 - ratio, 0),
+    label: LABEL[status],
+    color: COLOR[status],
+  };
+}


### PR DESCRIPTION
## 概要

Issue #82 G（工具ライフトラッカー 予測拡張）を実装。

## 範囲
- ✅ 予測区間の信頼性バンド（±1σ / ±2σ）
- ✅ 残寿命予測（現在の累積使用時間から残り min / 残り mm）
- ✅ 交換推奨タイミングのアラート色分け（4 段階）
- ✅ 複数工具の比較モード（VB 進展の重ね描き）

## 変更点

### 純関数（テスト容易）
- `src/features/cutting/utils/taylorTool.ts`
  - `fitTaylor` の返り値に `sigmaLogV`（対数 V 残差 σ）を追加
  - `predictToolLifeWithBands(V, params, sigmaLogV)` — T と ±1σ / ±2σ 区間
  - `estimateRemainingLife(predictedTotalT, cumulativeMin, V)` — 残時間 + 残距離 + 使用率
  - テスト 5 件追加
- `src/features/tools/utils/wearStatus.ts`
  - `classifyWearStatus(vb)` — ISO 3685 finishing 0.3 mm を基準に 4 段階分類
    - `ok` (< 70%) / `warn` (残 20%) / `alert` (残 10%) / `exceeded` (限界超)
  - テスト 5 件

### UI
- `src/features/tools/components/TaylorPredictionPanel.tsx`
  - ±1σ / ±2σ 区間の T レンジを表示（fit 成立時のみ）
  - 累積使用時間と残寿命（min / mm）を追加
- `src/features/tools/components/VBComparisonChart.tsx` 新規
  - 複数シリーズの VB 進展を統一スケールで重ね描く純 SVG
  - 6 色サイクル + 凡例
- `src/features/tools/ToolLifeTrackerPage.tsx`
  - リストの「限界超」バッジを `classifyWearStatus` ベースの色付きラベルに置換
  - 各行にチェックボックス、2 件以上選択で比較モーダル起動

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- 信頼区間は対数 V 空間で残差標準偏差を出し、`T_pred · exp(±k · σ_logV / n)` で T 区間に変換。線形回帰の自然な拡張で説明可能性が高い
- 4 段階アラートは ISO 3685 の VB 0.3 mm を基準に、80% / 90% / 100% で色を切替。現場の「もうすぐ交換」感覚に合わせた
- 比較は VBChart を改造せず別コンポーネント `VBComparisonChart` として独立させ、責務を明確化

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run` ✅ 832 passed / 2 skipped

## 手動確認
- [ ] Taylor パネルに ±1σ / ±2σ 区間と残寿命が表示
- [ ] 工具リストの摩耗バッジが 4 段階で色分け
- [ ] 2 工具以上選択 → 「比較ビューを開く」 → 重ね描きチャート