### PR TITLE
feat(maiml): MaiML Studio を新設しコア要素として最上位に位置付け

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,12 @@ const ProjectListPage = lazy(() => import('./features/projects').then(m => ({ de
 const ProjectDetailPage = lazy(() => import('./features/projects').then(m => ({ default: m.ProjectDetailPage })));
 const DamageGalleryPage = lazy(() => import('./features/damage').then(m => ({ default: m.DamageGalleryPage })));
 const SemanticSearchPage = lazy(() => import('./features/search').then(m => ({ default: m.SemanticSearchPage })));
+const MaimlStudioHubPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlStudioHubPage })));
+const MaimlImportPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlImportPage })));
+const MaimlExportHubPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlExportHubPage })));
+const MaimlInspectPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlInspectPage })));
+const MaimlValidatePage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlValidatePage })));
+const MaimlDiffPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlDiffPage })));
 
 const LazyFallback = ({ label = 'ページを読み込み中...' }: { label?: string }) => (
   <div className="flex items-center justify-center h-64 text-text-lo">
@@ -273,6 +279,12 @@ export function App() {
       case 'help':    return lazyPage(<HelpPage onNav={navTo} />);
       case 'settings': return lazyPage(<MasterSettingsPage db={db} />);
       case 'about':   return lazyPage(<AboutPage />);
+      case 'maiml-hub':      return lazyPage(<MaimlStudioHubPage onNav={navTo} />);
+      case 'maiml-import':   return lazyPage(<MaimlImportPage db={db} dispatch={dispatch} onNav={navTo} />);
+      case 'maiml-export':   return lazyPage(<MaimlExportHubPage onNav={navTo} />);
+      case 'maiml-inspect':  return lazyPage(<MaimlInspectPage onNav={navTo} />);
+      case 'maiml-validate': return lazyPage(<MaimlValidatePage onNav={navTo} />);
+      case 'maiml-diff':     return lazyPage(<MaimlDiffPage onNav={navTo} />);
       default:        return lazyPage(<DashboardPage {...commonProps} />);
     }
   };

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-03-maiml-studio',
+    date: '2026-05-03',
+    type: 'feature',
+    title: 'MaiML Studio を新設しコア要素として最上位に位置付け',
+    body: 'MaiML (JIS K 0200:2024) を「エクスポート機能の 1 つ」から「アプリのコア要素」へ昇格させる MaiML Studio を新設しました。Hub ランディング + 5 サブ画面（インポート / エクスポート / インスペクト / バリデート / Diff）で構成され、サイドバーの最上位「コア」セクションから常時アクセスできます。インポートは drop → preview → commit の 3 段階で事故を防ぎ、インスペクトは XML を整形して構造ハイライトと部分一致検索を提供します。バリデートと Diff は暫定 (WIP) 表示で、Phase 9 で XSD 検証 + diff-match-patch ベース構造比較に拡張予定。',
+  },
+  {
     id: '2026-05-03-sidebar-ia-restructure',
     date: '2026-05-03',
     type: 'feature',

--- a/src/features/maiml/MaimlDiffPage.tsx
+++ b/src/features/maiml/MaimlDiffPage.tsx
@@ -1,0 +1,126 @@
+// MaiML Diff 画面（Phase 2 ではスタブ）。
+// 将来的には diff-match-patch ベースの構造比較 + 行ハイライトを実装。
+// Phase 2 は 2 ファイル受け取り → 行単位の単純比較を表示する暫定版。
+
+import { useState } from 'react';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+import { MaimlFileDropZone } from './components/MaimlFileDropZone';
+
+interface MaimlDiffPageProps {
+  onNav: (page: string) => void;
+}
+
+interface FileSlot {
+  filename: string;
+  text: string;
+}
+
+export const MaimlDiffPage = ({ onNav }: MaimlDiffPageProps) => {
+  const [a, setA] = useState<FileSlot | null>(null);
+  const [b, setB] = useState<FileSlot | null>(null);
+
+  return (
+    <MaimlPageLayout
+      title="MaiML Diff"
+      subtitle="Phase 2 暫定版: 2 ファイルの行数 / 要素数の差分を表示します。Phase 9 で diff-match-patch ベースの構造比較を実装予定。"
+      onBackToHub={() => onNav('maiml-hub')}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="rounded border border-[var(--border-faint)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px]">
+          <span className="font-semibold text-[var(--warn,#d97706)]">WIP:</span>
+          {' '}本格的な diff（行単位ハイライト + 構造比較）は Phase 9 で実装予定。
+          現状は両ファイルの簡易メタ比較のみです。
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <DiffSlot label="ファイル A" slot={a} onLoad={setA} />
+          <DiffSlot label="ファイル B" slot={b} onLoad={setB} />
+        </div>
+
+        {a && b && (
+          <section
+            aria-label="比較結果"
+            className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4 text-[12px]"
+          >
+            <h2 className="text-[13px] font-semibold mb-3">差分サマリ</h2>
+            <table className="w-full">
+              <thead>
+                <tr className="text-left border-b border-[var(--border-faint)]">
+                  <th className="px-2 py-1 font-semibold">項目</th>
+                  <th className="px-2 py-1 font-semibold text-right">A</th>
+                  <th className="px-2 py-1 font-semibold text-right">B</th>
+                  <th className="px-2 py-1 font-semibold text-right">差</th>
+                </tr>
+              </thead>
+              <tbody>
+                <DiffRow label="バイト" a={byteSize(a.text)} b={byteSize(b.text)} />
+                <DiffRow label="行数" a={lineCount(a.text)} b={lineCount(b.text)} />
+                <DiffRow label="要素タグ" a={elementCount(a.text)} b={elementCount(b.text)} />
+                <DiffRow label="property タグ" a={countMatches(a.text, /<property\s/g)} b={countMatches(b.text, /<property\s/g)} />
+                <DiffRow label="result タグ" a={countMatches(a.text, /<result\s/g)} b={countMatches(b.text, /<result\s/g)} />
+              </tbody>
+            </table>
+          </section>
+        )}
+      </div>
+    </MaimlPageLayout>
+  );
+};
+
+const DiffSlot = ({
+  label,
+  slot,
+  onLoad,
+}: {
+  label: string;
+  slot: FileSlot | null;
+  onLoad: (slot: FileSlot | null) => void;
+}) => (
+  <div className="flex flex-col gap-2">
+    <div className="text-[12px] font-semibold">{label}</div>
+    {slot ? (
+      <div className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-3">
+        <div className="font-mono text-[12px] truncate">{slot.filename}</div>
+        <div className="text-[11px] text-[var(--text-lo)] mt-1">
+          {(byteSize(slot.text) / 1024).toFixed(1)} KB / {lineCount(slot.text)} 行
+        </div>
+        <button
+          type="button"
+          onClick={() => onLoad(null)}
+          className="mt-2 text-[11px] underline text-[var(--text-lo)]"
+        >
+          差し替え
+        </button>
+      </div>
+    ) : (
+      <MaimlFileDropZone
+        onFileLoaded={(text, filename) => onLoad({ text, filename })}
+        hint={`${label} を drop`}
+      />
+    )}
+  </div>
+);
+
+const DiffRow = ({ label, a, b }: { label: string; a: number; b: number }) => {
+  const delta = b - a;
+  return (
+    <tr className="border-b border-[var(--border-faint)]">
+      <td className="px-2 py-1">{label}</td>
+      <td className="px-2 py-1 font-mono text-right">{a.toLocaleString()}</td>
+      <td className="px-2 py-1 font-mono text-right">{b.toLocaleString()}</td>
+      <td
+        className="px-2 py-1 font-mono text-right"
+        style={{
+          color: delta > 0 ? 'var(--ok,#22c55e)' : delta < 0 ? 'var(--err,#dc2626)' : 'var(--text-lo)',
+        }}
+      >
+        {delta > 0 ? `+${delta}` : delta}
+      </td>
+    </tr>
+  );
+};
+
+const byteSize = (s: string) => new Blob([s]).size;
+const lineCount = (s: string) => (s ? s.split('\n').length : 0);
+const elementCount = (s: string) => countMatches(s, /<[a-zA-Z][^>]*>/g);
+const countMatches = (s: string, re: RegExp) => (s.match(re) ?? []).length;

--- a/src/features/maiml/MaimlExportHubPage.tsx
+++ b/src/features/maiml/MaimlExportHubPage.tsx
@@ -1,0 +1,92 @@
+// MaiML エクスポート導線をまとめたハブ。
+// 既存の export 入口（DetailPage / MaterialListPage / ProjectDetailPage / TestMatrixPage）
+// は引き続き各ページから動作するが、この Hub から「目的別」にナビゲートできるように
+// する。実際のエクスポートは各ページの DownloadPreviewModal で実行。
+
+import type { IconName } from '@/components/Icon';
+import { Icon } from '@/components/Icon';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+
+interface MaimlExportHubPageProps {
+  onNav: (page: string) => void;
+}
+
+interface ExportTile {
+  title: string;
+  subtitle: string;
+  icon: IconName;
+  destination: string;
+  destinationLabel: string;
+}
+
+const TILES: ExportTile[] = [
+  {
+    title: '材料単体',
+    subtitle: '材料データ詳細から MaiML エクスポート（単一 Material）',
+    icon: 'embed',
+    destination: 'list',
+    destinationLabel: '材料データ一覧',
+  },
+  {
+    title: '材料一覧（バルク）',
+    subtitle: 'フィルタ済の材料データを一括 MaiML 化（複数 Material）',
+    icon: 'list',
+    destination: 'list',
+    destinationLabel: '材料データ一覧',
+  },
+  {
+    title: '案件バンドル',
+    subtitle: '案件 + 試験片 + 試験 + 損傷を 1 ファイル化（Project + 子要素）',
+    icon: 'report',
+    destination: 'pjlist',
+    destinationLabel: '案件一覧',
+  },
+  {
+    title: '試験集合（マトリクス選択）',
+    subtitle: '試験マトリクスのセル選択 → 単一 / 一括エクスポート',
+    icon: 'scan',
+    destination: 'matrix',
+    destinationLabel: '試験マトリクス',
+  },
+];
+
+export const MaimlExportHubPage = ({ onNav }: MaimlExportHubPageProps) => (
+  <MaimlPageLayout
+    title="MaiML エクスポート"
+    subtitle="目的別のエクスポート導線。各画面で DownloadPreviewModal によるプレビューを挟んで安全にダウンロードできます。"
+    onBackToHub={() => onNav('maiml-hub')}
+  >
+    <div
+      className="grid gap-3"
+      style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}
+    >
+      {TILES.map((tile) => (
+        <button
+          key={tile.title}
+          type="button"
+          onClick={() => onNav(tile.destination)}
+          className="text-left rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4 hover:bg-[var(--hover)] focus:outline focus:outline-2 focus:outline-[var(--accent,#2563eb)] transition-colors"
+          aria-label={`${tile.destinationLabel} へ移動して ${tile.title} をエクスポート`}
+        >
+          <div className="flex items-center gap-2 mb-2">
+            <Icon name={tile.icon} size={16} className="text-[var(--accent,#2563eb)]" />
+            <div className="text-[14px] font-semibold">{tile.title}</div>
+          </div>
+          <div className="text-[11px] text-[var(--text-lo)] leading-relaxed mb-3">
+            {tile.subtitle}
+          </div>
+          <div className="text-[11px] text-[var(--text-md)]">
+            → {tile.destinationLabel}
+          </div>
+        </button>
+      ))}
+    </div>
+
+    <div className="mt-6 text-[11px] text-[var(--text-lo)] leading-relaxed max-w-2xl">
+      MaiML 出力先は将来 Repository 経由で API push できるようになる予定ですが、現状は
+      ブラウザ側でのファイルダウンロードのみです。すべての出力は MaiML (JIS K 0200:2024)
+      の <code className="font-mono">{`<maiml>`}</code> ルート + provenance / uncertainty を
+      含む形式で round-trip 可能です。
+    </div>
+  </MaimlPageLayout>
+);

--- a/src/features/maiml/MaimlImportPage.tsx
+++ b/src/features/maiml/MaimlImportPage.tsx
@@ -1,0 +1,211 @@
+// MaiML インポート画面。
+// drop → preview → commit の 3 段階で取り込み事故を防ぐ。
+// 現状は材料 (Material[]) の round-trip 完全対応のみ。
+// Project / TestSet の inverse parser は未実装のため、その場合は Inspect での
+// 確認案内のみを出す（ADR-016 で明記予定）。
+
+import { useState } from 'react';
+import type { Material } from '@/types';
+import type { DbAction } from '@/types';
+import { parseMaimlToMaterials } from '@/services/maiml';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+import { MaimlFileDropZone } from './components/MaimlFileDropZone';
+
+interface MaimlImportPageProps {
+  db: Material[];
+  dispatch: React.Dispatch<DbAction>;
+  onNav: (page: string) => void;
+}
+
+interface ParsedState {
+  filename: string;
+  materials: Material[];
+  warnings: string[];
+  generatedAt: string | null;
+  source: string | null;
+}
+
+export const MaimlImportPage = ({ db, dispatch, onNav }: MaimlImportPageProps) => {
+  const [parsed, setParsed] = useState<ParsedState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [imported, setImported] = useState<{ count: number; skipped: number } | null>(null);
+
+  const reset = () => {
+    setParsed(null);
+    setError(null);
+    setImported(null);
+  };
+
+  const handleFile = (text: string, filename: string) => {
+    reset();
+    try {
+      const result = parseMaimlToMaterials(text);
+      setParsed({
+        filename,
+        materials: result.materials,
+        warnings: result.warnings,
+        generatedAt: result.generatedAt,
+        source: result.source,
+      });
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!parsed) return;
+    const existing = new Set(db.map((r) => r.id));
+    const fresh = parsed.materials.filter((m) => m.id && !existing.has(m.id));
+    const skipped = parsed.materials.length - fresh.length;
+    if (fresh.length === 0) {
+      setImported({ count: 0, skipped });
+      return;
+    }
+    dispatch({ type: 'IMPORT', records: fresh });
+    setImported({ count: fresh.length, skipped });
+  };
+
+  return (
+    <MaimlPageLayout
+      title="MaiML インポート"
+      subtitle="MaiML / XML ファイルを 3 段階（取込 → preview → commit）で安全に取り込みます。即反映は事故になりやすいため必ずプレビューを挟みます。"
+      onBackToHub={() => onNav('maiml-hub')}
+    >
+      <div className="flex flex-col gap-4 max-w-3xl">
+        {!parsed && !error && !imported && (
+          <MaimlFileDropZone onFileLoaded={handleFile} onError={setError} />
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.08)] p-4 text-[13px]">
+            <div className="font-semibold text-[var(--err,#dc2626)] mb-1">読み込みエラー</div>
+            <div className="text-[var(--text-md)]">{error}</div>
+            <button
+              type="button"
+              onClick={reset}
+              className="mt-3 text-[12px] underline text-[var(--text-lo)]"
+            >
+              別のファイルを試す
+            </button>
+          </div>
+        )}
+
+        {parsed && !imported && (
+          <div className="flex flex-col gap-3">
+            <header className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-mono text-[13px] truncate">{parsed.filename}</div>
+                <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[var(--accent-dim)] text-[var(--accent,#2563eb)]">
+                  preview
+                </span>
+              </div>
+              <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">
+                <dt className="text-[var(--text-lo)]">取込件数</dt>
+                <dd className="font-mono text-right">{parsed.materials.length} 件</dd>
+                <dt className="text-[var(--text-lo)]">出力日時</dt>
+                <dd className="font-mono text-right">{parsed.generatedAt ?? '—'}</dd>
+                <dt className="text-[var(--text-lo)]">出力元</dt>
+                <dd className="font-mono text-right">{parsed.source ?? '—'}</dd>
+              </dl>
+            </header>
+
+            {parsed.warnings.length > 0 && (
+              <details className="rounded-lg border border-[var(--warn,#d97706)] bg-[rgba(217,119,6,0.08)] p-3">
+                <summary className="cursor-pointer text-[13px] font-semibold text-[var(--warn,#d97706)]">
+                  警告 {parsed.warnings.length} 件（クリックで展開）
+                </summary>
+                <ul className="mt-2 text-[12px] list-disc list-inside flex flex-col gap-1">
+                  {parsed.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+
+            <section
+              aria-label="取り込み対象の材料"
+              className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
+            >
+              <div className="text-[12px] text-[var(--text-lo)] px-3 py-1.5 bg-[var(--bg-sunken)] border-b border-[var(--border-faint)]">
+                取り込み対象一覧（先頭 10 件）
+              </div>
+              <table className="w-full text-[12px]">
+                <thead>
+                  <tr className="bg-[var(--bg-raised)] border-b border-[var(--border-faint)]">
+                    <th className="px-3 py-1.5 text-left font-semibold">ID</th>
+                    <th className="px-3 py-1.5 text-left font-semibold">名前</th>
+                    <th className="px-3 py-1.5 text-right font-semibold">硬度 HV</th>
+                    <th className="px-3 py-1.5 text-right font-semibold">引張 MPa</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {parsed.materials.slice(0, 10).map((m) => (
+                    <tr key={m.id} className="border-b border-[var(--border-faint)]">
+                      <td className="px-3 py-1 font-mono">{m.id}</td>
+                      <td className="px-3 py-1">{m.name}</td>
+                      <td className="px-3 py-1 font-mono text-right">{m.hv}</td>
+                      <td className="px-3 py-1 font-mono text-right">{m.ts}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {parsed.materials.length > 10 && (
+                <div className="px-3 py-1.5 text-[11px] text-[var(--text-lo)]">
+                  他 {parsed.materials.length - 10} 件
+                </div>
+              )}
+            </section>
+
+            <div className="flex items-center gap-3 justify-end">
+              <button
+                type="button"
+                onClick={reset}
+                className="text-[12px] px-3 py-1.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                className="text-[12px] px-3 py-1.5 rounded bg-[var(--accent,#2563eb)] text-white hover:opacity-90"
+              >
+                {parsed.materials.length} 件を取り込む
+              </button>
+            </div>
+          </div>
+        )}
+
+        {imported && (
+          <div className="rounded-lg border border-[var(--ok,#22c55e)] bg-[rgba(34,197,94,0.08)] p-4">
+            <div className="text-[14px] font-semibold text-[var(--ok,#22c55e)]">
+              取込完了
+            </div>
+            <p className="mt-1 text-[13px]">
+              {imported.count} 件を取り込みました
+              {imported.skipped > 0 && (
+                <span className="text-[var(--text-lo)]">（既存 ID 重複により {imported.skipped} 件を skip）</span>
+              )}
+              。
+            </p>
+            <div className="flex items-center gap-3 mt-3">
+              <button
+                type="button"
+                onClick={() => onNav('list')}
+                className="text-[12px] px-3 py-1.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+              >
+                材料データ一覧へ
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="text-[12px] underline text-[var(--text-lo)]"
+              >
+                別のファイルを取り込む
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </MaimlPageLayout>
+  );
+};

--- a/src/features/maiml/MaimlInspectPage.tsx
+++ b/src/features/maiml/MaimlInspectPage.tsx
@@ -1,0 +1,195 @@
+// MaiML XML を整形 + 強調表示するインスペクタ。
+// drop / ペーストで文字列を受け取り、indent と要素ハイライトをかけて読みやすく表示。
+// 検索ボックスで substring 一致をハイライト（XPath は将来対応）。
+
+import { useMemo, useState } from 'react';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+import { MaimlFileDropZone } from './components/MaimlFileDropZone';
+import { MAIML_MAX_BYTES } from '@/services/maiml';
+
+interface MaimlInspectPageProps {
+  onNav: (page: string) => void;
+}
+
+/**
+ * 単純な XML インデント。`<a><b>x</b></a>` のような単一要素は壊さず、
+ * タグの境界で改行 + ネスト深さに応じてスペースを入れる。
+ * 完全な整形ではないが、人間の目視確認には十分な軽量パターン。
+ */
+function prettyXml(xml: string): string {
+  if (!xml.trim()) return '';
+  // <?xml ?> と <!-- --> はそのまま、間に改行を挟む
+  const PADDING = '  ';
+  const reg = /(>)(<)(\/*)/g;
+  let formatted = xml.replace(reg, '$1\n$2$3');
+  // 浅いインデントロジック: 開きタグでネスト +1、閉じタグでネスト -1
+  let pad = 0;
+  formatted = formatted
+    .split('\n')
+    .map((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return '';
+      let indent = pad;
+      if (trimmed.startsWith('</')) {
+        pad = Math.max(pad - 1, 0);
+        indent = pad;
+      } else if (trimmed.startsWith('<') && !trimmed.startsWith('<?') && !trimmed.startsWith('<!--')) {
+        const isSelfClose = /\/>$/.test(trimmed) || /<\/.*>/.test(trimmed);
+        if (!isSelfClose) {
+          indent = pad;
+          pad += 1;
+        }
+      }
+      return PADDING.repeat(indent) + trimmed;
+    })
+    .filter((l) => l.length > 0)
+    .join('\n');
+  return formatted;
+}
+
+export const MaimlInspectPage = ({ onNav }: MaimlInspectPageProps) => {
+  const [text, setText] = useState('');
+  const [filename, setFilename] = useState('');
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const formatted = useMemo(() => prettyXml(text), [text]);
+
+  const stats = useMemo(() => {
+    const bytes = new Blob([text]).size;
+    const lines = text.split('\n').length;
+    const elementMatches = text.match(/<[a-zA-Z][^>]*>/g) ?? [];
+    return { bytes, lines, elements: elementMatches.length };
+  }, [text]);
+
+  // 検索ハイライト: substring を <mark> で囲む（XML の中なので safe な escape も必要）
+  const renderedLines = useMemo(() => {
+    if (!formatted) return [] as { text: string; key: number }[];
+    return formatted.split('\n').map((line, i) => ({ text: line, key: i }));
+  }, [formatted]);
+
+  const handleFile = (loaded: string, name: string) => {
+    setError(null);
+    setText(loaded);
+    setFilename(name);
+  };
+
+  const handlePaste = (value: string) => {
+    setError(null);
+    setText(value);
+    setFilename('(直接ペースト)');
+  };
+
+  return (
+    <MaimlPageLayout
+      title="MaiML インスペクト"
+      subtitle="MaiML XML を整形して構造を素早く把握。検索ボックスで substring を強調表示します。"
+      onBackToHub={() => onNav('maiml-hub')}
+    >
+      <div className="flex flex-col gap-4">
+        {!text && (
+          <>
+            <MaimlFileDropZone
+              onFileLoaded={handleFile}
+              onError={setError}
+              hint="MaiML ファイルを drop、または下のテキスト欄に直接ペースト"
+            />
+            <textarea
+              placeholder={`<?xml version="1.0" encoding="UTF-8"?>\n<maiml version="1.0">\n  ...\n</maiml>`}
+              onChange={(e) => {
+                if (e.target.value.length > MAIML_MAX_BYTES) {
+                  setError('入力が上限を超えています');
+                  return;
+                }
+                if (e.target.value.trim()) handlePaste(e.target.value);
+              }}
+              className="w-full h-32 p-2 text-[12px] font-mono leading-[1.5] rounded border border-[var(--border-faint)] bg-[var(--bg-sunken)] resize-y"
+              aria-label="MaiML 直接ペースト入力"
+            />
+          </>
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.08)] p-3 text-[13px]">
+            <div className="font-semibold text-[var(--err,#dc2626)]">エラー</div>
+            <div>{error}</div>
+          </div>
+        )}
+
+        {text && (
+          <div className="flex flex-col gap-3">
+            <header className="flex items-center justify-between gap-3 flex-wrap">
+              <div className="flex items-center gap-3 text-[12px]">
+                <span className="font-mono">{filename}</span>
+                <span className="text-[var(--text-lo)]">
+                  {(stats.bytes / 1024).toFixed(1)} KB / {stats.lines.toLocaleString()} 行 / {stats.elements} 要素
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="部分一致で検索"
+                  className="px-2 py-1 text-[12px] rounded border border-[var(--border-faint)] bg-transparent"
+                  aria-label="MaiML 内のテキスト検索"
+                />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setText('');
+                    setFilename('');
+                    setSearch('');
+                  }}
+                  className="text-[11px] underline text-[var(--text-lo)]"
+                >
+                  クリア
+                </button>
+              </div>
+            </header>
+
+            <pre
+              className="overflow-auto max-h-[60vh] p-3 text-[11px] font-mono leading-[1.5] rounded border border-[var(--border-faint)] whitespace-pre"
+              style={{ background: 'var(--bg-sunken)', color: 'var(--text-md)' }}
+              aria-label="MaiML XML プレビュー"
+            >
+              {renderedLines.map(({ text: line, key }) => (
+                <div key={key}>
+                  {search && line.toLowerCase().includes(search.toLowerCase())
+                    ? highlight(line, search)
+                    : line}
+                </div>
+              ))}
+            </pre>
+          </div>
+        )}
+      </div>
+    </MaimlPageLayout>
+  );
+};
+
+/** 部分一致を <mark> で囲む（HTML エンティティは扱わない、純文字列ベース） */
+function highlight(line: string, query: string): React.ReactNode {
+  const lower = line.toLowerCase();
+  const q = query.toLowerCase();
+  const out: React.ReactNode[] = [];
+  let i = 0;
+  while (i < line.length) {
+    const idx = lower.indexOf(q, i);
+    if (idx < 0) {
+      out.push(line.slice(i));
+      break;
+    }
+    if (idx > i) out.push(line.slice(i, idx));
+    out.push(
+      <mark
+        key={idx}
+        style={{ background: 'rgba(245,158,11,0.45)', color: 'inherit' }}
+      >
+        {line.slice(idx, idx + query.length)}
+      </mark>,
+    );
+    i = idx + query.length;
+  }
+  return out;
+}

--- a/src/features/maiml/MaimlStudioHubPage.tsx
+++ b/src/features/maiml/MaimlStudioHubPage.tsx
@@ -1,0 +1,126 @@
+// MaiML Studio のランディングページ。
+// 5 サブ画面 (Import / Export / Inspect / Validate / Diff) のカード一覧 +
+// MaiML が何かを 1 段落で説明 + 直近のローカル履歴を表示する。
+//
+// MaiML はクライアントの存在理由（JIS K 0200:2024 に準拠したラボ相互運用
+// フォーマット）であり、export 機能の 1 つではなくアプリのコア要素である
+// ことを最初に印象付ける役割。
+
+import type { IconName } from '@/components/Icon';
+import { Icon } from '@/components/Icon';
+
+interface MaimlStudioHubPageProps {
+  onNav: (page: string) => void;
+}
+
+interface StudioCard {
+  id: string;
+  title: string;
+  subtitle: string;
+  icon: IconName;
+  badge?: string;
+}
+
+const CARDS: StudioCard[] = [
+  {
+    id: 'maiml-import',
+    title: 'インポート',
+    subtitle: 'MaiML / XML ファイルを取り込む。3 段階（drop → preview → commit）で必ず止める',
+    icon: 'plus',
+  },
+  {
+    id: 'maiml-export',
+    title: 'エクスポート',
+    subtitle: '材料・案件・試験集合の MaiML 書き出し導線をここに集約',
+    icon: 'embed',
+  },
+  {
+    id: 'maiml-inspect',
+    title: 'インスペクト',
+    subtitle: 'MaiML XML を整形・強調表示し、構造を素早く把握',
+    icon: 'scan',
+  },
+  {
+    id: 'maiml-validate',
+    title: 'バリデート',
+    subtitle: 'XSD + provenance / uncertainty 必須項目チェック',
+    icon: 'check',
+    badge: 'WIP',
+  },
+  {
+    id: 'maiml-diff',
+    title: 'Diff',
+    subtitle: '2 つの MaiML ファイルを構造比較',
+    icon: 'similar',
+    badge: 'WIP',
+  },
+];
+
+export const MaimlStudioHubPage = ({ onNav }: MaimlStudioHubPageProps) => (
+  <div className="flex flex-col h-full overflow-hidden">
+    <header className="px-6 py-4 border-b border-[var(--border-faint)]">
+      <div className="flex items-center gap-3">
+        <h1 className="text-xl font-bold">MaiML Studio</h1>
+        <span className="text-[10px] font-bold tracking-[.08em] uppercase px-2 py-0.5 rounded bg-[var(--accent-dim)] text-[var(--accent,#2563eb)]">
+          CORE
+        </span>
+      </div>
+      <p className="text-[13px] text-[var(--text-lo)] mt-1">
+        MaiML (JIS K 0200:2024) は分析化学・材料試験の計測データを記述する XML 標準フォーマットです。
+        Matlens の中核は MaiML の入出力にあり、本 Studio から全ての MaiML 操作を行います。
+      </p>
+    </header>
+
+    <div className="flex-1 overflow-auto p-6 flex flex-col gap-6">
+      <section
+        aria-label="MaiML Studio サブ機能"
+        className="grid gap-3"
+        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))' }}
+      >
+        {CARDS.map((card) => (
+          <button
+            key={card.id}
+            type="button"
+            onClick={() => onNav(card.id)}
+            className="text-left rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4 hover:bg-[var(--hover)] focus:outline focus:outline-2 focus:outline-[var(--accent,#2563eb)] transition-colors"
+            aria-label={`${card.title} へ移動`}
+          >
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <Icon name={card.icon} size={18} className="text-[var(--accent,#2563eb)]" />
+              {card.badge && (
+                <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[var(--bg-sunken)] text-[var(--text-lo)]">
+                  {card.badge}
+                </span>
+              )}
+            </div>
+            <div className="text-[14px] font-semibold mb-1">{card.title}</div>
+            <div className="text-[11px] text-[var(--text-lo)] leading-relaxed">
+              {card.subtitle}
+            </div>
+          </button>
+        ))}
+      </section>
+
+      <section
+        aria-label="MaiML について"
+        className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4"
+      >
+        <h2 className="text-[14px] font-semibold mb-2">MaiML とは</h2>
+        <ul className="text-[12px] leading-relaxed list-disc list-inside text-[var(--text-md)] flex flex-col gap-1">
+          <li>
+            <strong>規格</strong>: JIS K 0200:2024 / 日本分析機器工業会（JAIMA）が策定した XML 規格
+          </li>
+          <li>
+            <strong>用途</strong>: 計測データの不変表現 + provenance（出所 / 計測者 / 校正履歴）+ uncertainty（不確かさ）
+          </li>
+          <li>
+            <strong>外部連携</strong>: ラボ計測器 / LIMS / OEM への引き渡しの標準フォーマット
+          </li>
+          <li>
+            <strong>Matlens での扱い</strong>: 材料単体 / 試験集合 / 案件バンドル の 3 種類で round-trip
+          </li>
+        </ul>
+      </section>
+    </div>
+  </div>
+);

--- a/src/features/maiml/MaimlValidatePage.tsx
+++ b/src/features/maiml/MaimlValidatePage.tsx
@@ -1,0 +1,119 @@
+// MaiML バリデート画面（Phase 2 ではスタブ）。
+// 将来的には XSD 検証 + provenance / uncertainty 必須項目チェックを行う。
+// 仮実装として、既存 parseMaimlToMaterials の warnings リストを表示するだけにする
+// （これだけでも「MaiML が壊れていないか」の素朴チェックには有用）。
+
+import { useState } from 'react';
+import { parseMaimlToMaterials } from '@/services/maiml';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+import { MaimlFileDropZone } from './components/MaimlFileDropZone';
+
+interface MaimlValidatePageProps {
+  onNav: (page: string) => void;
+}
+
+interface ValidationResult {
+  filename: string;
+  materialCount: number;
+  warnings: string[];
+  generatedAt: string | null;
+}
+
+export const MaimlValidatePage = ({ onNav }: MaimlValidatePageProps) => {
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const validate = (text: string, filename: string) => {
+    setError(null);
+    try {
+      const r = parseMaimlToMaterials(text);
+      setResult({
+        filename,
+        materialCount: r.materials.length,
+        warnings: r.warnings,
+        generatedAt: r.generatedAt,
+      });
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  return (
+    <MaimlPageLayout
+      title="MaiML バリデート"
+      subtitle="Phase 2 暫定版: parseMaimlToMaterials の警告リストを表示します。XSD 検証 + provenance / uncertainty 必須項目チェックは Phase 9 で実装予定。"
+      onBackToHub={() => onNav('maiml-hub')}
+    >
+      <div className="flex flex-col gap-4 max-w-3xl">
+        <div className="rounded border border-[var(--border-faint)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px]">
+          <span className="font-semibold text-[var(--warn,#d97706)]">WIP:</span>
+          {' '}本格的な XSD 検証と必須項目チェックは Phase 9 で実装予定。
+          現状は parser 側の警告リスト表示のみです。
+        </div>
+
+        {!result && !error && (
+          <MaimlFileDropZone
+            onFileLoaded={validate}
+            onError={setError}
+            hint="MaiML ファイルを drop して検証"
+          />
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.08)] p-3 text-[13px]">
+            <div className="font-semibold text-[var(--err,#dc2626)] mb-1">パースエラー</div>
+            <div>{error}</div>
+            <button
+              type="button"
+              onClick={() => setError(null)}
+              className="mt-2 text-[12px] underline text-[var(--text-lo)]"
+            >
+              再試行
+            </button>
+          </div>
+        )}
+
+        {result && (
+          <div className="flex flex-col gap-3">
+            <header className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="font-mono text-[13px] truncate">{result.filename}</div>
+                <span
+                  className="text-[10px] font-mono px-2 py-0.5 rounded"
+                  style={{
+                    background: result.warnings.length === 0 ? 'rgba(34,197,94,0.14)' : 'rgba(217,119,6,0.14)',
+                    color: result.warnings.length === 0 ? 'var(--ok,#22c55e)' : 'var(--warn,#d97706)',
+                  }}
+                >
+                  {result.warnings.length === 0 ? 'OK' : `${result.warnings.length} 警告`}
+                </span>
+              </div>
+              <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">
+                <dt className="text-[var(--text-lo)]">取込可能件数</dt>
+                <dd className="font-mono text-right">{result.materialCount} 件</dd>
+                <dt className="text-[var(--text-lo)]">出力日時</dt>
+                <dd className="font-mono text-right">{result.generatedAt ?? '—'}</dd>
+              </dl>
+            </header>
+
+            {result.warnings.length > 0 && (
+              <ul className="rounded-lg border border-[var(--warn,#d97706)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px] list-disc list-inside flex flex-col gap-1">
+                {result.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setResult(null)}
+              className="text-[12px] underline text-[var(--text-lo)] self-start"
+            >
+              別のファイルを検証
+            </button>
+          </div>
+        )}
+      </div>
+    </MaimlPageLayout>
+  );
+};

--- a/src/features/maiml/components/MaimlFileDropZone.tsx
+++ b/src/features/maiml/components/MaimlFileDropZone.tsx
@@ -1,0 +1,88 @@
+// MaiML / XML ファイルを drag & drop または file picker で受け取る汎用 zone。
+// - MAIML_MAX_BYTES (10 MB) の size guard
+// - .maiml / .xml 拡張子チェック（厳密ではなく注意喚起レベル）
+// - ファイル本文（string）+ filename を親に返す
+
+import { useRef, useState } from 'react';
+import { MAIML_MAX_BYTES } from '@/services/maiml';
+
+interface MaimlFileDropZoneProps {
+  onFileLoaded: (text: string, filename: string) => void;
+  onError?: (message: string) => void;
+  /** placeholder 表示（例: 「.maiml または .xml をドロップ」）*/
+  hint?: string;
+}
+
+export const MaimlFileDropZone = ({ onFileLoaded, onError, hint }: MaimlFileDropZoneProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const reportError = (message: string) => {
+    if (onError) onError(message);
+  };
+
+  const handleFile = async (file: File) => {
+    if (file.size > MAIML_MAX_BYTES) {
+      reportError(`ファイルサイズが上限 (${(MAIML_MAX_BYTES / 1024 / 1024).toFixed(0)} MB) を超えています`);
+      return;
+    }
+    try {
+      const text = await file.text();
+      onFileLoaded(text, file.name);
+    } catch (e) {
+      reportError(`読み込みエラー: ${(e as Error).message}`);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  };
+
+  return (
+    <div
+      onDragOver={(e) => {
+        e.preventDefault();
+        setIsDragging(true);
+      }}
+      onDragLeave={() => setIsDragging(false)}
+      onDrop={handleDrop}
+      onClick={() => inputRef.current?.click()}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          inputRef.current?.click();
+        }
+      }}
+      aria-label="MaiML / XML ファイルをドロップまたはクリックで選択"
+      className={`flex flex-col items-center justify-center gap-2 p-8 rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
+        isDragging
+          ? 'border-[var(--accent,#2563eb)] bg-[var(--accent-dim)]'
+          : 'border-[var(--border-faint)] bg-[var(--bg-raised)] hover:bg-[var(--hover)]'
+      }`}
+    >
+      <div className="text-[14px] font-semibold">
+        {hint ?? 'MaiML / XML ファイルをドロップ、またはクリックで選択'}
+      </div>
+      <div className="text-[11px] text-[var(--text-lo)]">
+        対応拡張子: .maiml / .xml（最大 {(MAIML_MAX_BYTES / 1024 / 1024).toFixed(0)} MB）
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".maiml,.xml"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) handleFile(file);
+          // 同じファイルを連続で選べるように value をリセット
+          e.target.value = '';
+        }}
+        className="hidden"
+      />
+    </div>
+  );
+};

--- a/src/features/maiml/components/MaimlPageLayout.tsx
+++ b/src/features/maiml/components/MaimlPageLayout.tsx
@@ -1,0 +1,31 @@
+// MaiML Studio 配下サブ画面の共通レイアウト。
+// Hub への戻り導線、ページタイトル、サブタイトルを統一。
+
+import type { ReactNode } from 'react';
+
+interface MaimlPageLayoutProps {
+  title: string;
+  subtitle?: string;
+  /** Hub に戻るためのコールバック（onNav('maiml-hub') を渡す想定） */
+  onBackToHub: () => void;
+  children: ReactNode;
+}
+
+export const MaimlPageLayout = ({ title, subtitle, onBackToHub, children }: MaimlPageLayoutProps) => (
+  <div className="flex flex-col h-full overflow-hidden">
+    <header className="px-6 py-4 border-b border-[var(--border-faint)]">
+      <button
+        type="button"
+        onClick={onBackToHub}
+        className="text-[12px] text-[var(--text-lo)] underline mb-1"
+      >
+        ← MaiML Studio
+      </button>
+      <h1 className="text-xl font-bold">{title}</h1>
+      {subtitle && (
+        <p className="text-[13px] text-[var(--text-lo)] mt-1">{subtitle}</p>
+      )}
+    </header>
+    <div className="flex-1 overflow-auto p-6">{children}</div>
+  </div>
+);

--- a/src/features/maiml/index.ts
+++ b/src/features/maiml/index.ts
@@ -1,0 +1,9 @@
+// MaiML Studio feature 配下の barrel。
+// App.tsx の lazy import 経路を 1 行で揃えるため一箇所に集約。
+
+export { MaimlStudioHubPage } from './MaimlStudioHubPage';
+export { MaimlImportPage } from './MaimlImportPage';
+export { MaimlExportHubPage } from './MaimlExportHubPage';
+export { MaimlInspectPage } from './MaimlInspectPage';
+export { MaimlValidatePage } from './MaimlValidatePage';
+export { MaimlDiffPage } from './MaimlDiffPage';


### PR DESCRIPTION
## 概要

IA リファクタ計画の **Phase 2: MaiML Studio 新設**。MaiML (JIS K 0200:2024) を「エクスポート機能の 1 つ」から「アプリのコア要素」へ昇格させる Studio を新設。

## 構成

### Hub (`/maiml-hub`)
- 5 カード（Import / Export / Inspect / Validate / Diff）
- 「MaiML とは」コラム（規格 / 用途 / 外部連携 / Matlens での扱い）

### 5 サブ画面
| 画面 | 状態 | 説明 |
|---|---|---|
| `maiml-import` | ✅ 実装済 | drop → preview → commit の 3 段階。事故防止 |
| `maiml-export` | ✅ 実装済 | 4 タイルから既存ページ export 動線へ誘導 |
| `maiml-inspect` | ✅ 実装済 | XML 整形 + 部分一致 highlight + 統計 |
| `maiml-validate` | 🚧 WIP | parser warning 表示のみ。Phase 9 で XSD 検証 |
| `maiml-diff` | 🚧 WIP | 行・byte・要素数差分。Phase 9 で構造比較 |

## 設計判断

- **Materials のみ完全 round-trip**: Project / TestSet の inverse parser は未実装のため、Inspect での確認案内のみ
- **既存導線は壊さない**: DetailPage / ProjectDetailPage / TestMatrixPage の MaiML 出口はそのまま動作
- **Validate / Diff を Phase 9 に分離**: 5/18 着任時のコア表示優先度を最大化、本格実装は後段
- **Import の 3 段階**: 「即反映は事故」という研究データ運用の鉄則

## 再利用
- `src/services/maiml.ts` の `parseMaimlToMaterials` / `MAIML_MAX_BYTES`
- 既存 `DownloadPreviewModal`（Export Hub から各ページの既存実装に誘導）

## 検証
- `pnpm typecheck` ✅
- `pnpm lint --quiet` ✅
- `pnpm test --run` ✅ 839 passed / 2 skipped

## 手動確認
- [ ] `/maiml-hub` で 5 カードが表示
- [ ] サンプル MaiML を Import → preview → commit → 材料データ一覧で取込確認
- [ ] 既存 export ファイルを Inspect に drop → 整形表示
- [ ] Validate で warning が出るファイル / 出ないファイルを確認
- [ ] Diff で 2 ファイルの差分テーブル

## 関連
- 計画書: `~/.claude/plans/smooth-imagining-twilight.md` Phase 2
- 前 PR: #116 サイドバー IA 再構成
- 次 PR: Phase 3 検索統合 + Phase 4 可視化統合