### PR TITLE
feat(maiml): バリデートと Diff をフル実装し WIP を解消

### DIFF
--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-03-maiml-validate-diff-full',
+    date: '2026-05-03',
+    type: 'feature',
+    title: 'MaiML Studio のバリデートと Diff をフル実装',
+    body: 'MaiML Studio の「バリデート」と「Diff」を正式機能に格上げしました。バリデートは DOCTYPE 拒否・header メタ・provenance / uncertainty 必須項目を意味的に検証し、エラー / 警告 / 情報の 3 段階で報告します。Diff は LCS ベースの行差分を純 TS で実装し、A 側 / B 側の行番号とハイライトで変更を可視化、追加 / 削除 / 変更なしのサマリも表示します。両機能とも純関数（src/services/maimlValidate.ts / maimlDiff.ts）として実装されており、フレームワーク非依存で再利用可能です。',
+  },
+  {
     id: '2026-05-03-docs-refresh-maiml-core',
     date: '2026-05-03',
     type: 'info',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -35,8 +35,8 @@ export const NAV_ITEMS: NavItem[] = [
       { id:'maiml-import',   label:'インポート',   labelEn:'Import',   icon:'plus' },
       { id:'maiml-export',   label:'エクスポート', labelEn:'Export',   icon:'embed' },
       { id:'maiml-inspect',  label:'インスペクト', labelEn:'Inspect',  icon:'scan' },
-      { id:'maiml-validate', label:'バリデート',   labelEn:'Validate', icon:'check', badgeLabel:'WIP', badgeVariant:'gray' },
-      { id:'maiml-diff',     label:'Diff',         labelEn:'Diff',     icon:'similar', badgeLabel:'WIP', badgeVariant:'gray' },
+      { id:'maiml-validate', label:'バリデート',   labelEn:'Validate', icon:'check' },
+      { id:'maiml-diff',     label:'Diff',         labelEn:'Diff',     icon:'similar' },
     ],
   },
 

--- a/src/features/maiml/MaimlDiffPage.tsx
+++ b/src/features/maiml/MaimlDiffPage.tsx
@@ -1,8 +1,9 @@
-// MaiML Diff 画面（Phase 2 ではスタブ）。
-// 将来的には diff-match-patch ベースの構造比較 + 行ハイライトを実装。
-// Phase 2 は 2 ファイル受け取り → 行単位の単純比較を表示する暫定版。
+// MaiML Diff 画面（Phase 9 フル実装）。
+// LCS ベースの行差分（diffLines 純関数）を表示する。
+// 大規模ファイル時のパフォーマンスは将来 Myers アルゴリズムへの差し替えで対応。
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { diffLines, type DiffLine } from '@/services/maimlDiff';
 import { MaimlPageLayout } from './components/MaimlPageLayout';
 import { MaimlFileDropZone } from './components/MaimlFileDropZone';
 
@@ -18,49 +19,75 @@ interface FileSlot {
 export const MaimlDiffPage = ({ onNav }: MaimlDiffPageProps) => {
   const [a, setA] = useState<FileSlot | null>(null);
   const [b, setB] = useState<FileSlot | null>(null);
+  const [showEqual, setShowEqual] = useState(true);
+
+  const diff = useMemo(() => {
+    if (!a || !b) return null;
+    return diffLines(a.text, b.text);
+  }, [a, b]);
+
+  const filtered = useMemo(() => {
+    if (!diff) return [] as DiffLine[];
+    return showEqual ? diff.lines : diff.lines.filter((l) => l.op !== 'equal');
+  }, [diff, showEqual]);
 
   return (
     <MaimlPageLayout
       title="MaiML Diff"
-      subtitle="Phase 2 暫定版: 2 ファイルの行数 / 要素数の差分を表示します。Phase 9 で diff-match-patch ベースの構造比較を実装予定。"
+      subtitle="2 つの MaiML / XML ファイルを行単位で差分表示します。LCS ベースの純 TS 実装で、改行コードは LF / CRLF を吸収します。"
       onBackToHub={() => onNav('maiml-hub')}
     >
       <div className="flex flex-col gap-4">
-        <div className="rounded border border-[var(--border-faint)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px]">
-          <span className="font-semibold text-[var(--warn,#d97706)]">WIP:</span>
-          {' '}本格的な diff（行単位ハイライト + 構造比較）は Phase 9 で実装予定。
-          現状は両ファイルの簡易メタ比較のみです。
-        </div>
-
         <div className="grid gap-4 md:grid-cols-2">
-          <DiffSlot label="ファイル A" slot={a} onLoad={setA} />
-          <DiffSlot label="ファイル B" slot={b} onLoad={setB} />
+          <DiffSlot label="ファイル A（変更前）" slot={a} onLoad={setA} />
+          <DiffSlot label="ファイル B（変更後）" slot={b} onLoad={setB} />
         </div>
 
-        {a && b && (
-          <section
-            aria-label="比較結果"
-            className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4 text-[12px]"
-          >
-            <h2 className="text-[13px] font-semibold mb-3">差分サマリ</h2>
-            <table className="w-full">
-              <thead>
-                <tr className="text-left border-b border-[var(--border-faint)]">
-                  <th className="px-2 py-1 font-semibold">項目</th>
-                  <th className="px-2 py-1 font-semibold text-right">A</th>
-                  <th className="px-2 py-1 font-semibold text-right">B</th>
-                  <th className="px-2 py-1 font-semibold text-right">差</th>
-                </tr>
-              </thead>
-              <tbody>
-                <DiffRow label="バイト" a={byteSize(a.text)} b={byteSize(b.text)} />
-                <DiffRow label="行数" a={lineCount(a.text)} b={lineCount(b.text)} />
-                <DiffRow label="要素タグ" a={elementCount(a.text)} b={elementCount(b.text)} />
-                <DiffRow label="property タグ" a={countMatches(a.text, /<property\s/g)} b={countMatches(b.text, /<property\s/g)} />
-                <DiffRow label="result タグ" a={countMatches(a.text, /<result\s/g)} b={countMatches(b.text, /<result\s/g)} />
-              </tbody>
-            </table>
-          </section>
+        {a && b && diff && (
+          <>
+            <section
+              aria-label="差分サマリ"
+              className="grid grid-cols-3 gap-2 text-[12px]"
+            >
+              <SummaryCard label="追加" value={diff.summary.added} color="var(--ok,#22c55e)" bg="rgba(34,197,94,0.08)" />
+              <SummaryCard label="削除" value={diff.summary.removed} color="var(--err,#dc2626)" bg="rgba(220,38,38,0.08)" />
+              <SummaryCard label="変更なし" value={diff.summary.equal} color="var(--text-md)" bg="rgba(148,163,184,0.06)" />
+            </section>
+
+            <div className="flex items-center gap-3 text-[12px]">
+              <label className="inline-flex items-center gap-1.5">
+                <input
+                  type="checkbox"
+                  checked={showEqual}
+                  onChange={(e) => setShowEqual(e.target.checked)}
+                />
+                変更なし行も表示
+              </label>
+              <span className="text-[var(--text-lo)]">表示行数: {filtered.length}</span>
+            </div>
+
+            <section
+              aria-label="差分内容"
+              className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
+            >
+              <div className="overflow-x-auto max-h-[60vh]">
+                <table className="w-full text-[11px] font-mono">
+                  <thead className="bg-[var(--bg-raised)] sticky top-0">
+                    <tr className="border-b border-[var(--border-faint)]">
+                      <th className="px-2 py-1 text-right font-semibold w-12">A</th>
+                      <th className="px-2 py-1 text-right font-semibold w-12">B</th>
+                      <th className="px-2 py-1 text-left font-semibold">行</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filtered.map((line, i) => (
+                      <DiffRow key={i} line={line} />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
         )}
       </div>
     </MaimlPageLayout>
@@ -82,7 +109,7 @@ const DiffSlot = ({
       <div className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-3">
         <div className="font-mono text-[12px] truncate">{slot.filename}</div>
         <div className="text-[11px] text-[var(--text-lo)] mt-1">
-          {(byteSize(slot.text) / 1024).toFixed(1)} KB / {lineCount(slot.text)} 行
+          {(new Blob([slot.text]).size / 1024).toFixed(1)} KB / {slot.text.split('\n').length} 行
         </div>
         <button
           type="button"
@@ -101,26 +128,41 @@ const DiffSlot = ({
   </div>
 );
 
-const DiffRow = ({ label, a, b }: { label: string; a: number; b: number }) => {
-  const delta = b - a;
+const SummaryCard = ({
+  label,
+  value,
+  color,
+  bg,
+}: {
+  label: string;
+  value: number;
+  color: string;
+  bg: string;
+}) => (
+  <div className="rounded border p-3" style={{ borderColor: color, background: bg }}>
+    <div className="text-[10px] uppercase tracking-[0.05em] text-[var(--text-lo)]">{label}</div>
+    <div className="font-mono text-2xl font-bold" style={{ color }}>
+      {value.toLocaleString()}
+    </div>
+  </div>
+);
+
+const DiffRow = ({ line }: { line: DiffLine }) => {
+  const styles =
+    line.op === 'added'
+      ? { background: 'rgba(34,197,94,0.10)', color: 'var(--ok,#22c55e)' }
+      : line.op === 'removed'
+        ? { background: 'rgba(220,38,38,0.10)', color: 'var(--err,#dc2626)' }
+        : { background: 'transparent', color: 'var(--text-md)' };
+  const sign = line.op === 'added' ? '+' : line.op === 'removed' ? '-' : ' ';
   return (
-    <tr className="border-b border-[var(--border-faint)]">
-      <td className="px-2 py-1">{label}</td>
-      <td className="px-2 py-1 font-mono text-right">{a.toLocaleString()}</td>
-      <td className="px-2 py-1 font-mono text-right">{b.toLocaleString()}</td>
-      <td
-        className="px-2 py-1 font-mono text-right"
-        style={{
-          color: delta > 0 ? 'var(--ok,#22c55e)' : delta < 0 ? 'var(--err,#dc2626)' : 'var(--text-lo)',
-        }}
-      >
-        {delta > 0 ? `+${delta}` : delta}
+    <tr className="border-b border-[var(--border-faint)] align-top" style={styles}>
+      <td className="px-2 py-0.5 text-right tabular-nums opacity-70">{line.lineA ?? ''}</td>
+      <td className="px-2 py-0.5 text-right tabular-nums opacity-70">{line.lineB ?? ''}</td>
+      <td className="px-2 py-0.5 whitespace-pre">
+        <span className="opacity-60 mr-1">{sign}</span>
+        {line.text}
       </td>
     </tr>
   );
 };
-
-const byteSize = (s: string) => new Blob([s]).size;
-const lineCount = (s: string) => (s ? s.split('\n').length : 0);
-const elementCount = (s: string) => countMatches(s, /<[a-zA-Z][^>]*>/g);
-const countMatches = (s: string, re: RegExp) => (s.match(re) ?? []).length;

--- a/src/features/maiml/MaimlStudioHubPage.tsx
+++ b/src/features/maiml/MaimlStudioHubPage.tsx
@@ -43,16 +43,14 @@ const CARDS: StudioCard[] = [
   {
     id: 'maiml-validate',
     title: 'バリデート',
-    subtitle: 'XSD + provenance / uncertainty 必須項目チェック',
+    subtitle: 'DOCTYPE 拒否・header メタ・provenance / uncertainty 必須項目を検証',
     icon: 'check',
-    badge: 'WIP',
   },
   {
     id: 'maiml-diff',
     title: 'Diff',
-    subtitle: '2 つの MaiML ファイルを構造比較',
+    subtitle: '2 つの MaiML / XML ファイルを行単位で差分表示（LCS ベース）',
     icon: 'similar',
-    badge: 'WIP',
   },
 ];
 

--- a/src/features/maiml/MaimlValidatePage.tsx
+++ b/src/features/maiml/MaimlValidatePage.tsx
@@ -1,10 +1,9 @@
-// MaiML バリデート画面（Phase 2 ではスタブ）。
-// 将来的には XSD 検証 + provenance / uncertainty 必須項目チェックを行う。
-// 仮実装として、既存 parseMaimlToMaterials の warnings リストを表示するだけにする
-// （これだけでも「MaiML が壊れていないか」の素朴チェックには有用）。
+// MaiML バリデート画面（Phase 9 フル実装）。
+// validateMaiml 純関数で意味的検証を行い、severity (error/warn/info) ごとに
+// グループ化して表示する。XSD 完全検証は CI（xmllint）で別途行う前提。
 
 import { useState } from 'react';
-import { parseMaimlToMaterials } from '@/services/maiml';
+import { validateMaiml, type MaimlValidationReport, type IssueSeverity } from '@/services/maimlValidate';
 import { MaimlPageLayout } from './components/MaimlPageLayout';
 import { MaimlFileDropZone } from './components/MaimlFileDropZone';
 
@@ -12,56 +11,47 @@ interface MaimlValidatePageProps {
   onNav: (page: string) => void;
 }
 
-interface ValidationResult {
+const SEVERITY_LABEL: Record<IssueSeverity, string> = {
+  error: 'エラー',
+  warn: '警告',
+  info: '情報',
+};
+
+const SEVERITY_COLOR: Record<IssueSeverity, { fg: string; bg: string }> = {
+  error: { fg: 'var(--err, #dc2626)', bg: 'rgba(220,38,38,0.08)' },
+  warn: { fg: 'var(--warn, #d97706)', bg: 'rgba(217,119,6,0.08)' },
+  info: { fg: 'var(--text-md, #cbd5e1)', bg: 'rgba(148,163,184,0.08)' },
+};
+
+interface RunState {
   filename: string;
-  materialCount: number;
-  warnings: string[];
-  generatedAt: string | null;
+  report: MaimlValidationReport;
 }
 
 export const MaimlValidatePage = ({ onNav }: MaimlValidatePageProps) => {
-  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [run, setRun] = useState<RunState | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const validate = (text: string, filename: string) => {
     setError(null);
-    try {
-      const r = parseMaimlToMaterials(text);
-      setResult({
-        filename,
-        materialCount: r.materials.length,
-        warnings: r.warnings,
-        generatedAt: r.generatedAt,
-      });
-    } catch (e) {
-      setError((e as Error).message);
-    }
+    const report = validateMaiml(text);
+    setRun({ filename, report });
   };
 
   return (
     <MaimlPageLayout
       title="MaiML バリデート"
-      subtitle="Phase 2 暫定版: parseMaimlToMaterials の警告リストを表示します。XSD 検証 + provenance / uncertainty 必須項目チェックは Phase 9 で実装予定。"
+      subtitle="DOCTYPE 拒否・ルート要素・header メタ・provenance / uncertainty 必須項目を検証します。XSD 完全検証は CI（xmllint）で別途実施します。"
       onBackToHub={() => onNav('maiml-hub')}
     >
       <div className="flex flex-col gap-4 max-w-3xl">
-        <div className="rounded border border-[var(--border-faint)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px]">
-          <span className="font-semibold text-[var(--warn,#d97706)]">WIP:</span>
-          {' '}本格的な XSD 検証と必須項目チェックは Phase 9 で実装予定。
-          現状は parser 側の警告リスト表示のみです。
-        </div>
-
-        {!result && !error && (
-          <MaimlFileDropZone
-            onFileLoaded={validate}
-            onError={setError}
-            hint="MaiML ファイルを drop して検証"
-          />
+        {!run && !error && (
+          <MaimlFileDropZone onFileLoaded={validate} onError={setError} hint="MaiML ファイルを drop して検証" />
         )}
 
         {error && (
           <div className="rounded-lg border border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.08)] p-3 text-[13px]">
-            <div className="font-semibold text-[var(--err,#dc2626)] mb-1">パースエラー</div>
+            <div className="font-semibold text-[var(--err,#dc2626)] mb-1">読み込みエラー</div>
             <div>{error}</div>
             <button
               type="button"
@@ -73,40 +63,73 @@ export const MaimlValidatePage = ({ onNav }: MaimlValidatePageProps) => {
           </div>
         )}
 
-        {result && (
+        {run && (
           <div className="flex flex-col gap-3">
             <header className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
               <div className="flex items-center justify-between gap-3 flex-wrap">
-                <div className="font-mono text-[13px] truncate">{result.filename}</div>
+                <div className="font-mono text-[13px] truncate">{run.filename}</div>
                 <span
                   className="text-[10px] font-mono px-2 py-0.5 rounded"
                   style={{
-                    background: result.warnings.length === 0 ? 'rgba(34,197,94,0.14)' : 'rgba(217,119,6,0.14)',
-                    color: result.warnings.length === 0 ? 'var(--ok,#22c55e)' : 'var(--warn,#d97706)',
+                    background: run.report.errorCount === 0 ? 'rgba(34,197,94,0.14)' : SEVERITY_COLOR.error.bg,
+                    color: run.report.errorCount === 0 ? 'var(--ok,#22c55e)' : SEVERITY_COLOR.error.fg,
                   }}
                 >
-                  {result.warnings.length === 0 ? 'OK' : `${result.warnings.length} 警告`}
+                  {run.report.errorCount === 0
+                    ? 'OK'
+                    : `${run.report.errorCount} エラー / ${run.report.warnCount} 警告`}
                 </span>
               </div>
               <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[12px]">
-                <dt className="text-[var(--text-lo)]">取込可能件数</dt>
-                <dd className="font-mono text-right">{result.materialCount} 件</dd>
+                <dt className="text-[var(--text-lo)]">documentKind</dt>
+                <dd className="font-mono text-right">{run.report.documentKind ?? '—'}</dd>
                 <dt className="text-[var(--text-lo)]">出力日時</dt>
-                <dd className="font-mono text-right">{result.generatedAt ?? '—'}</dd>
+                <dd className="font-mono text-right">{run.report.generatedAt ?? '—'}</dd>
+                <dt className="text-[var(--text-lo)]">出力元</dt>
+                <dd className="font-mono text-right">{run.report.source ?? '—'}</dd>
               </dl>
             </header>
 
-            {result.warnings.length > 0 && (
-              <ul className="rounded-lg border border-[var(--warn,#d97706)] bg-[rgba(217,119,6,0.06)] p-3 text-[12px] list-disc list-inside flex flex-col gap-1">
-                {result.warnings.map((w, i) => (
-                  <li key={i}>{w}</li>
+            <section
+              aria-label="検証結果"
+              className="grid grid-cols-3 gap-2 text-[12px]"
+            >
+              <Stat label="エラー" count={run.report.errorCount} severity="error" />
+              <Stat label="警告" count={run.report.warnCount} severity="warn" />
+              <Stat label="情報" count={run.report.infoCount} severity="info" />
+            </section>
+
+            {run.report.issues.length === 0 ? (
+              <div className="rounded-lg border border-[var(--ok,#22c55e)] bg-[rgba(34,197,94,0.08)] p-3 text-[13px]">
+                指摘事項はありません。
+              </div>
+            ) : (
+              <ul className="rounded-lg border border-[var(--border-faint)] divide-y divide-[var(--border-faint)] overflow-hidden">
+                {run.report.issues.map((issue, i) => (
+                  <li
+                    key={i}
+                    className="px-3 py-2 text-[12px] flex items-start gap-3"
+                    style={{ background: SEVERITY_COLOR[issue.severity].bg }}
+                  >
+                    <span
+                      className="text-[10px] font-mono uppercase tracking-[0.05em] px-1.5 py-0.5 rounded shrink-0"
+                      style={{
+                        color: SEVERITY_COLOR[issue.severity].fg,
+                        border: `1px solid ${SEVERITY_COLOR[issue.severity].fg}`,
+                      }}
+                    >
+                      {SEVERITY_LABEL[issue.severity]}
+                    </span>
+                    <span className="font-mono text-[10px] text-[var(--text-lo)] shrink-0">{issue.code}</span>
+                    <span className="flex-1">{issue.message}</span>
+                  </li>
                 ))}
               </ul>
             )}
 
             <button
               type="button"
-              onClick={() => setResult(null)}
+              onClick={() => setRun(null)}
               className="text-[12px] underline text-[var(--text-lo)] self-start"
             >
               別のファイルを検証
@@ -117,3 +140,18 @@ export const MaimlValidatePage = ({ onNav }: MaimlValidatePageProps) => {
     </MaimlPageLayout>
   );
 };
+
+const Stat = ({ label, count, severity }: { label: string; count: number; severity: IssueSeverity }) => (
+  <div
+    className="rounded border p-3"
+    style={{
+      borderColor: SEVERITY_COLOR[severity].fg,
+      background: SEVERITY_COLOR[severity].bg,
+    }}
+  >
+    <div className="text-[10px] uppercase tracking-[0.05em] text-[var(--text-lo)]">{label}</div>
+    <div className="font-mono text-2xl font-bold" style={{ color: SEVERITY_COLOR[severity].fg }}>
+      {count}
+    </div>
+  </div>
+);

--- a/src/services/maimlDiff.test.ts
+++ b/src/services/maimlDiff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { diffLines } from './maimlDiff';
+
+describe('diffLines', () => {
+  it('returns all equals when inputs are identical', () => {
+    const a = 'a\nb\nc';
+    const r = diffLines(a, a);
+    expect(r.summary.equal).toBe(3);
+    expect(r.summary.added).toBe(0);
+    expect(r.summary.removed).toBe(0);
+  });
+
+  it('handles pure additions', () => {
+    const r = diffLines('a\nb', 'a\nb\nc');
+    expect(r.summary.added).toBe(1);
+    expect(r.summary.removed).toBe(0);
+    expect(r.lines[2]).toEqual({ op: 'added', lineA: null, lineB: 3, text: 'c' });
+  });
+
+  it('handles pure removals', () => {
+    const r = diffLines('a\nb\nc', 'a\nb');
+    expect(r.summary.removed).toBe(1);
+    expect(r.summary.added).toBe(0);
+    expect(r.lines[2]).toEqual({ op: 'removed', lineA: 3, lineB: null, text: 'c' });
+  });
+
+  it('handles modifications as add+remove pairs', () => {
+    const r = diffLines('a\nb\nc', 'a\nB\nc');
+    expect(r.summary.added).toBe(1);
+    expect(r.summary.removed).toBe(1);
+    expect(r.summary.equal).toBe(2);
+  });
+
+  it('treats CRLF and LF identically', () => {
+    const r = diffLines('a\r\nb\r\n', 'a\nb\n');
+    expect(r.summary.equal).toBe(2);
+    expect(r.summary.added).toBe(0);
+    expect(r.summary.removed).toBe(0);
+  });
+
+  it('handles empty inputs', () => {
+    expect(diffLines('', '').summary.total).toBe(0);
+    expect(diffLines('a', '').summary.removed).toBe(1);
+    expect(diffLines('', 'b').summary.added).toBe(1);
+  });
+
+  it('preserves correct line numbers for both sides', () => {
+    const r = diffLines('a\nb\nc', 'a\nx\ny\nc');
+    const removedB = r.lines.find((l) => l.op === 'removed' && l.text === 'b');
+    expect(removedB?.lineA).toBe(2);
+    expect(removedB?.lineB).toBeNull();
+    const addedY = r.lines.find((l) => l.op === 'added' && l.text === 'y');
+    expect(addedY?.lineA).toBeNull();
+    expect(addedY?.lineB).toBe(3);
+  });
+});

--- a/src/services/maimlDiff.ts
+++ b/src/services/maimlDiff.ts
@@ -1,0 +1,111 @@
+// MaiML / 任意のテキスト 2 ファイルの行差分を計算する純関数。
+// LCS（最長共通部分列）ベースで Myers アルゴリズム相当の挙動を行単位で再現。
+// 軽量実装（DP テーブル）で外部依存ゼロ。
+//
+// 1 ファイル数 KB の MaiML 想定では DP テーブル O(n*m) でも数 ms で終わる。
+// MB 級になる場合は将来 Myers の差分アルゴリズム or hash chunking に置換する余地あり。
+
+export type DiffOp = 'equal' | 'added' | 'removed';
+
+export interface DiffLine {
+  op: DiffOp;
+  /** A 側の行番号（1-origin、added の場合は null） */
+  lineA: number | null;
+  /** B 側の行番号（1-origin、removed の場合は null） */
+  lineB: number | null;
+  text: string;
+}
+
+export interface DiffSummary {
+  added: number;
+  removed: number;
+  equal: number;
+  total: number;
+}
+
+export interface DiffResult {
+  lines: DiffLine[];
+  summary: DiffSummary;
+}
+
+/**
+ * 2 文字列を行単位で LCS 計算し、表示用の差分配列を返す。
+ * 改行は LF / CRLF を吸収し、末尾の空行は drop する。
+ */
+export function diffLines(a: string, b: string): DiffResult {
+  const aLines = splitLines(a);
+  const bLines = splitLines(b);
+  const lcs = computeLcsTable(aLines, bLines);
+  const trace = backtrack(aLines, bLines, lcs);
+
+  let added = 0;
+  let removed = 0;
+  let equal = 0;
+  for (const line of trace) {
+    if (line.op === 'added') added++;
+    else if (line.op === 'removed') removed++;
+    else equal++;
+  }
+
+  return {
+    lines: trace,
+    summary: { added, removed, equal, total: trace.length },
+  };
+}
+
+function splitLines(s: string): string[] {
+  const norm = s.replace(/\r\n/g, '\n');
+  const arr = norm.split('\n');
+  // 末尾改行のみの場合に空文字列が 1 個増えるので削る
+  if (arr.length > 0 && arr[arr.length - 1] === '') arr.pop();
+  return arr;
+}
+
+/**
+ * 古典的な LCS DP テーブル。
+ * dp[i][j] = a[0..i) と b[0..j) の LCS 長
+ */
+function computeLcsTable(a: string[], b: string[]): number[][] {
+  const n = a.length;
+  const m = b.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = 1; i <= n; i++) {
+    const ai = a[i - 1]!;
+    for (let j = 1; j <= m; j++) {
+      if (ai === b[j - 1]!) {
+        dp[i]![j] = dp[i - 1]![j - 1]! + 1;
+      } else {
+        dp[i]![j] = Math.max(dp[i - 1]![j]!, dp[i]![j - 1]!);
+      }
+    }
+  }
+  return dp;
+}
+
+function backtrack(a: string[], b: string[], dp: number[][]): DiffLine[] {
+  const out: DiffLine[] = [];
+  let i = a.length;
+  let j = b.length;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      out.unshift({ op: 'equal', lineA: i, lineB: j, text: a[i - 1]! });
+      i--;
+      j--;
+    } else if (dp[i - 1]![j]! >= dp[i]![j - 1]!) {
+      out.unshift({ op: 'removed', lineA: i, lineB: null, text: a[i - 1]! });
+      i--;
+    } else {
+      out.unshift({ op: 'added', lineA: null, lineB: j, text: b[j - 1]! });
+      j--;
+    }
+  }
+  while (i > 0) {
+    out.unshift({ op: 'removed', lineA: i, lineB: null, text: a[i - 1]! });
+    i--;
+  }
+  while (j > 0) {
+    out.unshift({ op: 'added', lineA: null, lineB: j, text: b[j - 1]! });
+    j--;
+  }
+  return out;
+}

--- a/src/services/maimlValidate.test.ts
+++ b/src/services/maimlValidate.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { validateMaiml } from './maimlValidate';
+
+const VALID_MIN = `<?xml version="1.0" encoding="UTF-8"?>
+<maiml version="1.0">
+  <header>
+    <property key="generatedAt">2026-05-03T10:00:00.000Z</property>
+    <property key="source">matlens</property>
+    <property key="documentKind">material</property>
+  </header>
+  <data>
+    <results>
+      <material id="MAT-1">
+        <property key="SampleId">MAT-1</property>
+        <property key="SampleName">SUS304</property>
+        <property key="Author">研究員</property>
+        <property key="RegisteredOn">2026-04-01</property>
+        <property key="AiDetected">false</property>
+      </material>
+      <result sampleRef="MAT-1">
+        <property key="name">hardness</property>
+        <property key="unit">HV</property>
+        <property key="uncertainty">3.0</property>
+        <content>186</content>
+      </result>
+    </results>
+  </data>
+</maiml>`;
+
+describe('validateMaiml', () => {
+  it('returns no errors for a valid minimal MaiML', () => {
+    const r = validateMaiml(VALID_MIN);
+    expect(r.errorCount).toBe(0);
+  });
+
+  it('returns header metadata', () => {
+    const r = validateMaiml(VALID_MIN);
+    expect(r.documentKind).toBe('material');
+    expect(r.source).toBe('matlens');
+    expect(r.generatedAt).toContain('2026-05-03T');
+  });
+
+  it('flags empty input as error', () => {
+    const r = validateMaiml('');
+    expect(r.errorCount).toBe(1);
+    expect(r.issues[0]?.code).toBe('empty');
+  });
+
+  it('refuses DOCTYPE for security', () => {
+    const r = validateMaiml('<!DOCTYPE foo><maiml/>');
+    expect(r.errorCount).toBeGreaterThan(0);
+    expect(r.issues.some((i) => i.code === 'doctype-forbidden')).toBe(true);
+  });
+
+  it('flags wrong root element', () => {
+    const r = validateMaiml('<not-maiml/>');
+    expect(r.issues.some((i) => i.code === 'root-not-maiml')).toBe(true);
+  });
+
+  it('warns when generatedAt is missing', () => {
+    const xml = VALID_MIN.replace('<property key="generatedAt">2026-05-03T10:00:00.000Z</property>', '');
+    const r = validateMaiml(xml);
+    expect(r.issues.some((i) => i.code === 'header-generatedAt-missing')).toBe(true);
+    expect(r.warnCount).toBeGreaterThan(0);
+  });
+
+  it('warns when uncertainty is missing on result', () => {
+    const xml = VALID_MIN.replace('<property key="uncertainty">3.0</property>', '');
+    const r = validateMaiml(xml);
+    expect(r.issues.some((i) => i.code === 'result-uncertainty-missing')).toBe(true);
+  });
+
+  it('returns info when material provenance is thin', () => {
+    const xml = VALID_MIN
+      .replace('<property key="Author">研究員</property>', '')
+      .replace('<property key="RegisteredOn">2026-04-01</property>', '')
+      .replace('<property key="AiDetected">false</property>', '');
+    const r = validateMaiml(xml);
+    expect(r.issues.some((i) => i.code === 'material-provenance-thin')).toBe(true);
+    expect(r.infoCount).toBeGreaterThan(0);
+  });
+
+  it('warns on missing data block', () => {
+    const xml = `<?xml version="1.0"?>
+<maiml version="1.0">
+  <header><property key="generatedAt">2026-05-03T10:00:00.000Z</property><property key="source">x</property><property key="documentKind">material</property></header>
+  <data><results /></data>
+</maiml>`;
+    const r = validateMaiml(xml);
+    expect(r.issues.some((i) => i.code === 'no-data-block')).toBe(true);
+  });
+});

--- a/src/services/maimlValidate.ts
+++ b/src/services/maimlValidate.ts
@@ -1,0 +1,178 @@
+// MaiML 検証ロジック（純関数）。
+// 完全な XSD 検証ではなく、Matlens 運用上重要な「規約準拠 + provenance /
+// uncertainty 必須項目」を中心にした意味的検証。
+//
+// 完全な XSD 検証が必要な場合は CI で `xmllint --schema` を回す前提。
+// 本モジュールはブラウザ・Nuxt SSR 双方で動かすため `DOMParser` を引数注入式にし、
+// 純関数として呼び出し側からテストできるようにしている。
+
+export type IssueSeverity = 'error' | 'warn' | 'info';
+
+export interface MaimlIssue {
+  severity: IssueSeverity;
+  code: string;
+  message: string;
+}
+
+export interface MaimlValidationReport {
+  documentKind: string | null;
+  generatedAt: string | null;
+  source: string | null;
+  issues: MaimlIssue[];
+  /** 全件のうち error の数 */
+  errorCount: number;
+  /** 全件のうち warn の数 */
+  warnCount: number;
+  /** 全件のうち info の数（参考情報、ヒント） */
+  infoCount: number;
+}
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+/** ブラウザの DOMParser を引数注入できるようにする（SSR 互換用） */
+export type ParseXml = (xml: string) => Document;
+
+const defaultParse: ParseXml = (xml) => {
+  const parser = new DOMParser();
+  return parser.parseFromString(xml, 'application/xml');
+};
+
+/**
+ * MaiML 文字列を検証し、issue 一覧と header メタを返す純関数。
+ * パースに失敗した時点で error を 1 件だけ返して即終了する。
+ */
+export function validateMaiml(xml: string, parseXml: ParseXml = defaultParse): MaimlValidationReport {
+  const issues: MaimlIssue[] = [];
+  const empty: MaimlValidationReport = {
+    documentKind: null,
+    generatedAt: null,
+    source: null,
+    issues,
+    errorCount: 0,
+    warnCount: 0,
+    infoCount: 0,
+  };
+
+  if (!xml || !xml.trim()) {
+    issues.push({ severity: 'error', code: 'empty', message: 'XML 本文が空です' });
+    return finalize(empty, issues);
+  }
+  if (xml.length > MAX_BYTES) {
+    issues.push({
+      severity: 'error',
+      code: 'too-large',
+      message: `ファイルサイズが上限 ${(MAX_BYTES / 1024 / 1024).toFixed(0)} MB を超えています`,
+    });
+    return finalize(empty, issues);
+  }
+  if (/<!DOCTYPE/i.test(xml)) {
+    issues.push({
+      severity: 'error',
+      code: 'doctype-forbidden',
+      message: 'DOCTYPE 宣言は受け付けません（Billion Laughs / XXE 防御）',
+    });
+    return finalize(empty, issues);
+  }
+
+  let doc: Document;
+  try {
+    doc = parseXml(xml);
+  } catch (e) {
+    issues.push({ severity: 'error', code: 'parse-failed', message: `パース失敗: ${(e as Error).message}` });
+    return finalize(empty, issues);
+  }
+
+  const parseError = doc.querySelector('parsererror');
+  if (parseError) {
+    issues.push({ severity: 'error', code: 'parse-error', message: 'XML パースエラー（要素 <parsererror> あり）' });
+    return finalize(empty, issues);
+  }
+
+  const root = doc.documentElement;
+  if (!root || root.localName !== 'maiml') {
+    issues.push({ severity: 'error', code: 'root-not-maiml', message: 'ルート要素が <maiml> ではありません' });
+    return finalize(empty, issues);
+  }
+
+  // header の存在確認
+  const header = root.getElementsByTagName('header')[0] ?? null;
+  if (!header) {
+    issues.push({ severity: 'error', code: 'header-missing', message: '<header> 要素が見つかりません' });
+  }
+
+  const headerProps = collectProperties(header);
+  const generatedAt = headerProps.generatedAt || null;
+  const source = headerProps.source || null;
+  const documentKind = headerProps.documentKind || null;
+
+  if (!generatedAt) {
+    issues.push({ severity: 'warn', code: 'header-generatedAt-missing', message: 'header.generatedAt が未設定（追跡性の観点で推奨）' });
+  } else if (!/^\d{4}-\d{2}-\d{2}T/.test(generatedAt)) {
+    issues.push({ severity: 'warn', code: 'header-generatedAt-format', message: `header.generatedAt が ISO 8601 形式ではない可能性: "${generatedAt}"` });
+  }
+  if (!source) {
+    issues.push({ severity: 'info', code: 'header-source-missing', message: 'header.source（出力元）の指定を推奨' });
+  }
+  if (!documentKind) {
+    issues.push({ severity: 'warn', code: 'header-documentKind-missing', message: 'header.documentKind（material / project-bundle / test-set）の指定を推奨' });
+  }
+
+  // 主要ブロックの少なくとも 1 つを期待
+  const hasMaterials = root.getElementsByTagName('material').length > 0;
+  const hasProjects = root.getElementsByTagName('project').length > 0;
+  const hasTests = root.getElementsByTagName('test').length > 0;
+  if (!hasMaterials && !hasProjects && !hasTests) {
+    issues.push({ severity: 'warn', code: 'no-data-block', message: '<material> / <project> / <test> のいずれも見つかりません' });
+  }
+
+  // result 要素の provenance / uncertainty 必須チェック
+  const results = Array.from(root.getElementsByTagName('result'));
+  for (const r of results) {
+    const props = collectProperties(r);
+    const sampleRef = r.getAttribute('sampleRef') ?? r.getAttribute('id') ?? '(no-id)';
+    if (!props.uncertainty && !r.getAttribute('uncertainty')) {
+      issues.push({
+        severity: 'warn',
+        code: 'result-uncertainty-missing',
+        message: `<result ${sampleRef}> に uncertainty（不確かさ）が未設定`,
+      });
+    }
+  }
+
+  // material / test に provenance プロパティが推奨される（情報レベル）
+  const materials = Array.from(root.getElementsByTagName('material'));
+  for (const m of materials) {
+    const props = collectProperties(m);
+    if (!props.AiDetected && !props.Author && !props.RegisteredOn) {
+      issues.push({
+        severity: 'info',
+        code: 'material-provenance-thin',
+        message: `<material ${m.getAttribute('id') ?? ''}> に Author / RegisteredOn / AiDetected が無く provenance 情報が薄い`,
+      });
+    }
+  }
+
+  return finalize({ documentKind, generatedAt, source, issues, errorCount: 0, warnCount: 0, infoCount: 0 }, issues);
+}
+
+function finalize(report: MaimlValidationReport, issues: MaimlIssue[]): MaimlValidationReport {
+  return {
+    ...report,
+    issues,
+    errorCount: issues.filter((i) => i.severity === 'error').length,
+    warnCount: issues.filter((i) => i.severity === 'warn').length,
+    infoCount: issues.filter((i) => i.severity === 'info').length,
+  };
+}
+
+function collectProperties(parent: Element | null): Record<string, string> {
+  const map: Record<string, string> = {};
+  if (!parent) return map;
+  for (const child of Array.from(parent.children)) {
+    if (child.localName !== 'property') continue;
+    const key = child.getAttribute('key');
+    if (!key) continue;
+    map[key] = child.textContent?.trim() ?? '';
+  }
+  return map;
+}


### PR DESCRIPTION
## 概要

IA リファクタ計画の **Phase 9 (Optional)**。MaiML Studio の Validate / Diff を WIP スタブからフル実装に格上げ。

## 新規モジュール

### `src/services/maimlValidate.ts`
意味的検証の純関数。XSD 完全検証は CI（xmllint）に委ね、Matlens 運用上重要な以下を検証:
- DOCTYPE 拒否（Billion Laughs / XXE 防御）
- ルート要素 `<maiml>` 確認
- header メタ（generatedAt / source / documentKind）の妥当性
- `<result>` の uncertainty 必須
- `<material>` の provenance 情報の薄さチェック

severity を error / warn / info の 3 段階に分類、code 付き issue 一覧を返す。`DOMParser` を引数注入式にして SSR 互換も確保。

### `src/services/maimlDiff.ts`
LCS ベースの行差分純関数。
- O(n*m) DP テーブル + back-track で行 op (equal / added / removed) を返却
- 改行は LF / CRLF を吸収
- 両側の行番号を保持
- 数 KB の MaiML なら数 ms で処理。MB 級は将来 Myers アルゴリズムへ差替え余地

## UI 更新
- `MaimlValidatePage.tsx`: `validateMaiml` 呼び出し、severity 別サマリカード + issue 一覧（severity ラベル + code + メッセージ）
- `MaimlDiffPage.tsx`: 行差分テーブル（A/B 行番号 + +/- 記号 + 色分け）、変更なし行表示トグル、追加/削除/変更なしサマリ
- `MaimlStudioHubPage.tsx`: WIP バッジ除去、サブタイトル更新
- `constants.ts`: NAV_ITEMS の WIP ラベル除去

## テスト
- `maimlValidate.test.ts`: 9 件（valid case / 空 / DOCTYPE / wrong root / generatedAt missing / uncertainty missing / provenance thin / no data block 等）
- `maimlDiff.test.ts`: 7 件（identical / 純追加 / 純削除 / 修正 / CRLF / 空 / 行番号維持）
- 全テスト 855 passed / 2 skipped（前 839 から +16）

## 検証
- `pnpm typecheck` ✅
- `pnpm lint --quiet` ✅
- `pnpm test --run` ✅

## 設計判断
- **XSD 完全検証は CI に委ねる**: ブラウザで `xmllint-wasm` を読むより、CI で `xmllint --schema` を 1 回回す方が単純
- **diff-match-patch を使わず自前 LCS**: 依存追加なしで純 TS、framework-agnostic を維持
- **Severity 3 段階**: error（規約違反）/ warn（推奨設定欠落）/ info（ヒント）で運用感に合わせる
- **DOMParser を引数注入**: ADR-0016 の framework-agnostic 原則に沿って Vue/Nuxt SSR でも動作可能に

## 関連
- 計画書: `~/.claude/plans/smooth-imagining-twilight.md` Phase 9
- ADR-0016 で「全データ MaiML round-trip 可能」原則の検証ツールが完成
- これで IA リファクタ Core (Phase 1-8) + Optional Phase 9 が完了