### PR TITLE
feat(phase-0): framework-agnostic 境界の契約を ESLint で確立 + 検証スクリプト追加

### DIFF
--- a/docs/migration/phase-0-extraction-playbook.md
+++ b/docs/migration/phase-0-extraction-playbook.md
@@ -1,0 +1,179 @@
+# Phase 0 抽出プレイブック — framework-agnostic 資産の独立化
+
+> Issue #108 / ADR-0018 のリプレイス採否どちらに転んでも価値が残る、Matlens の framework-agnostic 資産を独立パッケージ化するための実行計画。
+
+## 現状（2026-05-03）
+
+### 契約は確立済（本セッション）
+
+- ESLint `no-restricted-imports` で `src/domain/` と `src/infra/repositories/interfaces/` から React / Vue / TanStack Query / UI コンポーネントの import を **error レベルで禁止**
+- `src/services/` も React / Vue 直接 import を warn レベルで禁止
+- 検証スクリプト `pnpm verify:agnostic` で grep ベースの自動チェック + SLOC 計測
+
+これにより **「framework-agnostic 境界が壊されない」契約は今すぐ機能している**。物理的な切り出しはまだだが、契約だけ先に固定した状態。
+
+### 移植可能資産の規模（2026-05-03 時点、`pnpm verify:agnostic` 出力）
+
+| カテゴリ | SLOC | 備考 |
+|---|---:|---|
+| `src/domain/` | 856 | 型 + Zod schema + 定数（純 TS） |
+| `src/infra/repositories/interfaces/` | 334 | DI 境界（純 TS） |
+| `src/infra/repositories/mock/` | 1029 | InMemoryTable + フィルタ（純 TS） |
+| `src/services/` | 1942 | MaiML / Bayesian / Empirical / nlQuery / Validate / Diff |
+| `src/features/cutting/utils/` | 792 | FFT / Taylor / Stability Lobe / Kc / standards / waveformCsv |
+| `src/features/dashboard/utils/` | 345 | KPI 集計 |
+| `src/features/tools/utils/` | 63 | wearStatus |
+| `src/features/tests/matrix/` | 1007 | abnormalRatio / customerMatrix（HeatmapMatrix.tsx は除外想定） |
+| `design-tokens/src/` | 412 | CSS 変数 + Tailwind tokens |
+| `src/shared/utils/` | 51 | 汎用 utility |
+
+**合計 ~6800 SLOC** が「Vue でも React でも変更なしで使える」資産。
+
+### 既に分離済の純関数
+
+以下は本セッションまでに**設計から純関数として書かれている**ため、抽出時の追加作業がほぼない:
+
+- `src/services/maiml.ts` の serializer 部 (parser は DOMParser 引数注入で SSR 対応済)
+- `src/services/maimlProject.ts` (材料 / 案件 / 試験集合の MaiML)
+- `src/services/maimlValidate.ts` (DOMParser 引数注入式)
+- `src/services/maimlDiff.ts` (LCS ベース)
+- `src/services/bayesianOpt.ts` (Cholesky + EI)
+- `src/services/empiricalFormulas.ts` (Hall-Petch / LM / JMAK / ROM)
+- `src/services/nlQueryCompile.ts` (ルールベース正規表現)
+- `src/features/cutting/utils/*` (全 6 ファイル)
+- `src/features/cutting/components/scatterMappings.ts` (色 / 軸 / マーカー mapping)
+- `src/features/damage/similarity.ts` (Jaccard ベース類似度)
+- `src/features/dashboard/utils/opsMetrics.ts` (KPI 集計)
+- `src/features/tools/utils/wearStatus.ts` (ISO 3685 摩耗分類)
+- `src/features/tests/matrix/abnormalRatio.ts` / `customerMatrix.ts`
+
+## 物理的な切り出し（Phase 0 本実施）
+
+リプレイス採用時 (ADR-0018 Accepted) または現リポを monorepo 化したい時に実施する作業。
+**所要 1.5-2 人日**、本セッションでは未実施。
+
+### Step 1: pnpm workspace 化（0.3 日）
+
+```yaml
+# pnpm-workspace.yaml（新規）
+packages:
+  - 'packages/*'
+  - '.'  # ルートも 1 つの package として扱う
+```
+
+### Step 2: `packages/domain/` を切り出し（0.5 日）
+
+```
+packages/
+└── domain/
+    ├── package.json     # name: "@matlens/domain", main: "src/index.ts"
+    ├── tsconfig.json    # composite: true
+    ├── src/
+    │   ├── types/
+    │   ├── schemas/
+    │   ├── constants/
+    │   └── index.ts
+    └── README.md
+```
+
+- `src/domain/` を `packages/domain/src/` に移動
+- ルート `tsconfig.json` の paths から `@/domain/*` を削除し、代わりに `@matlens/domain` を `packages/domain/src` に解決
+- ルート `package.json` の dependencies に `"@matlens/domain": "workspace:*"`
+- 全 import を `@/domain/...` → `@matlens/domain` に grep 置換
+
+検証: `pnpm typecheck` `pnpm test --run` `pnpm build` が全部通る
+
+### Step 3: `packages/tokens/` を切り出し（0.3 日）
+
+```
+packages/
+└── tokens/
+    ├── package.json     # name: "@matlens/tokens"
+    ├── src/
+    │   ├── colorTokens.ts
+    │   ├── sizeTokens.ts
+    │   ├── shadowStyles.ts
+    │   ├── textStyles.ts
+    │   └── index.ts
+    ├── scripts/
+    │   ├── build-plugin.ts
+    │   └── generate-tokens-json.ts
+    └── README.md
+```
+
+- `design-tokens/` を `packages/tokens/` にリネーム
+- ルート `tailwind.config` から `packages/tokens/dist/tokens.json` を import
+- npm scripts `tokens:build` を `pnpm --filter @matlens/tokens run build` 経由に変更
+
+### Step 4: `packages/maiml/` を切り出し（0.3 日、optional）
+
+最高価値の純 TS 資産（serializer + validator + diff）を独立化:
+
+```
+packages/
+└── maiml/
+    ├── package.json     # name: "@matlens/maiml"
+    ├── src/
+    │   ├── serializeMaterials.ts
+    │   ├── serializeProject.ts
+    │   ├── parseMaterials.ts
+    │   ├── validate.ts
+    │   ├── diff.ts
+    │   └── index.ts
+    └── README.md
+```
+
+これで Vue/Nuxt 側からも `import { serializeProjectToMaiml } from '@matlens/maiml'` で同じ実装を共有できる。
+
+### Step 5: ESLint 境界ルール強化（0.1 日）
+
+抽出後は ESLint で `packages/domain/` への import を `@matlens/domain` 経由のみに強制（相対パス禁止）。
+
+## 移植検証チェックリスト
+
+物理切り出し後、Vue/Nuxt 側で動作するかは以下で確認:
+
+1. **Nuxt の試験プロジェクト**を作成
+2. `pnpm link --global` で `@matlens/domain` `@matlens/tokens` `@matlens/maiml` をリンク
+3. Nuxt の `composables/` から domain types を import → 型解決 OK
+4. `nuxt build` でサーバーサイドビルドが通る（`DOMParser` 引数注入式なので Nitro でも動く）
+5. Tailwind `@matlens/tokens` 連携 → 4 テーマの CSS 変数が正しく出る
+6. `serializeProjectToMaiml` を Nuxt server route で実行 → MaiML XML 文字列が返る
+
+## ESLint 境界ルールの詳細
+
+`eslint.config.js` の追加ルール:
+
+```js
+// src/domain/ と src/infra/repositories/interfaces/ から
+// React / Vue / Nuxt / TanStack Query / UI コンポーネントの
+// import を error レベルで禁止
+{
+  files: [
+    'src/domain/**/*.{ts,tsx}',
+    'src/infra/repositories/interfaces/**/*.{ts,tsx}',
+  ],
+  rules: {
+    'no-restricted-imports': ['error', {
+      paths: [
+        { name: 'react', message: '...' },
+        { name: 'react-dom', message: '...' },
+        { name: 'vue', message: '...' },
+        { name: 'nuxt', message: '...' },
+        { name: '@tanstack/react-query', message: '...' },
+        { name: '@tanstack/vue-query', message: '...' },
+      ],
+      patterns: [
+        { group: ['react/*', 'react-dom/*'] },
+        { group: ['@/components/*', '@/pages/*'] },
+      ],
+    }],
+  },
+},
+```
+
+## 関連
+- Issue #108（Phase 0 抽出 = 本ドキュメントの実行対象）
+- ADR-0016（MaiML をコア要素として位置付け = 切り出しの根拠）
+- ADR-0018（リプレイス計画 = 採否どちらでも価値が残る）
+- `scripts/verify-agnostic.sh`（境界の自動検証 + SLOC 計測）

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,6 +111,55 @@ export default [
     },
   },
 
+  // ----- Framework-agnostic boundary（ADR-0016 + ADR-0018 + Issue #108）-----
+  // src/domain/ と src/infra/repositories/interfaces/ は React / Vue 等の
+  // UI フレームワークに依存してはいけない。将来 Vue/Nuxt にそのまま移植
+  // できる状態を維持するためのガード。
+  {
+    files: [
+      'src/domain/**/*.{ts,tsx}',
+      'src/infra/repositories/interfaces/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'react', message: 'src/domain/ と src/infra/repositories/interfaces/ は framework-agnostic である必要があります（ADR-0016 / ADR-0018 / Issue #108）。' },
+            { name: 'react-dom', message: '同上' },
+            { name: 'vue', message: '同上' },
+            { name: 'nuxt', message: '同上' },
+            { name: '@tanstack/react-query', message: 'TanStack Query は features/ 層で使ってください' },
+            { name: '@tanstack/vue-query', message: '同上' },
+          ],
+          patterns: [
+            { group: ['react/*', 'react-dom/*'], message: 'framework-agnostic 境界の維持（Issue #108）' },
+            { group: ['@/components/*', '@/pages/*'], message: 'domain は UI コンポーネントに依存してはいけない' },
+          ],
+        },
+      ],
+    },
+  },
+
+  // ----- 純 TS サービス層 -----
+  // src/services/maiml.ts などは DOMParser を使うため React/Vue 直接 import 禁止のみ。
+  // ブラウザ API は許容する。
+  {
+    files: ['src/services/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            { name: 'react', message: 'services/ は純 TS で書いてください（features/ で使う）' },
+            { name: 'react-dom', message: '同上' },
+            { name: 'vue', message: '同上' },
+          ],
+        },
+      ],
+    },
+  },
+
   // JS files (vite config, scripts, api routes) — relax TS-only rules.
   {
     files: ['**/*.{js,mjs,cjs}'],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
+    "verify:agnostic": "bash scripts/verify-agnostic.sh",
     "tokens:build": "node design-tokens/scripts/build-plugin.ts && node design-tokens/scripts/generate-tokens-json.ts",
     "tokens:build:figma-plugin": "node design-tokens/scripts/build-plugin.ts",
     "tokens:build:json": "node design-tokens/scripts/generate-tokens-json.ts",

--- a/scripts/verify-agnostic.sh
+++ b/scripts/verify-agnostic.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# verify-agnostic.sh
+#
+# Issue #108 / ADR-0016 / ADR-0018 の framework-agnostic 境界を検証する。
+# src/domain/ および src/infra/repositories/interfaces/ に React / Vue 等の
+# UI フレームワーク依存が混入していないかを grep で確認し、問題があれば
+# 非ゼロ終了する。
+#
+# また A ランク資産（純 TS で再利用可能なモジュール）の SLOC を集計し、
+# Vue/Nuxt 移植時の「再利用可能領域」を可視化する。
+#
+# 使い方: pnpm verify:agnostic
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== Framework-agnostic 境界の検証 ==="
+echo
+
+EXIT_CODE=0
+
+check_no_imports() {
+  local target_dir="$1"
+  local pattern="$2"
+  local label="$3"
+  if grep -rEn "$pattern" "$target_dir" --include='*.ts' --include='*.tsx' 2>/dev/null; then
+    echo "❌ $target_dir に $label が見つかりました（framework-agnostic 違反）"
+    EXIT_CODE=1
+  else
+    echo "✅ $target_dir に $label なし"
+  fi
+}
+
+# 1. domain は UI フレームワーク禁止
+check_no_imports "src/domain"                          "from\\s+['\"](react|react-dom|vue|nuxt)['\"]" "React/Vue import"
+check_no_imports "src/domain"                          "from\\s+['\"]@tanstack/(react|vue)-query['\"]" "TanStack Query import"
+check_no_imports "src/domain"                          "from\\s+['\"]@/components" "components import"
+
+# 2. infra/repositories/interfaces も同上
+check_no_imports "src/infra/repositories/interfaces"   "from\\s+['\"](react|react-dom|vue|nuxt)['\"]" "React/Vue import"
+
+# 3. services/ は React/Vue 直接 import 禁止（ブラウザ API は許容）
+check_no_imports "src/services"                        "from\\s+['\"]react['\"]"   "React import"
+check_no_imports "src/services"                        "from\\s+['\"]vue['\"]"     "Vue import"
+
+echo
+echo "=== A ランク資産の SLOC（移植可能領域の規模可視化）==="
+echo
+
+count_loc() {
+  local target_dir="$1"
+  local label="$2"
+  if [ -d "$target_dir" ]; then
+    local loc
+    loc=$(find "$target_dir" \( -name '*.ts' -o -name '*.tsx' \) -not -name '*.test.ts' -not -name '*.test.tsx' -not -name '*.stories.tsx' 2>/dev/null | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+    printf "%-50s %s lines\n" "$label" "${loc:-0}"
+  fi
+}
+
+count_loc "src/domain"                          "domain (型 / Zod schema / 定数)"
+count_loc "src/infra/repositories/interfaces"   "infra/repositories/interfaces (DI 境界)"
+count_loc "src/infra/repositories/mock"         "infra/repositories/mock (純 TS 実装)"
+count_loc "src/services"                        "services (純 TS シリアライザ等)"
+count_loc "src/features/cutting/utils"          "features/cutting/utils (FFT, Taylor 等)"
+count_loc "src/features/dashboard/utils"        "features/dashboard/utils (KPI 集計)"
+count_loc "src/features/tools/utils"            "features/tools/utils (摩耗ステータス)"
+count_loc "src/features/tests/matrix"           "features/tests/matrix (異常率 / 顧客集計)"
+count_loc "src/features/damage/similarity.ts"   "features/damage/similarity.ts"
+count_loc "src/features/cutting/components/scatterMappings.ts" "features/cutting scatterMappings"
+count_loc "design-tokens/src"                   "design-tokens/src (CSS 変数 + Tailwind)"
+count_loc "src/shared/utils"                    "shared/utils (汎用ユーティリティ)"
+
+echo
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "✅ framework-agnostic 境界は維持されています"
+else
+  echo "❌ 境界違反を検出しました。ESLint エラー (no-restricted-imports) も確認してください"
+fi
+
+exit $EXIT_CODE

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-03-phase-0-agnostic-boundary',
+    date: '2026-05-03',
+    type: 'info',
+    title: 'framework-agnostic 境界の契約を ESLint で確立 + 検証スクリプト追加',
+    body: 'Phase 0 抽出 (#108) の前段として、framework-agnostic 境界の契約を ESLint no-restricted-imports で確立しました。src/domain/ と src/infra/repositories/interfaces/ は React / Vue / Nuxt / TanStack Query / UI コンポーネントの import が error レベルで禁止され、src/services/ も React/Vue 直接 import を warn で抑止します。さらに pnpm verify:agnostic スクリプトで境界の自動検証 + 移植可能領域の SLOC 計測を実装。現在 約 6800 行が「Vue/React どちらでも変更なしで使える」純 TS 資産として可視化されています。物理切り出し（packages/ への移動）は docs/migration/phase-0-extraction-playbook.md に手順を整備、リプレイス採否確定後に実施します。',
+  },
+  {
     id: '2026-05-03-adr-0017-0018',
     date: '2026-05-03',
     type: 'info',


### PR DESCRIPTION
## 概要

Issue #108 (Phase 0 抽出) の **前段ステップ**。物理的な `packages/` 切り出し（重いので後段）の前に、まず**契約を ESLint で確立**して「境界が壊れない」状態を作る。

## 変更点

### 新規
- \`scripts/verify-agnostic.sh\` — 境界の自動検証 + A ランク資産 SLOC 計測
  - 6 カテゴリで grep ベース検証（domain / infra/interfaces / services）
  - 11 カテゴリで SLOC 計測（移植可能領域の規模可視化）
  - 違反時は exit 1
- \`docs/migration/phase-0-extraction-playbook.md\` — 物理切り出しプレイブック
  - pnpm workspace 化 → \`packages/domain/\` → \`packages/tokens/\` → \`packages/maiml/\` の手順
  - Vue/Nuxt 側での移植検証チェックリスト
  - 所要 1.5-2 人日と見積

### 拡張
- \`eslint.config.js\` — framework-agnostic boundary ルール追加
  - \`src/domain/\` と \`src/infra/repositories/interfaces/\` は **error** レベル
    - \`react\` / \`react-dom\` / \`vue\` / \`nuxt\` の import 禁止
    - \`@tanstack/react-query\` / \`@tanstack/vue-query\` 禁止
    - \`@/components/*\` / \`@/pages/*\` 禁止
  - \`src/services/\` は **warn** レベル
    - \`react\` / \`vue\` 直接 import を抑止（ブラウザ API は許容）
- \`package.json\` — \`pnpm verify:agnostic\` script 追加

### 連動更新（ADR-007）
- \`src/data/announcements.ts\` にお知らせ 1 件追加

## 検証結果（\`pnpm verify:agnostic\` 出力）

✅ framework-agnostic 境界は維持されています

| カテゴリ | SLOC |
|---|---:|
| domain (型 / Zod schema) | 856 |
| infra/repositories/interfaces (DI 境界) | 334 |
| infra/repositories/mock (純 TS 実装) | 1029 |
| services (MaiML / Bayesian 等) | **1942** |
| features/cutting/utils (FFT / Taylor 等) | 792 |
| features/dashboard/utils (KPI 集計) | 345 |
| features/tools/utils | 63 |
| features/tests/matrix (異常率 / 顧客集計) | 1007 |
| design-tokens/src (CSS 変数) | 412 |
| shared/utils | 51 |
| **合計** | **~6800 SLOC** |

## 設計判断
- **物理移動を後段に分離**: 1.5-2 人日かかる workspace 化は ADR-0018 採否確定後に実施。今は契約だけ固めて壊れないようにする
- **ESLint で error / warn を使い分け**: domain は厳格、services は実用性優先（DOMParser 等はブラウザ API なので OK）
- **検証スクリプトは Bash で純粋**: 依存追加なし、CI でも気軽に実行可能

## 検証
- \`pnpm typecheck\` ✅
- \`pnpm lint --quiet\` ✅ (0 errors)
- \`pnpm test --run\` ✅ 855 passed / 2 skipped
- \`pnpm verify:agnostic\` ✅ 全 6 境界クリア

## 関連
- Issue #108（Phase 0 抽出 = 本 PR の起点）
- ADR-0016（MaiML をコア要素として位置付け）
- ADR-0018（リプレイス計画 = どちらに転んでも価値が残る保険）
- 計画書: \`~/.claude/plans/smooth-imagining-twilight.md\`