### PR TITLE
feat(cutting): 波形ビューアに重ね描きモードと CSV ダウンロードを追加

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-02-waveform-overlay-csv',
+    date: '2026-05-02',
+    type: 'feature',
+    title: '波形ビューアに重ね描きモードと CSV ダウンロードを追加',
+    body: '波形ビューアの上部に「単独 / 重ね描き」のビューモード切替を追加しました。重ね描きモードでは切削抵抗 X / Y / Z や振動など複数チャネルを共通の縦軸で並べて見られるようになり、チャネル間の同期挙動を直感的に確認できます。さらに「CSV」ボタンで、選択チャネルの時間波形と FFT 振幅スペクトルを 1 つの CSV ファイルにまとめて書き出せます。外部解析ツール（Excel / Python 等）に取り込む導線です。',
+  },
+  {
     id: '2026-05-02-tool-life-prediction-and-compare',
     date: '2026-05-02',
     type: 'feature',

--- a/src/features/cutting/components/WaveformViewer.tsx
+++ b/src/features/cutting/components/WaveformViewer.tsx
@@ -1,13 +1,26 @@
 // 波形ビューア。時系列プロット + FFT スペクトル + 基本統計を純 SVG で描画する。
 // 依存ゼロ（自前 FFT を使用）。128 点規模の PoC 用途を想定。
+//
+// 表示モード:
+//   - single  (既定) — 選択チャネル 1 本を統計付きで表示
+//   - overlay        — 全チャネルを同一スケールで重ね描き
+//                       チャネル間の同期挙動（X / Y / Z 切削抵抗の相関等）を
+//                       直感的に確認するための比較ビュー
+//
+// CSV ダウンロード: 選択チャネルの時間波形 + FFT 振幅スペクトルをまとめて
+// CSV ファイルとして出力する（外部解析ツールで再利用可能）。
 
 import { useEffect, useMemo, useState } from 'react';
 import type { WaveformSample } from '@/domain/types';
 import { binFrequency, fft, magnitudeSpectrum } from '../utils/fft';
+import { buildWaveformCsv, defaultWaveformCsvFilename } from '../utils/waveformCsv';
+import { downloadTextFile } from '@/services/downloadFile';
 
 export interface WaveformViewerProps {
   samples: WaveformSample[];
 }
+
+type ViewMode = 'single' | 'overlay';
 
 interface WaveformStats {
   min: number;
@@ -59,6 +72,7 @@ const CHANNEL_LABEL: Record<WaveformSample['channel'], string> = {
 export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
   const firstSampleId = samples[0]?.id ?? '';
   const [activeId, setActiveId] = useState<string>(firstSampleId);
+  const [viewMode, setViewMode] = useState<ViewMode>('single');
 
   // samples が差し替わったら選択状態をリセットする（前回の activeId が新しい配列に
   // 含まれないと詳細表示と選択状態が乖離するため）
@@ -140,6 +154,12 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
     return { freq: freqs[peakIdx] ?? 0, mag: peakMag };
   }, [spectrum]);
 
+  const handleCsvDownload = () => {
+    if (!active) return;
+    const csv = buildWaveformCsv(active, spectrum);
+    downloadTextFile(csv, defaultWaveformCsvFilename(active), 'text/csv');
+  };
+
   if (!active) {
     return (
       <div className="text-[11px] text-[var(--text-lo)]">
@@ -152,8 +172,47 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      {/* チャネルタブ */}
-      {samples.length > 1 && (
+      {/* 操作行: モード切替 + CSV */}
+      <div className="flex items-center gap-2 flex-wrap">
+        {samples.length > 1 && (
+          <div
+            className="flex items-center gap-1"
+            role="radiogroup"
+            aria-label="波形ビューア表示モード"
+          >
+            {([
+              { v: 'single' as const, label: '単独' },
+              { v: 'overlay' as const, label: '重ね描き' },
+            ]).map((o) => (
+              <button
+                key={o.v}
+                type="button"
+                role="radio"
+                aria-checked={viewMode === o.v}
+                onClick={() => setViewMode(o.v)}
+                className={`px-2 py-0.5 text-[11px] rounded border transition-colors ${
+                  viewMode === o.v
+                    ? 'bg-[var(--accent,#2563eb)] text-white border-transparent'
+                    : 'text-[var(--text-md)] border-[var(--border-faint)] hover:bg-[var(--hover)]'
+                }`}
+              >
+                {o.label}
+              </button>
+            ))}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={handleCsvDownload}
+          className="ml-auto text-[11px] px-2 py-0.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+          aria-label="選択波形を CSV ダウンロード"
+        >
+          CSV
+        </button>
+      </div>
+
+      {/* チャネルタブ（単独モードのみ） */}
+      {samples.length > 1 && viewMode === 'single' && (
         <div
           className="flex items-center gap-1 flex-wrap"
           role="tablist"
@@ -181,8 +240,13 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
         </div>
       )}
 
-      {/* 統計値 */}
-      {stats && (
+      {/* 重ね描き（overlay）モード — 全チャネルを共通スケールで描画 */}
+      {viewMode === 'overlay' && samples.length > 1 && (
+        <OverlayPlot samples={samples} />
+      )}
+
+      {/* 統計値（単独モードのみ） */}
+      {viewMode === 'single' && stats && (
         <dl className="grid grid-cols-2 gap-x-3 gap-y-0.5 text-[11px]">
           <dt className="text-[var(--text-lo)]">min</dt>
           <dd className="font-mono text-right">
@@ -215,7 +279,8 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
         </dl>
       )}
 
-      {/* 時間領域プロット */}
+      {/* 時間領域プロット（単独モード） */}
+      {viewMode === 'single' && (
       <div>
         <div className="text-[10px] text-[var(--text-lo)] mb-0.5">
           時間領域 ({active.values.length} 点 / {active.sampleRateHz} Hz)
@@ -238,8 +303,10 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
           <path d={timeDomainPath} stroke={color} strokeWidth={1.2} fill="none" />
         </svg>
       </div>
+      )}
 
-      {/* 周波数領域プロット */}
+      {/* 周波数領域プロット（単独モード） */}
+      {viewMode === 'single' && (
       <div>
         <div className="text-[10px] text-[var(--text-lo)] mb-0.5">
           周波数領域 (FFT 片側振幅スペクトル)
@@ -262,6 +329,84 @@ export const WaveformViewer = ({ samples }: WaveformViewerProps) => {
           <path d={spectrumPath} stroke={color} strokeWidth={1.2} fill="none" />
         </svg>
       </div>
+      )}
+    </div>
+  );
+};
+
+// ----- Overlay プロット（複数波形の同期表示） -----
+
+interface OverlayPlotProps {
+  samples: WaveformSample[];
+}
+
+const OverlayPlot = ({ samples }: OverlayPlotProps) => {
+  const allValues = samples.flatMap((s) => s.values);
+  if (allValues.length === 0) return null;
+  const yMin = Math.min(...allValues);
+  const yMax = Math.max(...allValues);
+  const yRange = yMax === yMin ? 1 : yMax - yMin;
+  const w = 560;
+  const h = 160;
+  const pad = 24;
+  const plotW = w - pad * 2;
+  const plotH = h - pad * 2;
+  const longestN = Math.max(...samples.map((s) => s.values.length), 1);
+
+  const buildPath = (values: readonly number[]) => {
+    if (values.length === 0) return '';
+    const parts: string[] = [];
+    for (let i = 0; i < values.length; i++) {
+      const x = pad + (plotW * i) / Math.max(1, longestN - 1);
+      const y = pad + plotH - ((values[i]! - yMin) / yRange) * plotH;
+      parts.push(`${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`);
+    }
+    return parts.join(' ');
+  };
+
+  return (
+    <div>
+      <div className="text-[10px] text-[var(--text-lo)] mb-0.5">
+        重ね描き（{samples.length} チャネル / 共通スケール）
+      </div>
+      <svg
+        viewBox={`0 0 ${w} ${h}`}
+        width="100%"
+        className="block"
+        role="img"
+        aria-label="複数チャネルの時間波形 重ね描き"
+      >
+        <rect
+          x={pad}
+          y={pad}
+          width={plotW}
+          height={plotH}
+          fill="var(--bg-base, transparent)"
+          stroke="var(--border-faint, #334155)"
+        />
+        {samples.map((s) => (
+          <path
+            key={s.id}
+            d={buildPath(s.values)}
+            stroke={CHANNEL_COLOR[s.channel]}
+            strokeWidth={1.1}
+            fill="none"
+            opacity={0.85}
+          />
+        ))}
+      </svg>
+      <ul className="flex gap-3 flex-wrap text-[11px] mt-1" aria-label="チャネル凡例">
+        {samples.map((s) => (
+          <li key={s.id} className="flex items-center gap-1.5">
+            <span
+              aria-hidden
+              className="inline-block w-3 h-3 rounded-sm"
+              style={{ background: CHANNEL_COLOR[s.channel] }}
+            />
+            {CHANNEL_LABEL[s.channel]}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/features/cutting/utils/waveformCsv.test.ts
+++ b/src/features/cutting/utils/waveformCsv.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import type { WaveformSample } from '@/domain/types';
+import { buildWaveformCsv, defaultWaveformCsvFilename } from './waveformCsv';
+
+const sample: WaveformSample = {
+  id: 'wf-1',
+  processId: 'cp-1',
+  channel: 'force_x',
+  unit: 'N',
+  sampleRateHz: 1000,
+  values: [1, 2, 3],
+  startedAt: '2026-04-17T10:00:00+09:00',
+};
+
+describe('buildWaveformCsv', () => {
+  it('writes header lines and data rows', () => {
+    const csv = buildWaveformCsv(sample, null);
+    expect(csv).toContain('# Matlens waveform CSV');
+    expect(csv).toContain('# sampleRateHz=1000');
+    expect(csv).toContain('timeSec,value,frequencyHz,magnitude');
+    // 3 サンプル → 3 データ行
+    // 7 ヘッダ + 1 カラム名 + 3 データ行
+    expect(csv.trim().split('\n')).toHaveLength(7 + 1 + 3);
+  });
+
+  it('aligns time and frequency rows by index, padding shorter side', () => {
+    const csv = buildWaveformCsv(sample, {
+      freqs: [0, 100],
+      mags: [0.5, 1.5],
+    });
+    const lines = csv.trim().split('\n');
+    // 7 ヘッダ + 1 カラム名 + max(3, 2) = 11
+    expect(lines).toHaveLength(7 + 1 + 3);
+    // 最初のデータ行（index=0）は時間と周波数両方が埋まる
+    expect(lines[8]).toMatch(/^0\.000000,1,0\.000,0\.500000$/);
+    // 3 行目（index=2）は時間のみで周波数列は空
+    expect(lines[10]).toMatch(/^0\.002000,3,,$/);
+  });
+});
+
+describe('defaultWaveformCsvFilename', () => {
+  it('encodes channel + id + date in the filename', () => {
+    const name = defaultWaveformCsvFilename(sample);
+    expect(name).toMatch(/^waveform_force_x_wf-1_\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+});

--- a/src/features/cutting/utils/waveformCsv.ts
+++ b/src/features/cutting/utils/waveformCsv.ts
@@ -1,0 +1,75 @@
+// 波形サンプルの CSV シリアライザ（純関数）。
+// 生波形 + FFT 振幅スペクトルを 1 ファイルにまとめ、外部解析ツールに
+// インポートしやすい縦持ち CSV を返す。
+//
+// 出力フォーマット:
+//   # header lines (# で始まる)
+//   timeSec,value,frequencyHz,magnitude
+//   0.000,12.3,0.0,0.123
+//   ...
+//
+// 時間/周波数のサンプル数は揃わないので、長い方に合わせて空欄で埋める。
+
+import type { WaveformSample } from '@/domain/types';
+
+export interface FftResultLite {
+  freqs: number[];
+  mags: number[];
+}
+
+/** 値をコンマ・改行・ダブルクォートに対して安全な CSV 字句に整形する */
+function escapeCell(value: string | number): string {
+  const text = String(value);
+  if (/[",\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+export function buildWaveformCsv(sample: WaveformSample, spectrum: FftResultLite | null): string {
+  const headerLines = [
+    `# Matlens waveform CSV`,
+    `# sampleId=${sample.id}`,
+    `# channel=${sample.channel}`,
+    `# unit=${sample.unit}`,
+    `# sampleRateHz=${sample.sampleRateHz}`,
+    `# pointCount=${sample.values.length}`,
+    `# startedAt=${sample.startedAt}`,
+  ];
+
+  const dt = sample.sampleRateHz > 0 ? 1 / sample.sampleRateHz : 0;
+  const timeRows = sample.values.map((v, i) => ({
+    timeSec: i * dt,
+    value: v,
+  }));
+  const freqRows = spectrum
+    ? spectrum.freqs.map((f, i) => ({ frequencyHz: f, magnitude: spectrum.mags[i] ?? 0 }))
+    : [];
+
+  const totalRows = Math.max(timeRows.length, freqRows.length);
+  const lines: string[] = [
+    ...headerLines,
+    ['timeSec', 'value', 'frequencyHz', 'magnitude'].map(escapeCell).join(','),
+  ];
+  for (let i = 0; i < totalRows; i++) {
+    const t = timeRows[i];
+    const f = freqRows[i];
+    lines.push(
+      [
+        t ? t.timeSec.toFixed(6) : '',
+        t ? t.value : '',
+        f ? f.frequencyHz.toFixed(3) : '',
+        f ? (f.magnitude ?? 0).toFixed(6) : '',
+      ]
+        .map(escapeCell)
+        .join(','),
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+export function defaultWaveformCsvFilename(sample: WaveformSample): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const slug = `${sample.channel}_${sample.id}`.replace(/[^A-Za-z0-9_-]+/g, '-');
+  return `waveform_${slug}_${date}.csv`;
+}


### PR DESCRIPTION
## 概要

Issue #82 H（波形ビューアの機能拡張）を実装。

## 範囲
- ✅ 複数波形の重ね描画（条件違いの比較）
- ✅ チャネル間の相関表示（X / Y / Z 切削抵抗の同期表示）— 上記の重ね描きで同時に達成
- ⏭ ピーク周波数の推移（工具寿命進行 vs 周波数シフト） — 単一プロセスの viewer の範囲を超えるため別 issue 候補（ToolLifeTracker レベルで実装する方が自然）
- ✅ CSV ダウンロード（生データ + FFT 結果）

## 変更点

### 純関数（テスト容易）
- `src/features/cutting/utils/waveformCsv.ts`
  - `buildWaveformCsv(sample, spectrum)` — 時間波形 + FFT 振幅スペクトルを 1 ファイルにまとめた縦持ち CSV を生成
  - `defaultWaveformCsvFilename(sample)` — `waveform_<channel>_<id>_<date>.csv`
- `src/features/cutting/utils/waveformCsv.test.ts` — 単体テスト 3 件

### UI 拡張
- `src/features/cutting/components/WaveformViewer.tsx`
  - `viewMode` (`single` / `overlay`) のトグルを上部に追加
  - 重ね描きモード: 内部コンポーネント `OverlayPlot` で全チャネルを共通スケールで描画 + 凡例
  - 「CSV」ボタンで active sample を `buildWaveformCsv` + `downloadTextFile` で出力
  - 既存の単独モード（チャネル切替・統計・FFT）はそのまま維持

### 連動更新（ADR-007）
- `src/data/announcements.ts` にお知らせ 1 件追加

## 設計判断
- CSV は「時間波形のみ」「FFT のみ」を別ファイルに分けず、1 ファイルに縦持ちで両方含める設計。Excel / pandas での再利用が一手間少ない
- OverlayPlot を WaveformViewer 内に定義したのは、共通スケールの算出ロジックが viewer 専用で他で使う見込みが低いため。汎用化はユースケースが増えてから

## 検証
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors)
- `pnpm test --run` ✅ 835 passed / 2 skipped

## 手動確認
- [ ] /cutting-conditions の選択プロセスが波形を持つとき、重ね描きトグルが表示
- [ ] 重ね描きモードで複数チャネルが共通スケールで重なる
- [ ] CSV ボタン押下で `.csv` がダウンロードされ、Excel で開ける