### PR TITLE
feat(explore): 検索 4 画面と可視化 4 画面をそれぞれ 1 タブ画面に統合

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,8 @@ const MaimlExportHubPage = lazy(() => import('./features/maiml').then(m => ({ de
 const MaimlInspectPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlInspectPage })));
 const MaimlValidatePage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlValidatePage })));
 const MaimlDiffPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlDiffPage })));
+const SearchHubPage = lazy(() => import('./features/explore').then(m => ({ default: m.SearchHubPage })));
+const VisualizeHubPage = lazy(() => import('./features/explore').then(m => ({ default: m.VisualizeHubPage })));
 
 const LazyFallback = ({ label = 'ページを読み込み中...' }: { label?: string }) => (
   <div className="flex items-center justify-center h-64 text-text-lo">
@@ -285,6 +287,18 @@ export function App() {
       case 'maiml-inspect':  return lazyPage(<MaimlInspectPage onNav={navTo} />);
       case 'maiml-validate': return lazyPage(<MaimlValidatePage onNav={navTo} />);
       case 'maiml-diff':     return lazyPage(<MaimlDiffPage onNav={navTo} />);
+      case 'search-hub':
+        return lazyPage(
+          <SearchHubPage
+            {...commonProps}
+            ragInitialQuery={ragInitialQuery}
+            clearRagInitialQuery={() => setRagInitialQuery('')}
+            simInitialBase={simInitialBase}
+            clearSimInitialBase={() => setSimInitialBase('')}
+          />,
+        );
+      case 'visualize-hub':
+        return lazyPage(<VisualizeHubPage db={db} />);
       default:        return lazyPage(<DashboardPage {...commonProps} />);
     }
   };

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-03-search-visualize-hubs',
+    date: '2026-05-03',
+    type: 'feature',
+    title: '検索 4 画面と可視化 4 画面をそれぞれ 1 タブ画面に統合',
+    body: 'サイドバーで散在していた検索系 4 画面（意味検索 / AI チャット / 類似材料 / 横断検索）を「検索（統合）」、可視化系 4 画面（タイムライン / 予測 vs 実績 / 結晶 3D / マルチスケール）を「可視化（統合）」に統合し、それぞれをタブ UI で 1 画面化しました。タブ選択は localStorage に永続化され、リロード後も同じタブが開きます。Crystal 3D は WebGL リソースを毎回再マウントしてリーク防止しています。旧ルート（/vsearch / /rag / /sim / /semsearch / /timeline / /overlay / /crystal / /multimodal）は引き続き直接 URL アクセス可能で、既存ブックマークは壊れません。',
+  },
+  {
     id: '2026-05-03-maiml-studio',
     date: '2026-05-03',
     type: 'feature',

--- a/src/features/explore/SearchHubPage.tsx
+++ b/src/features/explore/SearchHubPage.tsx
@@ -1,0 +1,141 @@
+// 検索（統合）ハブ。
+// 4 種類の検索画面（意味検索 / AI チャット / 類似材料 / 横断検索）を
+// 1 ページのタブ UI に統合する。各タブパネルは既存ページコンポーネントを
+// そのまま埋め込む（コードの重複を避ける）。
+//
+// 旧ルート (/vsearch / /rag / /sim / /semsearch) は App.tsx に残してあり、
+// 直接 URL アクセスは引き続き可能。サイドバーからは本ハブ経由で到達する。
+
+import { Suspense, useState } from 'react';
+import type { Material } from '@/types';
+import type { DbAction } from '@/types';
+import { VectorSearchPage } from '@/pages/VectorSearch';
+import { RAGChatPage } from '@/pages/RAGChat';
+import { SimilarPage } from '@/pages/Similar';
+import { SemanticSearchPage } from '@/features/search';
+
+type SearchTab = 'semantic' | 'chat' | 'similar' | 'cross';
+
+const TABS: { id: SearchTab; label: string; labelEn: string }[] = [
+  { id: 'semantic', label: '意味検索', labelEn: 'Semantic' },
+  { id: 'chat',     label: 'AI チャット', labelEn: 'AI Chat' },
+  { id: 'similar',  label: '類似材料',   labelEn: 'Similar' },
+  { id: 'cross',    label: '横断検索 (PoC)', labelEn: 'Cross-domain' },
+];
+
+const STORAGE_KEY = 'matlens_search_tab';
+
+interface SearchHubPageProps {
+  // VectorSearch / RAG / Similar が共通で必要とする props（App の commonProps 相当）
+  // を素直に受け取り、子に流すだけのハブ。
+  db: Material[];
+  dispatch: React.Dispatch<DbAction>;
+  onNav: (page: string) => void;
+  // useAI / useEmbedding / useVoice の戻り値（型は App.tsx と合わせる）
+  claude: unknown;
+  embedding: unknown;
+  voice: unknown;
+
+  // 初期タブ（直リンクや navTo の prefix で指定したい場合）
+  initialTab?: SearchTab;
+
+  // RAG / Similar 専用のディープリンクパラメータ
+  ragInitialQuery?: string;
+  clearRagInitialQuery?: () => void;
+  simInitialBase?: string;
+  clearSimInitialBase?: () => void;
+}
+
+const loadInitialTab = (): SearchTab => {
+  if (typeof window === 'undefined') return 'semantic';
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw && TABS.some((t) => t.id === raw)) return raw as SearchTab;
+  } catch {
+    // ignore
+  }
+  return 'semantic';
+};
+
+export const SearchHubPage = ({
+  db,
+  dispatch,
+  onNav,
+  claude,
+  embedding,
+  voice,
+  initialTab,
+  ragInitialQuery = '',
+  clearRagInitialQuery = () => undefined,
+  simInitialBase = '',
+  clearSimInitialBase = () => undefined,
+}: SearchHubPageProps) => {
+  const [tab, setTab] = useState<SearchTab>(initialTab ?? loadInitialTab());
+
+  const switchTab = (next: SearchTab) => {
+    setTab(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore
+    }
+  };
+
+  // 子ページに渡す props は既存と同じ commonProps shape
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const commonProps: any = { db, dispatch, onNav, claude, embedding, voice };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <header className="px-6 py-3 border-b border-[var(--border-faint)]">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-xl font-bold">検索（統合）</h1>
+          <span className="text-[11px] text-[var(--text-lo)]">
+            意味検索 / AI チャット / 類似材料 / 横断検索 を 1 画面にまとめました
+          </span>
+        </div>
+        <div className="mt-2 flex gap-1.5" role="tablist" aria-label="検索モード">
+          {TABS.map((t) => {
+            const active = tab === t.id;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => switchTab(t.id)}
+                className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                  active
+                    ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                    : 'border border-[var(--border-faint)] text-[var(--text-md)] hover:bg-[var(--hover)]'
+                }`}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+      </header>
+      <div className="flex-1 overflow-auto">
+        <Suspense fallback={<div className="p-6 text-[var(--text-lo)]">読み込み中…</div>}>
+          {tab === 'semantic' && <VectorSearchPage {...commonProps} />}
+          {tab === 'chat' && (
+            <RAGChatPage
+              {...commonProps}
+              initialQuery={ragInitialQuery}
+              clearInitialQuery={clearRagInitialQuery}
+            />
+          )}
+          {tab === 'similar' && (
+            <SimilarPage
+              {...commonProps}
+              initialBase={simInitialBase}
+              clearInitialBase={clearSimInitialBase}
+            />
+          )}
+          {tab === 'cross' && <SemanticSearchPage />}
+        </Suspense>
+      </div>
+    </div>
+  );
+};

--- a/src/features/explore/VisualizeHubPage.tsx
+++ b/src/features/explore/VisualizeHubPage.tsx
@@ -1,0 +1,100 @@
+// 可視化（統合）ハブ。
+// 4 種類の可視化画面（タイムライン / 予測 vs 実績 / 結晶 3D / マルチスケール）
+// を 1 ページのタブ UI に統合する。
+//
+// 旧ルート (/timeline / /overlay / /crystal / /multimodal) は App.tsx に
+// 残してあり、直接 URL アクセスは引き続き可能。
+//
+// Crystal3D は WebGL コンテキストを持つので tab 切替時に毎回 unmount される
+// よう key={tab} で再マウントを強制する（メモリリーク防止）。
+
+import { Suspense, lazy, useState } from 'react';
+import type { Material } from '@/types';
+
+type VisualizeTab = 'timeline' | 'overlay' | 'crystal' | 'multimodal';
+
+const TABS: { id: VisualizeTab; label: string; labelEn: string }[] = [
+  { id: 'timeline',   label: '加工タイムライン',     labelEn: 'Process Timeline' },
+  { id: 'overlay',    label: '予測 vs 実績',         labelEn: 'Prediction vs Actual' },
+  { id: 'crystal',    label: '結晶構造 3D',          labelEn: 'Crystal 3D' },
+  { id: 'multimodal', label: 'マルチスケール',       labelEn: 'Multiscale' },
+];
+
+const STORAGE_KEY = 'matlens_visualize_tab';
+
+// 個別ページは lazy import（重いのでタブ切替時のみロード）
+const ProcessTimelinePage = lazy(() => import('@/pages/ProcessTimeline').then((m) => ({ default: m.ProcessTimelinePage })));
+const OverlayPage = lazy(() => import('@/pages/Overlay').then((m) => ({ default: m.OverlayPage })));
+const Crystal3DPage = lazy(() => import('@/pages/Crystal3D').then((m) => ({ default: m.Crystal3DPage })));
+const MultiModalPage = lazy(() => import('@/pages/MultiModal').then((m) => ({ default: m.MultiModalPage })));
+
+interface VisualizeHubPageProps {
+  db: Material[];
+  initialTab?: VisualizeTab;
+}
+
+const loadInitialTab = (): VisualizeTab => {
+  if (typeof window === 'undefined') return 'timeline';
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw && TABS.some((t) => t.id === raw)) return raw as VisualizeTab;
+  } catch {
+    // ignore
+  }
+  return 'timeline';
+};
+
+export const VisualizeHubPage = ({ db, initialTab }: VisualizeHubPageProps) => {
+  const [tab, setTab] = useState<VisualizeTab>(initialTab ?? loadInitialTab());
+
+  const switchTab = (next: VisualizeTab) => {
+    setTab(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <header className="px-6 py-3 border-b border-[var(--border-faint)]">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-xl font-bold">可視化（統合）</h1>
+          <span className="text-[11px] text-[var(--text-lo)]">
+            タイムライン / 予測 vs 実績 / 結晶 3D / マルチスケール を 1 画面に集約
+          </span>
+        </div>
+        <div className="mt-2 flex gap-1.5" role="tablist" aria-label="可視化モード">
+          {TABS.map((t) => {
+            const active = tab === t.id;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={() => switchTab(t.id)}
+                className={`px-3 py-1 text-[12px] rounded transition-colors ${
+                  active
+                    ? 'bg-[var(--accent,#2563eb)] text-white font-semibold'
+                    : 'border border-[var(--border-faint)] text-[var(--text-md)] hover:bg-[var(--hover)]'
+                }`}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+      </header>
+      <div className="flex-1 overflow-auto" key={tab /* WebGL 等のリーク防止に強制再マウント */}>
+        <Suspense fallback={<div className="p-6 text-[var(--text-lo)]">読み込み中…</div>}>
+          {tab === 'timeline' && <ProcessTimelinePage />}
+          {tab === 'overlay' && <OverlayPage db={db} />}
+          {tab === 'crystal' && <Crystal3DPage />}
+          {tab === 'multimodal' && <MultiModalPage db={db} />}
+        </Suspense>
+      </div>
+    </div>
+  );
+};

--- a/src/features/explore/index.ts
+++ b/src/features/explore/index.ts
@@ -1,0 +1,2 @@
+export { SearchHubPage } from './SearchHubPage';
+export { VisualizeHubPage } from './VisualizeHubPage';


### PR DESCRIPTION
## 概要

IA リファクタ計画の **Phase 3 (検索統合) + Phase 4 (可視化統合)** を 1 PR で実施。サイドバーで散在していた 8 画面を 2 つのタブ画面に集約。

## 構成

### 検索（統合）`/search-hub`
| Tab | 既存ページ | 役割 |
|---|---|---|
| 意味検索 | VectorSearchPage | Embedding 類似度検索 |
| AI チャット | RAGChatPage | 検索拡張生成チャット |
| 類似材料 | SimilarPage | 基準材料からの類似 |
| 横断検索 (PoC) | SemanticSearchPage | ドメイン横断検索 |

### 可視化（統合）`/visualize-hub`
| Tab | 既存ページ | 役割 |
|---|---|---|
| 加工タイムライン | ProcessTimelinePage | 加工工程の時系列 |
| 予測 vs 実績 | OverlayPage | モデル予測の検証 |
| 結晶構造 3D | Crystal3DPage | BCC/FCC/HCP 可視化 |
| マルチスケール | MultiModalPage | スケール横断 |

## 設計判断

- **既存ページコンポーネントを無改修で埋め込み**: `VectorSearchPage` 等は props 互換のままタブパネルとしてレンダリング
- **タブ状態を localStorage 永続化**: `matlens_search_tab` / `matlens_visualize_tab`
- **Crystal 3D の WebGL リーク防止**: タブコンテナに `key={tab}` を付けて強制再マウント
- **旧ルートは破壊しない**: `/vsearch` / `/rag` / `/sim` / `/semsearch` / `/timeline` / `/overlay` / `/crystal` / `/multimodal` は App.tsx の case 文に残存、直接 URL は引き続き有効
- **lazy import**: VisualizeHubPage の各タブパネルを `lazy()` でラップ、初回ロードを軽量化

## 検証
- `pnpm typecheck` ✅
- `pnpm lint --quiet` ✅
- `pnpm test --run` ✅ 839 passed / 2 skipped

## 手動確認
- [ ] サイドバー「検索（統合）」展開 → クリックで `/search-hub` に遷移
- [ ] 4 タブ切替が機能、状態が localStorage 永続化される（リロードで復元）
- [ ] 旧 URL `/vsearch` / `/rag` 等が引き続き直接アクセス可能
- [ ] Crystal 3D タブを開いて他タブに移動 → 戻る際に再マウント（DevTools Memory で確認）

## 関連
- 計画書: `~/.claude/plans/smooth-imagining-twilight.md` Phase 3 + 4
- 前 PR: #117 MaiML Studio
- 次 PR: Phase 5 Dev 隔離 + Phase 8 ADR-016