### PR TITLE
docs(adr): 0017 (Tailwind v4 移行) と 0018 (Vue→React リプレイス計画) を起草

### DIFF
--- a/docs/adr/0017-tailwind-v4-migration.md
+++ b/docs/adr/0017-tailwind-v4-migration.md
@@ -1,0 +1,100 @@
+# ADR-0017: Tailwind CSS v3 → v4 移行戦略
+
+- Status: Proposed
+- Date: 2026-05-03
+- 関連: PR #98 (Dependabot bump、計画的延期), Issue #115
+
+## Context
+
+Dependabot が `tailwindcss` を `^3.4.0` → `^4.2.4` に bump する PR #98 を提案している。
+Tailwind v4 は **メジャーバージョンアップ**で、ビルドアーキテクチャと API が大きく変わる:
+
+- **PostCSS プラグイン名変更**: `tailwindcss` → `@tailwindcss/postcss`
+- **Vite 統合プラグイン推奨**: `@tailwindcss/vite`（高速）
+- **`@theme` ディレクティブ**: theme 拡張は CSS 内 `@theme { --color-foo: ... }` で書く新方式
+- **autoprefixer が組込み**: 別 deps として持つと冗長
+- **`bg-opacity-*` / `text-opacity-*` 削除**: `bg-black/50` 形式に強制
+- **デフォルトカラーパレットの再構成**
+
+CI が緑（Vercel Preview SUCCESS）なのは Tailwind v4 の v3 互換モードが効いているためで、
+**実際のスタイル出力が v3 と一致する保証はない**（サイレント壊れリスク）。
+
+加えて、本番アプリ（Vue/Nuxt）の推奨スタックとして Tailwind v4 + PrimeVue Unstyled を
+想定しており（`onsite_readiness_brief_2026_05.md`）、Matlens 側でも v4 への移行は
+方針的には正しい。問題は「いつ・どう移行するか」。
+
+## Decision
+
+### 採用方針
+- **Tailwind v3 → v4 への移行を採用する**
+- ただし **Dependabot PR #98 を直接マージせず**、独立した移行 branch で計画的に対応する
+- 移行作業は Phase 0 抽出（Issue #108）の `@matlens/tokens` パッケージ化と一体で進める
+
+### 移行ステップ
+1. **影響箇所の grep**:
+   - `bg-opacity-*` / `text-opacity-*` / `border-opacity-*` / `divide-opacity-*` の使用箇所
+   - カスタムテーマトークンの参照箇所（CSS 変数）
+   - PostCSS / Vite 設定ファイル
+2. **branch `feat/tailwind-v4-migration` で実証**:
+   - `tailwindcss@^4.2.4` 導入
+   - `@tailwindcss/postcss` または `@tailwindcss/vite` を採用
+   - `tailwind.config.{js,ts}` を v4 互換に整理 or `@theme` directive へ移行
+   - `autoprefixer` を deps から削除
+   - 影響箇所の utility 書き換え
+3. **検証**:
+   - `pnpm build` 後の `dist/assets/` の CSS サイズ比較（v3 vs v4）
+   - 4 テーマ（light / dark / sepia / contrast）すべてで Storybook 目視
+   - 主要 28 画面のスポットチェック
+   - design-tokens 連携の崩れがないか確認
+4. **Dependabot PR #98 を close** し、新 PR で取り込む
+
+### Vue 側との整合
+- 本番 Vue/Nuxt 側でも Tailwind v4 + PrimeVue Unstyled が推奨スタック
+- Matlens 側で先に v4 移行を済ませておけば、`@matlens/tokens`（`@theme` 形式の CSS variables）が Vue 側にもそのまま import 可能になる
+- リプレイスシナリオ（ADR-0018）採用時の作業量が縮減
+
+## Consequences
+
+### 良い点
+- v4 の高速ビルド + 改善された開発体験を享受
+- 本番 Vue/Nuxt 側との Tailwind バージョン整合
+- `@matlens/tokens` パッケージ化（Phase 0）の前提が整う
+- `bg-opacity-*` 等の deprecated パターンを根絶
+
+### 痛い点
+- 影響箇所の utility 書き換えが必要（`bg-black/50` 等）
+- `tailwind.config` の構造移行コスト
+- Storybook 4 テーマでの目視確認工数（半日想定）
+
+### 中立
+- Dependabot PR #98 は close（Dependabot は新 PR を再生成しなくなる）
+
+## 代替案（不採用）
+
+### A: PR #98 をそのままマージ
+- v3 互換モードでビルドは通るが、サイレント壊れリスクが残る
+- `autoprefixer` の冗長性も解消されない
+- 移行作業を「やった気になる」だけで実態は v3 のまま動作する
+
+### B: Tailwind v3 を据え置き
+- v4 の改善を逃す
+- 本番 Vue/Nuxt 側との不整合
+- `@matlens/tokens` パッケージ化時に v3/v4 二重管理が発生
+
+### C: Tailwind 自体を捨てる（PrimeVue/MUI 等のテーマシステムへ）
+- 移行コスト最大、現状の design-tokens との非互換
+- Matlens の 28 画面の class 書き換えが必要
+- 採用に値する根拠なし
+
+## 検証
+
+- `pnpm build` の dist サイズ比較で v4 が同等以下
+- Storybook 4 テーマでの目視で視認性に変化なし（または改善）
+- 855 tests pass を維持
+- design-tokens 連携の `tokens.json` が v4 環境でも生成可能
+
+## 関連
+- PR #98（Dependabot 自動生成、本 ADR 採用後に close）
+- Issue #115（本 ADR 起票元）
+- Issue #108（Phase 0 抽出と一体化）
+- Memory: `onsite_readiness_brief_2026_05.md`（Tailwind v4 + PrimeVue Unstyled 推奨）

--- a/docs/adr/0018-vue-to-react-replacement-proposal.md
+++ b/docs/adr/0018-vue-to-react-replacement-proposal.md
@@ -1,0 +1,131 @@
+# ADR-0018: 本番アプリの Vue/Nuxt → React/Next 早期リプレイス計画
+
+- Status: Proposed
+- Date: 2026-05-03
+- 関連: Issue #107 (本 ADR 起票元), Issue #108 (Phase 0 抽出), Issue #109 (現場入りキット), Issue #113 (説得材料収集)
+
+## Context
+
+Matlens は kickoff 用 PoC で React + Vite。現場の本番アプリは別リポジトリで Vue/Nuxt スタート済み。
+チームは全員フルスタックだがバックエンド主体で、フロントエンドおよび UI/UX 設計は a.ito が
+リードする見込み。本番開発は始まったばかりで、**今が技術選定のリプレイスコスト最小タイミング**。
+
+### 重要な前提シフト（誤認しやすい）
+
+- **2025-07 に Vercel が NuxtLabs を買収**。Nuxt と Next.js は同じ親会社配下となり、
+  「Vue は周縁エコシステム」という古い認知は事実誤認
+- → 「React に行くから安全」を判断軸にしない。タイミング × チームスキル × 既存資産 × AI 連携で押す
+
+### 早期リプレイスを支持する根拠
+
+| 軸 | 根拠 |
+|---|---|
+| **タイミング** | 本番開発が始まったばかり = Vue コードベース最小 = 移行コストが底値。1 ヶ月遅れごとに既存コード量が指数増、提案通過確率が下がる |
+| **既存資産** | Matlens PoC（React + Vite）の 28 画面 + 純 TS ロジック + デザイントークン + ADR がそのまま土台。**ゼロ起点ではない** |
+| **a.ito 生産性** | React/Next で 1.5-2x のスループット |
+| **AI 連携** | 10-12 月の AI SDK v6 + AI Gateway は Next.js 一級市民。Vue 版（`@ai-sdk/vue`）も存在するが参考実装の厚みが桁違い |
+| **採用市場** | 北米基準で React 求人優位（補助材料、決め手ではない） |
+
+## Decision
+
+### 採用方針
+1. **6/30 までに本 ADR を Accepted に格上げ**することを目標とする
+2. **5/18 着任 1 週目（5/18-5/24）に Issue #113 で説得材料を実測**:
+   - 既存 Vue コードの行数 / 画面数 / E2E カバレッジ
+   - チームの React 実務経験（Git 履歴ベース）
+   - Matlens PoC からの移植可能資産率
+3. **5/25-5/31 で本 ADR を草稿 → 数値根拠で更新**
+4. **6/1-6/14 で意思決定者向けプレゼン + Phase 0 並行着手（採用前提）**
+5. **6/15-6/30 で ADR レビュー → Accepted / Rejected 判定**
+
+### 移行戦略の優先順序
+1. **ページ単位の置換**（推奨ベースライン）: `/v2/*` だけ Next、リバースプロキシ分割
+2. **Web Components ブリッジ**: 表示部品を `defineCustomElement` で提供。React 19 が Custom Elements property 自動判別を改善済
+3. **single-spa / qiankun**: 30 画面では過剰、組織分割が物理的に必要なときだけ
+4. **iframe**: 最終手段
+
+### 推奨スタック
+- **Next.js 15 (App Router) + React 19**
+- **状態管理**: Zustand or TanStack Query のサーバ状態 + URL state を主軸（Redux は使わない）
+- **UI**: shadcn/ui + Radix UI + Tailwind v4（Matlens の延長で完全互換）
+- **テスト**: Vitest 4 + React Testing Library + Playwright + Storybook 9
+- **i18n**: next-intl（型生成 + middleware ロケール検出）
+- **フォーム**: React Hook Form + Zod (`@hookform/resolvers`)
+- **AI**: AI SDK v6 + AI Gateway（Next 一級市民）
+
+### 失敗パターン（避ける）
+- 「BE は React を読めるはず」幻想 → 1 週間ペアプロで実測
+- 段階移行が永久に終わらない → **強制カットオーバー日**を最初に引く
+- どちらにも振り切らない（最悪パターン）
+- Vercel ロックイン軽視（ITAR 案件はセルフホスト検証）
+
+## Consequences
+
+### 採用時（pros）
+- 5/18 から 6/30 までに方針確定 → 7 月から実装フェーズに集中可能
+- Matlens の 28 画面 + framework-agnostic 資産（domain/ tokens/ services/）がそのまま土台
+- AI SDK v6 連携が一級市民でストリーミング UI の参考実装が桁違いに豊富
+- a.ito の生産性最大化
+
+### 採用時（cons）
+- 既存 Vue コードの破棄コスト（ただし「タイミング」根拠でこれが最小値）
+- BE 主体チームの React 学習コスト（ペアプロで実証）
+- 政治的合意形成コスト（数値ベース提案で軽減）
+
+### Rejected 時（フォールバック）
+- Phase 0 抽出（#108）は Vue 継続でも 100% 価値が残る
+- 推奨スタックは Nuxt 4 + Pinia 3 + PrimeVue Unstyled に切替
+- ハーネス整備（#111）を Vue 版で実施
+- AI エージェント（#112）は `@ai-sdk/vue` で実装
+- リプレイス提案は「将来の選択肢」として ADR に残し、再提案の余地を残す
+
+## 完全リライトのコスト感
+
+業務系 SPA で 30-50 画面規模を完全リライトする場合:
+- 中堅 2 名 × 4-6 ヶ月（中央値 6 ヶ月）。業務ヒアリング並行で 1.5 倍
+- **E2E (Playwright) は 8 割再利用、ユニットは 0-2 割**
+- 残る資産: OpenAPI 型 / Zod schema / Tailwind tokens / 純 TS ドメインロジック / 純 SVG / MaiML パーサ
+- 失われる資産: Vue 専用 directive / template slot / Pinia reactivity / Nuxt SSR フェッチ
+
+## 想定反論と切り返し
+
+| 反論 | 切り返し |
+|---|---|
+| 「Vue でもう書き始めた」 | コミット履歴で実測。N 行未満なら破棄コスト 1-2 日。それ以上ならページ単位段階移行で吸収 |
+| 「BE 主体に React は無理」 | Git 履歴で React 経験を実測。0 ならペアプロ 1 週間で実証。Matlens の 28 画面が学習教材 |
+| 「Vue は十分モダン (NuxtLabs/Vercel 体制)」 | 事実として認める。**それでも** タイミング × 既存資産 × AI 連携で React を選ぶ |
+| 「移行コストが見えない」 | Phase 0（2 週間）で domain/infra/tokens を切り出せば残コストは UI 層のみで限定 |
+| 「政治的に重い」 | 5/18 着任 1 週目に「現状観察結果」として持ち込む。意思決定者の関与なしに既成事実化させない |
+
+## 検証
+
+- 5/18-5/24: Issue #113 で数値実測完了
+- 5/31 までに ADR 草稿が数値根拠で埋まる
+- 6/30 までに Accepted / Rejected が確定
+- Accepted 時: 7/1 から Next で実装フェーズ開始
+- Rejected 時: Phase 0 で抽出した framework-agnostic 資産を Vue 側で活用
+
+## 代替案（不採用）
+
+### A: Vue 継続を初期から決め打ち
+- a.ito の生産性 + AI 連携 + 既存資産の優位を活かしきれない
+- 「なぜ Vue か」の説明根拠が「既に始まっているから」のみで弱い
+
+### B: 段階移行を最終的に永久化
+- 失敗パターンとして明示済み。**強制カットオーバー日**を引かない限り選ばない
+
+### C: 完全リライトを 7 月以降に決定
+- 1 ヶ月遅れごとに既存 Vue コード量が増えて提案通過確率が下がる
+- 「タイミング」根拠を放棄することになる
+
+## 関連
+
+- Issue #107（本 ADR の起票元）
+- Issue #108（Phase 0 抽出 = どちらに転んでも価値が残る保険）
+- Issue #109（5/18 現場入りキット）
+- Issue #110（MaiML / Petri net / Excel UX 本番方針 = フレームワーク非依存）
+- Issue #111（ハーネス整備、採否で方針分岐）
+- Issue #112（AI エージェント UI、AI SDK v6 + Next 一級市民）
+- Issue #113（リプレイス提案 説得材料収集 = 本 ADR の数値根拠）
+- ADR-0017（Tailwind v4 移行 = Phase 0 と一体）
+- Memory: `replacement_proposal_stance.md` / `onsite_readiness_brief_2026_05.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,5 +57,7 @@ implementation details — those belong in commit messages.
 | [ADR-014](./ADR-014-monorepo-integration-execution-plan.md) | monorepo 統合の実行計画（判断点 4 件の決定 + Phase 4 詳細） | Accepted |
 | [ADR-015](./ADR-015-confidentiality-and-naming-policy.md) | 守秘義務対応とリポジトリ命名ポリシー | Accepted |
 | [0016](./0016-maiml-as-conceptual-core.md) | MaiML を「機能の 1 つ」ではなく「アプリのコア要素」として位置付ける | Accepted |
+| [0017](./0017-tailwind-v4-migration.md) | Tailwind CSS v3 → v4 移行戦略（PR #98 を計画的延期 + Phase 0 と一体化） | Proposed |
+| [0018](./0018-vue-to-react-replacement-proposal.md) | 本番アプリの Vue/Nuxt → React/Next 早期リプレイス計画 | Proposed |
 
 [nygard]: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-03-adr-0017-0018',
+    date: '2026-05-03',
+    type: 'info',
+    title: 'ADR-0017 (Tailwind v4 移行) と ADR-0018 (Vue→React リプレイス計画) を起草',
+    body: '5/18 現場入り後のフレームワーク判断・依存更新を計画的に進めるため、2 つの ADR を Proposed として起票しました。ADR-0017 は Dependabot PR #98 (Tailwind v4 bump) をそのままマージせず、計画的に v4 移行 + Phase 0 抽出と一体化する戦略を記述。ADR-0018 は Vue/Nuxt → React/Next 早期リプレイス計画で、6/30 までに Accepted/Rejected 判定を狙い、説得材料の数値実測から提案通過までの段取りを 4 軸（タイミング × 既存資産 × チーム × AI 連携）で整理しています。',
+  },
+  {
     id: '2026-05-03-maiml-validate-diff-full',
     date: '2026-05-03',
     type: 'feature',


### PR DESCRIPTION
## 概要

5/18 現場入り後の意思決定の土台となる 2 ADR を Proposed で起票。

## 新規

### ADR-0017: Tailwind v4 移行戦略
- Dependabot PR #98 を **そのままマージせず計画的に対応**
- Phase 0 抽出（#108）の `@matlens/tokens` パッケージ化と**一体化**
- 影響箇所 grep → 実証 branch → Storybook 4 テーマ目視 → 新 PR で取り込み → #98 close
- 本番 Vue/Nuxt 側も Tailwind v4 + PrimeVue Unstyled が推奨スタックで整合

### ADR-0018: Vue→React 早期リプレイス計画
- **6/30 までに Accepted/Rejected 判定**を目標
- 4 軸根拠: タイミング × 既存資産 × チーム × AI 連携
- スケジュール: 5/18-5/24 数値実測 (#113) → 5/25-5/31 草稿更新 → 6/14 プレゼン → 6/30 判定
- 想定反論 5 種への切り返し明示
- フォールバック（Rejected 時）: Phase 0 抽出は Vue 継続でも価値が残る保険

## 連動更新（ADR-007）
- `docs/adr/README.md`: 0017 / 0018 を index に追加
- `src/data/announcements.ts`: お知らせ 1 件追加

## 検証
- `pnpm typecheck` ✅
- `pnpm test --run` ✅ 855 passed / 2 skipped

## 関連 Issue
- Issue #107（リプレイス計画 ADR、本 ADR-0018 で対応）
- Issue #115（Tailwind v4 ADR、本 ADR-0017 で対応）
- Issue #108（Phase 0 抽出 = 両 ADR の前提）
- Issue #113（説得材料収集 = ADR-0018 の数値根拠）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * アーキテクチャ判断記録（ADR）として、Tailwind CSS v4への段階的移行方針とVue/NuxtからReact/Nextへの置き換え提案を追加しました。

* **Chores**
  * 新しいアーキテクチャ方針変更をアプリ内で告知するエントリを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->