### PR TITLE
feat(maiml): CSV → MaiML 変換画面を Studio に追加し Excel 元データの取込経路を整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## 5 分でわかる Matlens
 
-1. **MaiML Studio → インポート** で `.maiml` / `.xml` ファイルを drop（preview → commit の 3 段階で事故を防ぎます）
-2. **データ → 材料データ一覧** で取り込んだ材料を確認
-3. **試験マトリクス** でセルを選択し、その組合せの試験を MaiML で書き出し
-4. **MaiML Studio → インスペクト** で書き出したファイルの構造を整形表示
-5. **検索（統合）** で Embedding / RAG / 類似 / 横断検索を 1 画面のタブで使い分け
+1. **MaiML Studio → CSV→MaiML 変換** で現場の Excel エクスポート (CSV) を drop し、カラムマッピングで MaiML に変換
+2. **MaiML Studio → インポート** で `.maiml` / `.xml` ファイルを drop（preview → commit の 3 段階で事故を防ぎます）
+3. **データ → 材料データ一覧** で取り込んだ材料を確認
+4. **試験マトリクス** でセルを選択し、その組合せの試験を MaiML で書き出し
+5. **MaiML Studio → インスペクト** で書き出したファイルの構造を整形表示
 
 詳細は [`docs/demo/onboarding-5min.md`](docs/demo/onboarding-5min.md) を参照。
 
@@ -47,6 +47,7 @@
 | 機能 | 説明 |
 |------|------|
 | **MaiML インポート** | drop → preview → commit の 3 段階で `.maiml` / `.xml` ファイルを安全に取り込み。重複 ID は skip、警告は折り畳み表示 |
+| **CSV → MaiML 変換** | 現場の元データである Excel エクスポート (CSV / UTF-8) を Material のフィールドマッピングを介して MaiML XML に変換。`.maiml` ダウンロード or アプリ内取込を選択 |
 | **MaiML エクスポートハブ** | 材料単体 / 一覧バルク / 案件バンドル / 試験集合（マトリクス選択）の 4 出口を 1 画面で誘導 |
 | **MaiML インスペクト** | XML を整形表示し、部分一致検索でハイライト。drop / 直接ペースト両対応 |
 | **MaiML バリデート (WIP)** | 現状は parser warning 表示。Phase 9 で XSD + provenance / uncertainty 必須項目チェックを追加予定 |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ const DamageGalleryPage = lazy(() => import('./features/damage').then(m => ({ de
 const SemanticSearchPage = lazy(() => import('./features/search').then(m => ({ default: m.SemanticSearchPage })));
 const MaimlStudioHubPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlStudioHubPage })));
 const MaimlImportPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlImportPage })));
+const MaimlConvertPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlConvertPage })));
 const MaimlExportHubPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlExportHubPage })));
 const MaimlInspectPage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlInspectPage })));
 const MaimlValidatePage = lazy(() => import('./features/maiml').then(m => ({ default: m.MaimlValidatePage })));
@@ -283,6 +284,7 @@ export function App() {
       case 'about':   return lazyPage(<AboutPage />);
       case 'maiml-hub':      return lazyPage(<MaimlStudioHubPage onNav={navTo} />);
       case 'maiml-import':   return lazyPage(<MaimlImportPage db={db} dispatch={dispatch} onNav={navTo} />);
+      case 'maiml-convert':  return lazyPage(<MaimlConvertPage db={db} dispatch={dispatch} onNav={navTo} />);
       case 'maiml-export':   return lazyPage(<MaimlExportHubPage onNav={navTo} />);
       case 'maiml-inspect':  return lazyPage(<MaimlInspectPage onNav={navTo} />);
       case 'maiml-validate': return lazyPage(<MaimlValidatePage onNav={navTo} />);

--- a/src/data/announcements.ts
+++ b/src/data/announcements.ts
@@ -17,6 +17,13 @@ export interface Announcement {
 // 新しいお知らせは配列の先頭に追加する。
 export const ANNOUNCEMENTS: Announcement[] = [
   {
+    id: '2026-05-10-csv-to-maiml-convert',
+    date: '2026-05-10',
+    type: 'feature',
+    title: 'MaiML Studio に「CSV → MaiML 変換」を追加',
+    body: '現場の元データである Excel エクスポート (CSV / UTF-8) を MaiML XML に変換する画面を MaiML Studio に追加しました。CSV を drop すると自動でヘッダ検出と推測マッピングを行い、ユーザはカラムマッピング UI で Material フィールドへの割当を確認・修正できます。プレビューで安全に確認した後、.maiml ファイルとしてダウンロードするか、Studio Import 経由でアプリ内に取り込めます。日本語 / 英語ヘッダの揺らぎ（材料名 / SampleName 等）も吸収します。これにより「Excel 散在 → MaiML → ラボ計測器 / OEM」の経路が 1 画面で完結します。xlsx 直読みは bundle size の都合で後追い対応予定。',
+  },
+  {
     id: '2026-05-03-phase-0-agnostic-boundary',
     date: '2026-05-03',
     type: 'info',

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -33,6 +33,7 @@ export const NAV_ITEMS: NavItem[] = [
     defaultOpen: true,
     children: [
       { id:'maiml-import',   label:'インポート',   labelEn:'Import',   icon:'plus' },
+      { id:'maiml-convert',  label:'CSV→MaiML 変換', labelEn:'CSV→MaiML', icon:'embed', badgeLabel:'NEW', badgeVariant:'ai' },
       { id:'maiml-export',   label:'エクスポート', labelEn:'Export',   icon:'embed' },
       { id:'maiml-inspect',  label:'インスペクト', labelEn:'Inspect',  icon:'scan' },
       { id:'maiml-validate', label:'バリデート',   labelEn:'Validate', icon:'check' },
@@ -916,6 +917,39 @@ export const PAGE_GUIDES: PageGuide[] = [
       { chapterRef: '6', termId: 'Kc', label: '比切削抵抗 Kc（Kienzle）', labelEn: 'Specific Cutting Force Kc' },
       { chapterRef: '10', termId: 'SLD', label: 'Stability Lobe Diagram', labelEn: 'Stability Lobe Diagram' },
     ],
+  },
+  {
+    id: 'maiml-convert', icon: 'embed',
+    title: 'CSV → MaiML 変換', titleEn: 'CSV → MaiML Convert',
+    summary: '現場の元データである Excel エクスポート (CSV / UTF-8) を MaiML XML に変換する画面です。Material のフィールドへのカラムマッピングを介して、Excel → MaiML → ラボ計測器 / OEM の経路を 1 画面で完結させます。',
+    summaryEn: 'Convert Excel-exported CSV (UTF-8) into MaiML XML. With column mapping to Material fields, you can bridge the on-site Excel reality to the MaiML round-trip flow in one screen.',
+    features: [
+      'CSV / TSV ファイルを drop → 自動でヘッダ検出 + 推測マッピング',
+      'カラムマッピング UI で Material フィールドに割当（id / name は必須）',
+      'プレビュー（取込件数 / 警告 / 先頭 10 件）で安全に確認',
+      '.maiml ダウンロード or アプリ内 (Studio Import) に commit を選べる',
+      '日本語 / 英語ヘッダ揺らぎ吸収（材料名 / SampleName / 引張強さ / Tensile Strength 等）',
+    ],
+    featuresEn: [
+      'Drop CSV / TSV → auto header detection + inferred mapping',
+      'Column mapping UI assigns CSV headers to Material fields (id / name required)',
+      'Preview pane shows row count / warnings / first 10 rows for safe review',
+      'Choose between .maiml download and in-app commit (Studio Import)',
+      'Japanese / English header variant absorption (e.g. 材料名 vs SampleName)',
+    ],
+    tips: [
+      'Excel は「名前を付けて保存 → CSV (UTF-8)」で出してください。Shift_JIS は文字化けします',
+      '必須フィールド (id / name) が無いとプレビューが出ません。マッピングを確認してください',
+      '数値列に文字が混じっている行は警告を出して 0 で継続します（silent failure 禁止）',
+      'xlsx 直読みは未対応。bundle size の都合で後追い（ADR で計画）',
+    ],
+    tipsEn: [
+      'Save Excel as "CSV (UTF-8)". Shift_JIS encoding will produce mojibake',
+      'Mapping must include id and name; otherwise the preview will not appear',
+      'Rows where a numeric column contains text fall back to 0 with a warning (no silent failures)',
+      'Direct .xlsx parsing is deferred to a follow-up ADR for bundle-size reasons',
+    ],
+    related: ['maiml-import', 'maiml-export', 'list'],
   },
 ];
 

--- a/src/features/maiml/MaimlConvertPage.tsx
+++ b/src/features/maiml/MaimlConvertPage.tsx
@@ -1,0 +1,377 @@
+// CSV / Excel エクスポート → MaiML 変換画面。
+// 元データが現場の Excel に散在している現実 (痛み B1 🔥) を踏まえ、
+// Excel → CSV (UTF-8) → MaiML の経路を 1 画面で完結させる。
+//
+// フロー:
+//   1) CSV ファイルを drop
+//   2) ヘッダ行を検出し、Material フィールドへの推測マッピングを表示
+//   3) ユーザがマッピングを確認 / 修正 (id / name は必須)
+//   4) preview (取込 件数 + 警告 + 先頭 10 件)
+//   5) 「.maiml ダウンロード」 or 「Studio Import に commit」を選択
+//
+// xlsx は将来対応 (SheetJS は ~400KB のため遅延ロード前提)。
+// 現時点では Excel 「名前を付けて保存 → CSV (UTF-8)」運用を前提とする。
+
+import { useMemo, useState } from 'react';
+import type { Material, DbAction } from '@/types';
+import {
+  parseCsvWithHeader,
+  inferColumnMapping,
+  buildMaterialsFromCsv,
+  ALL_MATERIAL_FIELDS,
+  type ColumnMapping,
+  type MaterialField,
+  type CsvParseResult,
+} from '@/services/csvToMaiml';
+import { serializeMaterialsToMaiml } from '@/services/maiml';
+import { downloadTextFile } from '@/services/downloadFile';
+import { MaimlPageLayout } from './components/MaimlPageLayout';
+
+interface MaimlConvertPageProps {
+  db: Material[];
+  dispatch: React.Dispatch<DbAction>;
+  onNav: (page: string) => void;
+}
+
+interface LoadedCsv {
+  filename: string;
+  csv: CsvParseResult;
+}
+
+const REQUIRED_FIELDS: MaterialField[] = ['id', 'name'];
+
+export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps) => {
+  const [loaded, setLoaded] = useState<LoadedCsv | null>(null);
+  const [mapping, setMapping] = useState<ColumnMapping>({});
+  const [error, setError] = useState<string | null>(null);
+  const [imported, setImported] = useState<{ count: number; skipped: number } | null>(null);
+
+  const handleFile = async (file: File) => {
+    setError(null);
+    setImported(null);
+    if (!/\.(csv|tsv|txt)$/i.test(file.name)) {
+      setError('対応拡張子は .csv / .tsv / .txt です（Excel は CSV エクスポートしてください）');
+      return;
+    }
+    if (file.size > 10 * 1024 * 1024) {
+      setError('ファイルサイズが上限 (10 MB) を超えています');
+      return;
+    }
+    try {
+      const text = await file.text();
+      const csv = parseCsvWithHeader(text);
+      if (csv.headers.length === 0) {
+        setError('CSV のヘッダ行が読めませんでした');
+        return;
+      }
+      setLoaded({ filename: file.name, csv });
+      setMapping(inferColumnMapping(csv.headers));
+    } catch (e) {
+      setError(`読み込みエラー: ${(e as Error).message}`);
+    }
+  };
+
+  const reset = () => {
+    setLoaded(null);
+    setMapping({});
+    setError(null);
+    setImported(null);
+  };
+
+  // マッピング変更ハンドラ。空文字は割当解除。
+  const onMappingChange = (field: MaterialField, header: string) => {
+    setMapping((prev) => {
+      const next = { ...prev };
+      if (header === '') {
+        delete next[field];
+      } else {
+        next[field] = header;
+      }
+      return next;
+    });
+  };
+
+  const result = useMemo(() => {
+    if (!loaded) return null;
+    return buildMaterialsFromCsv(loaded.csv, mapping);
+  }, [loaded, mapping]);
+
+  const requiredMissing = REQUIRED_FIELDS.filter((f) => !mapping[f]);
+  const canCommit = !!result && requiredMissing.length === 0 && result.materials.length > 0;
+
+  const handleDownloadMaiml = () => {
+    if (!result || result.materials.length === 0) return;
+    const xml = serializeMaterialsToMaiml(result.materials, { source: 'matlens-csv-import' });
+    const base = loaded?.filename.replace(/\.(csv|tsv|txt)$/i, '') ?? 'export';
+    downloadTextFile(xml, `${base}.maiml`, 'application/xml');
+  };
+
+  const handleCommit = () => {
+    if (!result || result.materials.length === 0) return;
+    const existing = new Set(db.map((r) => r.id));
+    const fresh = result.materials.filter((m) => !existing.has(m.id));
+    const skipped = result.materials.length - fresh.length;
+    if (fresh.length === 0) {
+      setImported({ count: 0, skipped });
+      return;
+    }
+    dispatch({ type: 'IMPORT', records: fresh });
+    setImported({ count: fresh.length, skipped });
+  };
+
+  return (
+    <MaimlPageLayout
+      title="CSV → MaiML 変換"
+      subtitle="Excel エクスポート (CSV / UTF-8) を Material[] にマッピングし MaiML XML に変換します。.maiml をダウンロードするか、Studio Import 経由でアプリ内に取り込めます。"
+      onBackToHub={() => onNav('maiml-hub')}
+    >
+      <div className="flex flex-col gap-4 max-w-4xl">
+        {!loaded && !imported && (
+          <DropZone onFile={handleFile} />
+        )}
+
+        {error && (
+          <div className="rounded-lg border border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.08)] p-4 text-[13px]">
+            <div className="font-semibold text-[var(--err,#dc2626)] mb-1">エラー</div>
+            <div className="text-[var(--text-md)]">{error}</div>
+            <button
+              type="button"
+              onClick={() => setError(null)}
+              className="mt-3 text-[12px] underline text-[var(--text-lo)]"
+            >
+              閉じる
+            </button>
+          </div>
+        )}
+
+        {loaded && !imported && (
+          <>
+            <header className="rounded-lg border border-[var(--border-faint)] bg-[var(--bg-raised)] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div className="font-mono text-[13px] truncate">{loaded.filename}</div>
+                <span className="text-[12px] font-mono px-2 py-0.5 rounded bg-[var(--accent-dim)] text-[var(--accent,#2563eb)]">
+                  {loaded.csv.rows.length} 行 / {loaded.csv.headers.length} 列
+                </span>
+              </div>
+            </header>
+
+            <MappingTable
+              headers={loaded.csv.headers}
+              mapping={mapping}
+              onChange={onMappingChange}
+            />
+
+            {requiredMissing.length > 0 && (
+              <div className="rounded-lg border border-[var(--warn,#d97706)] bg-[rgba(217,119,6,0.08)] p-3 text-[13px]">
+                必須カラムが未割当です: {requiredMissing.join(', ')}
+              </div>
+            )}
+
+            {result && result.warnings.length > 0 && (
+              <details className="rounded-lg border border-[var(--warn,#d97706)] bg-[rgba(217,119,6,0.08)] p-3">
+                <summary className="cursor-pointer text-[13px] font-semibold text-[var(--warn,#d97706)]">
+                  警告 {result.warnings.length} 件（クリックで展開）
+                </summary>
+                <ul className="mt-2 text-[12px] list-disc list-inside flex flex-col gap-1 max-h-48 overflow-auto">
+                  {result.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              </details>
+            )}
+
+            {result && result.materials.length > 0 && (
+              <PreviewTable materials={result.materials} />
+            )}
+
+            <div className="flex items-center gap-3 justify-end">
+              <button
+                type="button"
+                onClick={reset}
+                className="text-[12px] px-3 py-1.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                onClick={handleDownloadMaiml}
+                disabled={!canCommit}
+                className="text-[12px] px-3 py-1.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)] disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                .maiml をダウンロード
+              </button>
+              <button
+                type="button"
+                onClick={handleCommit}
+                disabled={!canCommit}
+                className="text-[12px] px-3 py-1.5 rounded bg-[var(--accent,#2563eb)] text-white hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {result?.materials.length ?? 0} 件をアプリに取り込む
+              </button>
+            </div>
+          </>
+        )}
+
+        {imported && (
+          <div className="rounded-lg border border-[var(--ok,#22c55e)] bg-[rgba(34,197,94,0.08)] p-4">
+            <div className="text-[14px] font-semibold text-[var(--ok,#22c55e)]">取込完了</div>
+            <p className="mt-1 text-[13px]">
+              {imported.count} 件を取り込みました
+              {imported.skipped > 0 && (
+                <span className="text-[var(--text-lo)]">
+                  （既存 ID 重複により {imported.skipped} 件を skip）
+                </span>
+              )}
+              。
+            </p>
+            <div className="flex items-center gap-3 mt-3">
+              <button
+                type="button"
+                onClick={() => onNav('list')}
+                className="text-[12px] px-3 py-1.5 rounded border border-[var(--border-default)] hover:bg-[var(--hover)]"
+              >
+                材料データ一覧へ
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="text-[12px] underline text-[var(--text-lo)]"
+              >
+                別の CSV を変換する
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </MaimlPageLayout>
+  );
+};
+
+// ----- 内部コンポーネント -----
+
+const DropZone = ({ onFile }: { onFile: (file: File) => void }) => {
+  const [dragging, setDragging] = useState(false);
+  return (
+    <label
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragging(true);
+      }}
+      onDragLeave={() => setDragging(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragging(false);
+        const file = e.dataTransfer.files[0];
+        if (file) onFile(file);
+      }}
+      className={`flex flex-col items-center justify-center gap-2 p-8 rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
+        dragging
+          ? 'border-[var(--accent,#2563eb)] bg-[var(--accent-dim)]'
+          : 'border-[var(--border-faint)] bg-[var(--bg-raised)] hover:bg-[var(--hover)]'
+      }`}
+    >
+      <div className="text-[14px] font-semibold">CSV / TSV ファイルをドロップ、またはクリックで選択</div>
+      <div className="text-[12px] text-[var(--text-lo)]">
+        Excel から「名前を付けて保存 → CSV (UTF-8)」で書き出したファイルが対象（最大 10 MB）
+      </div>
+      <input
+        type="file"
+        accept=".csv,.tsv,.txt"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) onFile(file);
+          e.target.value = '';
+        }}
+      />
+    </label>
+  );
+};
+
+interface MappingTableProps {
+  headers: string[];
+  mapping: ColumnMapping;
+  onChange: (field: MaterialField, header: string) => void;
+}
+
+const MappingTable = ({ headers, mapping, onChange }: MappingTableProps) => (
+  <section
+    aria-label="カラムマッピング"
+    className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
+  >
+    <div className="text-[12px] text-[var(--text-lo)] px-3 py-1.5 bg-[var(--bg-sunken)] border-b border-[var(--border-faint)]">
+      カラムマッピング — Material のフィールドに、CSV のどのヘッダを割り当てるか選択
+    </div>
+    <table className="w-full text-[12px]">
+      <thead>
+        <tr className="bg-[var(--bg-raised)] border-b border-[var(--border-faint)]">
+          <th className="px-3 py-1.5 text-left font-semibold w-[40%]">Material フィールド</th>
+          <th className="px-3 py-1.5 text-left font-semibold">CSV ヘッダ</th>
+        </tr>
+      </thead>
+      <tbody>
+        {ALL_MATERIAL_FIELDS.map(({ field, label, required }) => (
+          <tr key={field} className="border-b border-[var(--border-faint)]">
+            <td className="px-3 py-1.5">
+              {label}
+              {required && (
+                <span className="ml-1 text-[var(--err,#dc2626)] font-bold">*</span>
+              )}
+            </td>
+            <td className="px-3 py-1">
+              <select
+                value={mapping[field] ?? ''}
+                onChange={(e) => onChange(field, e.target.value)}
+                className="text-[12px] px-2 py-1 rounded border border-[var(--border-default)] bg-[var(--bg-base)] min-w-[160px]"
+                aria-label={`${label} のカラム`}
+              >
+                <option value="">— 未割当 —</option>
+                {headers.map((h) => (
+                  <option key={h} value={h}>{h}</option>
+                ))}
+              </select>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </section>
+);
+
+const PreviewTable = ({ materials }: { materials: Material[] }) => (
+  <section
+    aria-label="取り込み対象プレビュー"
+    className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
+  >
+    <div className="text-[12px] text-[var(--text-lo)] px-3 py-1.5 bg-[var(--bg-sunken)] border-b border-[var(--border-faint)]">
+      プレビュー（先頭 10 件）— ここで内容を確認してから取込してください
+    </div>
+    <table className="w-full text-[12px]">
+      <thead>
+        <tr className="bg-[var(--bg-raised)] border-b border-[var(--border-faint)]">
+          <th className="px-3 py-1.5 text-left font-semibold">ID</th>
+          <th className="px-3 py-1.5 text-left font-semibold">名前</th>
+          <th className="px-3 py-1.5 text-left font-semibold">カテゴリ</th>
+          <th className="px-3 py-1.5 text-right font-semibold">硬度 HV</th>
+          <th className="px-3 py-1.5 text-right font-semibold">引張 MPa</th>
+        </tr>
+      </thead>
+      <tbody>
+        {materials.slice(0, 10).map((m) => (
+          <tr key={m.id} className="border-b border-[var(--border-faint)]">
+            <td className="px-3 py-1 font-mono">{m.id}</td>
+            <td className="px-3 py-1">{m.name}</td>
+            <td className="px-3 py-1">{m.cat}</td>
+            <td className="px-3 py-1 font-mono text-right">{m.hv}</td>
+            <td className="px-3 py-1 font-mono text-right">{m.ts}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    {materials.length > 10 && (
+      <div className="px-3 py-1.5 text-[12px] text-[var(--text-lo)]">
+        他 {materials.length - 10} 件
+      </div>
+    )}
+  </section>
+);

--- a/src/features/maiml/MaimlConvertPage.tsx
+++ b/src/features/maiml/MaimlConvertPage.tsx
@@ -19,6 +19,9 @@ import {
   inferColumnMapping,
   buildMaterialsFromCsv,
   ALL_MATERIAL_FIELDS,
+  REQUIRED_FIELDS,
+  SAMPLE_CSV,
+  SAMPLE_CSV_FILENAME,
   type ColumnMapping,
   type MaterialField,
   type CsvParseResult,
@@ -38,7 +41,7 @@ interface LoadedCsv {
   csv: CsvParseResult;
 }
 
-const REQUIRED_FIELDS: MaterialField[] = ['id', 'name'];
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
 export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps) => {
   const [loaded, setLoaded] = useState<LoadedCsv | null>(null);
@@ -53,22 +56,33 @@ export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps)
       setError('対応拡張子は .csv / .tsv / .txt です（Excel は CSV エクスポートしてください）');
       return;
     }
-    if (file.size > 10 * 1024 * 1024) {
+    if (file.size > MAX_FILE_SIZE_BYTES) {
       setError('ファイルサイズが上限 (10 MB) を超えています');
       return;
     }
     try {
       const text = await file.text();
-      const csv = parseCsvWithHeader(text);
-      if (csv.headers.length === 0) {
-        setError('CSV のヘッダ行が読めませんでした');
-        return;
-      }
-      setLoaded({ filename: file.name, csv });
-      setMapping(inferColumnMapping(csv.headers));
+      loadText(file.name, text);
     } catch (e) {
       setError(`読み込みエラー: ${(e as Error).message}`);
     }
+  };
+
+  // ファイル経路と sample 経路で共有する CSV テキスト → state 反映
+  const loadText = (filename: string, text: string) => {
+    const csv = parseCsvWithHeader(text);
+    if (csv.headers.length === 0) {
+      setError('CSV のヘッダ行が読めませんでした');
+      return;
+    }
+    setLoaded({ filename, csv });
+    setMapping(inferColumnMapping(csv.headers));
+  };
+
+  const loadSample = () => {
+    setError(null);
+    setImported(null);
+    loadText(SAMPLE_CSV_FILENAME, SAMPLE_CSV);
   };
 
   const reset = () => {
@@ -127,7 +141,7 @@ export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps)
     >
       <div className="flex flex-col gap-4 max-w-4xl">
         {!loaded && !imported && (
-          <DropZone onFile={handleFile} />
+          <DropZone onFile={handleFile} onSample={loadSample} />
         )}
 
         {error && (
@@ -249,53 +263,71 @@ export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps)
 
 // ----- 内部コンポーネント -----
 
-const DropZone = ({ onFile }: { onFile: (file: File) => void }) => {
+interface DropZoneProps {
+  onFile: (file: File) => void;
+  onSample: () => void;
+}
+
+const DropZone = ({ onFile, onSample }: DropZoneProps) => {
   const [dragging, setDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      aria-label="CSV / TSV ファイルをドロップまたはクリックで選択"
-      onClick={() => inputRef.current?.click()}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          inputRef.current?.click();
-        }
-      }}
-      onDragOver={(e) => {
-        e.preventDefault();
-        setDragging(true);
-      }}
-      onDragLeave={() => setDragging(false)}
-      onDrop={(e) => {
-        e.preventDefault();
-        setDragging(false);
-        const file = e.dataTransfer.files[0];
-        if (file) onFile(file);
-      }}
-      className={`flex flex-col items-center justify-center gap-2 p-8 rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
-        dragging
-          ? 'border-[var(--accent,#2563eb)] bg-[var(--accent-dim)]'
-          : 'border-[var(--border-faint)] bg-[var(--bg-raised)] hover:bg-[var(--hover)]'
-      }`}
-    >
-      <div className="text-[14px] font-semibold">CSV / TSV ファイルをドロップ、またはクリックで選択</div>
-      <div className="text-[12px] text-[var(--text-lo)]">
-        Excel から「名前を付けて保存 → CSV (UTF-8)」で書き出したファイルが対象（最大 10 MB）
-      </div>
-      <input
-        ref={inputRef}
-        type="file"
-        accept=".csv,.tsv,.txt"
-        className="hidden"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) onFile(file);
-          e.target.value = '';
+    <div className="flex flex-col gap-3">
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="CSV / TSV ファイルをドロップまたはクリックで選択"
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            inputRef.current?.click();
+          }
         }}
-      />
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          const file = e.dataTransfer.files[0];
+          if (file) onFile(file);
+        }}
+        className={`flex flex-col items-center justify-center gap-2 p-8 rounded-lg border-2 border-dashed cursor-pointer transition-colors ${
+          dragging
+            ? 'border-[var(--accent,#2563eb)] bg-[var(--accent-dim)]'
+            : 'border-[var(--border-faint)] bg-[var(--bg-raised)] hover:bg-[var(--hover)]'
+        }`}
+      >
+        <div className="text-[14px] font-semibold">CSV / TSV ファイルをドロップ、またはクリックで選択</div>
+        <div className="text-[12px] text-[var(--text-lo)]">
+          Excel から「名前を付けて保存 → CSV (UTF-8)」で書き出したファイルが対象（最大 10 MB）
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv,.tsv,.txt"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) onFile(file);
+            e.target.value = '';
+          }}
+        />
+      </div>
+      <div className="flex items-center gap-3 text-[12px] text-[var(--text-lo)]">
+        <span>手元に CSV が無い場合は</span>
+        <button
+          type="button"
+          onClick={onSample}
+          className="px-3 py-1.5 rounded border border-[var(--border-default)] bg-[var(--bg-raised)] hover:bg-[var(--hover)] text-[var(--text-hi)] font-semibold"
+        >
+          サンプル CSV を読み込む
+        </button>
+        <span className="text-[var(--text-lo)]">で挙動を試せます（Ti-6Al-4V / SUS316L 等 5 件 / 日英ヘッダ混在）</span>
+      </div>
     </div>
   );
 };

--- a/src/features/maiml/MaimlConvertPage.tsx
+++ b/src/features/maiml/MaimlConvertPage.tsx
@@ -12,7 +12,7 @@
 // xlsx は将来対応 (SheetJS は ~400KB のため遅延ロード前提)。
 // 現時点では Excel 「名前を付けて保存 → CSV (UTF-8)」運用を前提とする。
 
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import type { Material, DbAction } from '@/types';
 import {
   parseCsvWithHeader,
@@ -251,8 +251,19 @@ export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps)
 
 const DropZone = ({ onFile }: { onFile: (file: File) => void }) => {
   const [dragging, setDragging] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
   return (
-    <label
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="CSV / TSV ファイルをドロップまたはクリックで選択"
+      onClick={() => inputRef.current?.click()}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          inputRef.current?.click();
+        }
+      }}
       onDragOver={(e) => {
         e.preventDefault();
         setDragging(true);
@@ -275,6 +286,7 @@ const DropZone = ({ onFile }: { onFile: (file: File) => void }) => {
         Excel から「名前を付けて保存 → CSV (UTF-8)」で書き出したファイルが対象（最大 10 MB）
       </div>
       <input
+        ref={inputRef}
         type="file"
         accept=".csv,.tsv,.txt"
         className="hidden"
@@ -284,7 +296,7 @@ const DropZone = ({ onFile }: { onFile: (file: File) => void }) => {
           e.target.value = '';
         }}
       />
-    </label>
+    </div>
   );
 };
 

--- a/src/features/maiml/MaimlStudioHubPage.tsx
+++ b/src/features/maiml/MaimlStudioHubPage.tsx
@@ -29,6 +29,13 @@ const CARDS: StudioCard[] = [
     icon: 'plus',
   },
   {
+    id: 'maiml-convert',
+    title: 'CSV → MaiML 変換',
+    subtitle: 'Excel から CSV エクスポートしたデータをカラムマッピングで MaiML に変換',
+    icon: 'embed',
+    badge: 'NEW',
+  },
+  {
     id: 'maiml-export',
     title: 'エクスポート',
     subtitle: '材料・案件・試験集合の MaiML 書き出し導線をここに集約',

--- a/src/features/maiml/index.ts
+++ b/src/features/maiml/index.ts
@@ -3,6 +3,7 @@
 
 export { MaimlStudioHubPage } from './MaimlStudioHubPage';
 export { MaimlImportPage } from './MaimlImportPage';
+export { MaimlConvertPage } from './MaimlConvertPage';
 export { MaimlExportHubPage } from './MaimlExportHubPage';
 export { MaimlInspectPage } from './MaimlInspectPage';
 export { MaimlValidatePage } from './MaimlValidatePage';

--- a/src/services/csvToMaiml.test.ts
+++ b/src/services/csvToMaiml.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCsv,
+  parseCsvWithHeader,
+  inferColumnMapping,
+  buildMaterialsFromCsv,
+  convertCsvToMaiml,
+  type ColumnMapping,
+} from './csvToMaiml';
+
+describe('parseCsv', () => {
+  it('basic 3-column CSV を行ごとに分割する', () => {
+    const out = parseCsv('a,b,c\n1,2,3\n4,5,6\n');
+    expect(out).toEqual([
+      ['a', 'b', 'c'],
+      ['1', '2', '3'],
+      ['4', '5', '6'],
+    ]);
+  });
+
+  it('UTF-8 BOM を黙って捨てる', () => {
+    const out = parseCsv('\uFEFFid,name\nA,B');
+    expect(out[0]).toEqual(['id', 'name']);
+  });
+
+  it('ダブルクォート内のカンマと改行を保持する', () => {
+    const out = parseCsv('id,memo\n1,"a, b\nc"\n');
+    expect(out).toEqual([
+      ['id', 'memo'],
+      ['1', 'a, b\nc'],
+    ]);
+  });
+
+  it('"" を " にエスケープする', () => {
+    const out = parseCsv('id,memo\n1,"he said ""hi"""');
+    expect(out[1]).toEqual(['1', 'he said "hi"']);
+  });
+
+  it('CRLF を区切りとして扱う', () => {
+    const out = parseCsv('a,b\r\n1,2\r\n');
+    expect(out).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+  });
+
+  it('完全な空行は無視する', () => {
+    const out = parseCsv('a,b\n\n1,2\n\n');
+    expect(out).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+  });
+});
+
+describe('inferColumnMapping', () => {
+  it('日本語ヘッダから推測する', () => {
+    const mapping = inferColumnMapping(['材料ID', '材料名', '硬度', '引張強さ']);
+    expect(mapping.id).toBe('材料ID');
+    expect(mapping.name).toBe('材料名');
+    expect(mapping.hv).toBe('硬度');
+    expect(mapping.ts).toBe('引張強さ');
+  });
+
+  it('英語ヘッダから推測する', () => {
+    const mapping = inferColumnMapping(['SampleId', 'SampleName', 'HV', 'Tensile Strength']);
+    expect(mapping.id).toBe('SampleId');
+    expect(mapping.name).toBe('SampleName');
+    expect(mapping.hv).toBe('HV');
+    expect(mapping.ts).toBe('Tensile Strength');
+  });
+
+  it('既知でないヘッダは触らない', () => {
+    const mapping = inferColumnMapping(['unknown_col', 'foo']);
+    expect(Object.keys(mapping)).toHaveLength(0);
+  });
+
+  it('同一フィールドへの重複割当は最初の 1 つだけ', () => {
+    // hardness と HV は両方とも hv のヒント。先に来た方が勝つ。
+    const mapping = inferColumnMapping(['hardness', 'HV']);
+    expect(mapping.hv).toBe('hardness');
+  });
+});
+
+describe('buildMaterialsFromCsv', () => {
+  const csv = parseCsvWithHeader([
+    'ID,Name,Category,HV,Tensile Strength',
+    'M-001,Ti-6Al-4V,金属合金,340,950',
+    'M-002,SUS316L,金属合金,180,520',
+  ].join('\n'));
+
+  it('必須割当があれば Material[] を返す', () => {
+    const mapping: ColumnMapping = {
+      id: 'ID', name: 'Name', cat: 'Category', hv: 'HV', ts: 'Tensile Strength',
+    };
+    const { materials, warnings } = buildMaterialsFromCsv(csv, mapping);
+    expect(materials).toHaveLength(2);
+    expect(materials[0]?.id).toBe('M-001');
+    expect(materials[0]?.hv).toBe(340);
+    expect(materials[1]?.ts).toBe(520);
+    expect(warnings).toEqual([]);
+  });
+
+  it('id 未割当だと致命的で空配列 + warning', () => {
+    const mapping: ColumnMapping = { name: 'Name' };
+    const { materials, warnings } = buildMaterialsFromCsv(csv, mapping);
+    expect(materials).toEqual([]);
+    expect(warnings.some((w) => w.includes('id'))).toBe(true);
+  });
+
+  it('必須数値が読めない行は 0 + warning に落として継続する', () => {
+    const broken = parseCsvWithHeader('ID,Name,HV\nM-001,Ti,abc');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', hv: 'HV' };
+    const { materials, warnings } = buildMaterialsFromCsv(broken, mapping);
+    expect(materials).toHaveLength(1);
+    expect(materials[0]?.hv).toBe(0);
+    expect(warnings.some((w) => w.includes('hv'))).toBe(true);
+  });
+
+  it('id / name が空の行は skip', () => {
+    const data = parseCsvWithHeader('ID,Name\nM-001,Ti\n,Skipped');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials).toHaveLength(1);
+    expect(warnings.some((w) => w.includes('スキップ'))).toBe(true);
+  });
+
+  it('カテゴリの英語表記を吸収する', () => {
+    const data = parseCsvWithHeader('ID,Name,Cat\nM-001,Ti,metal alloy');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', cat: 'Cat' };
+    const { materials } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.cat).toBe('金属合金');
+  });
+});
+
+describe('convertCsvToMaiml', () => {
+  it('CSV → MaiML XML round-trip', () => {
+    const csvText = [
+      'ID,Name,Category,HV,Tensile Strength',
+      'M-001,Ti-6Al-4V,金属合金,340,950',
+    ].join('\n');
+    const mapping: ColumnMapping = {
+      id: 'ID', name: 'Name', cat: 'Category', hv: 'HV', ts: 'Tensile Strength',
+    };
+    const { materials, maiml, warnings } = convertCsvToMaiml(csvText, mapping, {
+      generatedAt: new Date('2026-05-10T00:00:00Z'),
+    });
+    expect(materials).toHaveLength(1);
+    expect(warnings).toEqual([]);
+    expect(maiml).toContain('<maiml');
+    expect(maiml).toContain('M-001');
+    expect(maiml).toContain('Ti-6Al-4V');
+    expect(maiml).toContain('matlens-csv-import');
+  });
+});

--- a/src/services/csvToMaiml.test.ts
+++ b/src/services/csvToMaiml.test.ts
@@ -5,6 +5,8 @@ import {
   inferColumnMapping,
   buildMaterialsFromCsv,
   convertCsvToMaiml,
+  REQUIRED_FIELDS,
+  SAMPLE_CSV,
   type ColumnMapping,
 } from './csvToMaiml';
 
@@ -128,8 +130,59 @@ describe('buildMaterialsFromCsv', () => {
   it('カテゴリの英語表記を吸収する', () => {
     const data = parseCsvWithHeader('ID,Name,Cat\nM-001,Ti,metal alloy');
     const mapping: ColumnMapping = { id: 'ID', name: 'Name', cat: 'Cat' };
-    const { materials } = buildMaterialsFromCsv(data, mapping);
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
     expect(materials[0]?.cat).toBe('金属合金');
+    // 英語表記は「認識済み」扱いなのでカテゴリ起因の warning は出ない
+    expect(warnings.some((w) => w.includes('カテゴリ'))).toBe(false);
+  });
+
+  it('未認識カテゴリは "金属合金" にフォールバックしつつ warning を出す', () => {
+    const data = parseCsvWithHeader('ID,Name,Cat\nM-001,Ti,unobtanium');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', cat: 'Cat' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.cat).toBe('金属合金');
+    expect(warnings.some((w) => w.includes('カテゴリ') && w.includes('unobtanium'))).toBe(true);
+  });
+
+  it('未認識ステータスは "レビュー待" にフォールバックしつつ warning を出す', () => {
+    const data = parseCsvWithHeader('ID,Name,Status\nM-001,Ti,bogus-state');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', status: 'Status' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.status).toBe('レビュー待');
+    expect(warnings.some((w) => w.includes('ステータス') && w.includes('bogus-state'))).toBe(true);
+  });
+
+  it('CSV 内で重複している ID は 2 件目以降を skip して warning に落とす', () => {
+    const data = parseCsvWithHeader('ID,Name\nM-001,Ti A\nM-001,Ti A 再登録\nM-002,Ti B');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials).toHaveLength(2);
+    expect(materials[0]?.name).toBe('Ti A');
+    expect(materials[1]?.id).toBe('M-002');
+    expect(warnings.some((w) => w.includes('M-001') && w.includes('重複'))).toBe(true);
+  });
+});
+
+describe('REQUIRED_FIELDS', () => {
+  it('UI と service で共有する公開定数', () => {
+    expect(REQUIRED_FIELDS).toEqual(['id', 'name']);
+  });
+});
+
+describe('SAMPLE_CSV', () => {
+  it('そのまま convert に流して preview に出せる', () => {
+    const csv = parseCsvWithHeader(SAMPLE_CSV);
+    const mapping = inferColumnMapping(csv.headers);
+    // 必須 (id / name) と中核数値 (hv / ts) は自動推測で埋まる前提
+    expect(mapping.id).toBeDefined();
+    expect(mapping.name).toBeDefined();
+    expect(mapping.hv).toBeDefined();
+    expect(mapping.ts).toBeDefined();
+
+    const { materials, warnings } = buildMaterialsFromCsv(csv, mapping);
+    expect(materials.length).toBeGreaterThanOrEqual(5);
+    expect(warnings).toEqual([]);
+    expect(materials[0]?.id).toBe('M-101');
   });
 });
 

--- a/src/services/csvToMaiml.ts
+++ b/src/services/csvToMaiml.ts
@@ -1,0 +1,359 @@
+// CSV (Excel エクスポートを含む) を Material[] に変換し、MaiML XML を生成する。
+//
+// 想定スキーム:
+//   元データは現場の Excel に散在している。Excel → CSV (UTF-8) を経由して
+//   Matlens に取り込み、MaiML round-trip に乗せる。これにより
+//   「Excel → MaiML → ラボ計測器 / OEM」を 1 経路で扱えるようにする。
+//
+// MVP の責務:
+//   - RFC 4180 風の CSV をパースする (双引用符 + ダブルクォートエスケープ)
+//   - UTF-8 BOM を黙って捨てる
+//   - 列マッピング (Material のフィールド → CSV のヘッダ名) を受け取り、
+//     型変換しつつ Material[] を組み立てる
+//   - 数値変換に失敗した必須フィールドは行単位の警告にする (silent failure 禁止)
+//   - 仕上げに既存の serializeMaterialsToMaiml で MaiML を吐く
+//
+// xlsx パーサ (SheetJS) は導入しない。Excel は「名前を付けて保存 → CSV」が
+// 確実なので、まず CSV 取り込みで現場痛みを解消し、xlsx は後追いとする。
+// （bundle size と framework-agnostic 境界の維持のため）
+
+import type { Material, MaterialCategory, MaterialStatus, Provenance } from '../types';
+import { serializeMaterialsToMaiml } from './maiml';
+
+// ----- CSV パース -----
+
+/** CSV セル値を 1 行ずつ取り出す。RFC 4180 風 (双引用符 + "" エスケープ)。 */
+export function parseCsv(text: string): string[][] {
+  // BOM を 1 度だけ落とす
+  const src = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = '';
+  let inQuote = false;
+
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+
+    if (inQuote) {
+      if (ch === '"') {
+        // "" → " のエスケープ
+        if (src[i + 1] === '"') {
+          cell += '"';
+          i++;
+        } else {
+          inQuote = false;
+        }
+      } else {
+        cell += ch;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inQuote = true;
+      continue;
+    }
+    if (ch === ',') {
+      row.push(cell);
+      cell = '';
+      continue;
+    }
+    if (ch === '\n' || ch === '\r') {
+      // \r\n は \n だけを区切りとして扱う
+      if (ch === '\r' && src[i + 1] === '\n') i++;
+      row.push(cell);
+      cell = '';
+      // 完全な空行は無視 (Excel エクスポートで末尾に出やすい)
+      if (!(row.length === 1 && row[0] === '')) {
+        rows.push(row);
+      }
+      row = [];
+      continue;
+    }
+    cell += ch;
+  }
+
+  // 末尾セル
+  if (cell !== '' || row.length > 0) {
+    row.push(cell);
+    if (!(row.length === 1 && row[0] === '')) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+export interface CsvParseResult {
+  headers: string[];
+  rows: string[][];
+}
+
+/** ヘッダ行 + データ行に分離。最初の非空行をヘッダとして扱う。 */
+export function parseCsvWithHeader(text: string): CsvParseResult {
+  const all = parseCsv(text);
+  const first = all[0];
+  if (!first) return { headers: [], rows: [] };
+  const headers = first.map((h) => h.trim());
+  const rows = all.slice(1);
+  return { headers, rows };
+}
+
+// ----- ヘッダ自動マッピング -----
+
+/** Material のどのフィールドに割り当てられるか。null = 割当なし */
+export type MaterialField =
+  | 'id'
+  | 'name'
+  | 'cat'
+  | 'comp'
+  | 'batch'
+  | 'date'
+  | 'author'
+  | 'status'
+  | 'memo'
+  | 'hv'
+  | 'ts'
+  | 'el'
+  | 'el2'
+  | 'pf'
+  | 'dn'
+  | 'provenance'
+  | 'microstructure'
+  | 'testMethod';
+
+export type ColumnMapping = Partial<Record<MaterialField, string>>;
+
+/** ヘッダ名（日本語 / 英語表記の代表的な揺らぎ）→ MaterialField */
+const HEADER_HINTS: Record<MaterialField, string[]> = {
+  id: ['id', 'sampleid', 'sample id', '材料id', '試料id', '管理番号'],
+  name: ['name', 'samplename', 'sample name', '材料名', '試料名', '名称'],
+  cat: ['category', 'cat', '分類', 'カテゴリ', '材料分類'],
+  comp: ['composition', 'comp', '組成'],
+  batch: ['batch', 'lot', 'ロット', 'バッチ'],
+  date: ['date', 'registeredon', '登録日', '日付'],
+  author: ['author', 'operator', '担当', '担当者', '作成者'],
+  status: ['status', '状態', 'ステータス'],
+  memo: ['memo', 'note', 'remarks', '備考', 'メモ'],
+  hv: ['hv', 'hardness', '硬度', '硬さ'],
+  ts: ['ts', 'tensile', 'tensilestrength', '引張強さ', '引張強度'],
+  el: ['el', 'elastic', 'elasticmodulus', 'youngs', 'ヤング率', '弾性率'],
+  el2: ['elongation', 'el2', '伸び', '伸び率'],
+  pf: ['pf', 'proof', 'proofstress', '耐力', '0.2%耐力'],
+  dn: ['dn', 'density', '密度'],
+  provenance: ['provenance', 'source', '出所', 'データ出所'],
+  microstructure: ['microstructure', 'micro', '組織', '金属組織'],
+  testMethod: ['testmethod', 'method', '試験方法', '規格'],
+};
+
+function normalizeHeader(h: string): string {
+  return h.toLowerCase().replace(/[\s_-]+/g, '');
+}
+
+/** ヘッダ一覧から推測でマッピングを埋める。確信が無い列は触らない。 */
+export function inferColumnMapping(headers: string[]): ColumnMapping {
+  const mapping: ColumnMapping = {};
+  const used = new Set<string>();
+  for (const [field, hints] of Object.entries(HEADER_HINTS) as [MaterialField, string[]][]) {
+    for (const header of headers) {
+      if (used.has(header)) continue;
+      const norm = normalizeHeader(header);
+      if (hints.some((hint) => norm === normalizeHeader(hint))) {
+        mapping[field] = header;
+        used.add(header);
+        break;
+      }
+    }
+  }
+  return mapping;
+}
+
+// ----- 値の変換 -----
+
+const CATEGORY_VALUES: MaterialCategory[] = ['金属合金', 'セラミクス', 'ポリマー', '複合材料'];
+const STATUS_VALUES: MaterialStatus[] = ['登録済', 'レビュー待', '承認済', '要修正'];
+const PROVENANCE_VALUES: Provenance[] = ['instrument', 'manual', 'ai', 'simulation'];
+
+function coerceCategory(value: string): MaterialCategory {
+  const trimmed = value.trim();
+  if ((CATEGORY_VALUES as string[]).includes(trimmed)) return trimmed as MaterialCategory;
+  // 英語表記の揺らぎ吸収
+  const lower = trimmed.toLowerCase();
+  if (lower.includes('metal') || lower.includes('alloy')) return '金属合金';
+  if (lower.includes('ceram')) return 'セラミクス';
+  if (lower.includes('polymer') || lower.includes('plastic')) return 'ポリマー';
+  if (lower.includes('composite') || lower.includes('cfrp') || lower.includes('cmc')) return '複合材料';
+  return '金属合金';
+}
+
+function coerceStatus(value: string): MaterialStatus {
+  const trimmed = value.trim();
+  if ((STATUS_VALUES as string[]).includes(trimmed)) return trimmed as MaterialStatus;
+  return 'レビュー待';
+}
+
+function coerceProvenance(value: string): Provenance | undefined {
+  const trimmed = value.trim().toLowerCase();
+  if ((PROVENANCE_VALUES as string[]).includes(trimmed)) return trimmed as Provenance;
+  return undefined;
+}
+
+function coerceNumberOrNull(value: string): number | null {
+  if (value === undefined || value === null) return null;
+  const cleaned = String(value).replace(/[, ]/g, '').trim();
+  if (cleaned === '') return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : null;
+}
+
+// ----- マッピング → Material[] -----
+
+export interface BuildMaterialsResult {
+  materials: Material[];
+  warnings: string[];
+}
+
+const REQUIRED_FIELDS: MaterialField[] = ['id', 'name'];
+const REQUIRED_NUMERIC_FIELDS: MaterialField[] = ['hv', 'ts'];
+
+/**
+ * カラムマッピングと CSV 行から Material[] を構築する。
+ * - REQUIRED_FIELDS が欠けている行は skip + warning
+ * - REQUIRED_NUMERIC_FIELDS は欠損時に 0 にフォールバックして warning
+ * - 任意フィールド (memo / provenance / microstructure / testMethod) は欠損時 undefined
+ */
+export function buildMaterialsFromCsv(
+  csv: CsvParseResult,
+  mapping: ColumnMapping,
+): BuildMaterialsResult {
+  const warnings: string[] = [];
+  const materials: Material[] = [];
+
+  // ヘッダ → 列インデックスの逆引き
+  const indexByHeader: Record<string, number> = {};
+  csv.headers.forEach((h, i) => {
+    indexByHeader[h] = i;
+  });
+
+  // 必須フィールドが mapping に無い場合は致命的なので空配列を返す
+  for (const field of REQUIRED_FIELDS) {
+    if (!mapping[field]) {
+      warnings.push(`必須フィールド「${field}」のカラムが未割当です`);
+    }
+  }
+  if (warnings.length > 0) {
+    return { materials: [], warnings };
+  }
+
+  const get = (row: string[], field: MaterialField): string | undefined => {
+    const header = mapping[field];
+    if (!header) return undefined;
+    const idx = indexByHeader[header];
+    if (idx === undefined) return undefined;
+    return row[idx];
+  };
+
+  csv.rows.forEach((row, rowIdx) => {
+    const lineNo = rowIdx + 2; // 1: header, 2-: data
+
+    const id = (get(row, 'id') ?? '').trim();
+    const name = (get(row, 'name') ?? '').trim();
+    if (!id || !name) {
+      warnings.push(`行 ${lineNo}: id または name が空のためスキップしました`);
+      return;
+    }
+
+    const numericOrZero = (field: MaterialField): number => {
+      const raw = get(row, field);
+      const n = coerceNumberOrNull(raw ?? '');
+      if (n === null) {
+        if (REQUIRED_NUMERIC_FIELDS.includes(field)) {
+          warnings.push(`行 ${lineNo} (${id}): ${field} が数値として読めず 0 を入れました`);
+        }
+        return 0;
+      }
+      return n;
+    };
+
+    const pfRaw = get(row, 'pf');
+    const pf = pfRaw === undefined || pfRaw.trim() === '' ? null : coerceNumberOrNull(pfRaw);
+
+    const provenanceRaw = get(row, 'provenance');
+    const provenance = provenanceRaw ? coerceProvenance(provenanceRaw) : undefined;
+
+    const material: Material = {
+      id,
+      name,
+      cat: coerceCategory(get(row, 'cat') ?? ''),
+      hv: numericOrZero('hv'),
+      ts: numericOrZero('ts'),
+      el: numericOrZero('el'),
+      pf,
+      el2: numericOrZero('el2'),
+      dn: numericOrZero('dn'),
+      comp: (get(row, 'comp') ?? '').trim(),
+      batch: (get(row, 'batch') ?? '').trim(),
+      date: (get(row, 'date') ?? new Date().toISOString().slice(0, 10)).trim(),
+      author: (get(row, 'author') ?? '').trim(),
+      status: coerceStatus(get(row, 'status') ?? ''),
+      ai: false,
+      memo: (get(row, 'memo') ?? '').trim(),
+    };
+
+    if (provenance) material.provenance = provenance;
+    const micro = get(row, 'microstructure');
+    if (micro && micro.trim()) material.microstructure = micro.trim();
+    const tm = get(row, 'testMethod');
+    if (tm && tm.trim()) material.testMethod = tm.trim();
+
+    materials.push(material);
+  });
+
+  return { materials, warnings };
+}
+
+// ----- ワンショット変換 -----
+
+export interface ConvertCsvToMaimlResult {
+  materials: Material[];
+  warnings: string[];
+  maiml: string;
+}
+
+/**
+ * CSV テキスト + マッピングから Material[] と MaiML XML を一気に作る。
+ * ページ側はこれを呼んで preview と download に分岐する。
+ */
+export function convertCsvToMaiml(
+  csvText: string,
+  mapping: ColumnMapping,
+  options: { source?: string; generatedAt?: Date } = {},
+): ConvertCsvToMaimlResult {
+  const csv = parseCsvWithHeader(csvText);
+  const { materials, warnings } = buildMaterialsFromCsv(csv, mapping);
+  const maiml = serializeMaterialsToMaiml(materials, {
+    source: options.source ?? 'matlens-csv-import',
+    generatedAt: options.generatedAt,
+  });
+  return { materials, warnings, maiml };
+}
+
+export const ALL_MATERIAL_FIELDS: { field: MaterialField; label: string; required?: boolean }[] = [
+  { field: 'id', label: 'ID (材料 ID)', required: true },
+  { field: 'name', label: '名前', required: true },
+  { field: 'cat', label: 'カテゴリ' },
+  { field: 'comp', label: '組成' },
+  { field: 'batch', label: 'バッチ' },
+  { field: 'date', label: '登録日' },
+  { field: 'author', label: '担当者' },
+  { field: 'status', label: 'ステータス' },
+  { field: 'memo', label: 'メモ / 備考' },
+  { field: 'hv', label: '硬度 HV' },
+  { field: 'ts', label: '引張強さ MPa' },
+  { field: 'el', label: '弾性率 GPa' },
+  { field: 'el2', label: '伸び %' },
+  { field: 'pf', label: '耐力 MPa' },
+  { field: 'dn', label: '密度 g/cm3' },
+  { field: 'provenance', label: 'Provenance' },
+  { field: 'microstructure', label: '組織記述' },
+  { field: 'testMethod', label: '試験方法 / 規格' },
+];

--- a/src/services/csvToMaiml.ts
+++ b/src/services/csvToMaiml.ts
@@ -173,22 +173,37 @@ const CATEGORY_VALUES: MaterialCategory[] = ['金属合金', 'セラミクス', 
 const STATUS_VALUES: MaterialStatus[] = ['登録済', 'レビュー待', '承認済', '要修正'];
 const PROVENANCE_VALUES: Provenance[] = ['instrument', 'manual', 'ai', 'simulation'];
 
-function coerceCategory(value: string): MaterialCategory {
-  const trimmed = value.trim();
-  if ((CATEGORY_VALUES as string[]).includes(trimmed)) return trimmed as MaterialCategory;
-  // 英語表記の揺らぎ吸収
-  const lower = trimmed.toLowerCase();
-  if (lower.includes('metal') || lower.includes('alloy')) return '金属合金';
-  if (lower.includes('ceram')) return 'セラミクス';
-  if (lower.includes('polymer') || lower.includes('plastic')) return 'ポリマー';
-  if (lower.includes('composite') || lower.includes('cfrp') || lower.includes('cmc')) return '複合材料';
-  return '金属合金';
+// 列挙値の coerce は「空欄はサイレントに default」「非空だが未認識ならフォールバック + unknown=true」
+// に分け、silent failure 禁止ポリシーに揃える。caller は unknown を見て warnings に push する。
+interface CoercionResult<T> {
+  value: T;
+  unknown: boolean;
 }
 
-function coerceStatus(value: string): MaterialStatus {
+function coerceCategory(value: string): CoercionResult<MaterialCategory> {
   const trimmed = value.trim();
-  if ((STATUS_VALUES as string[]).includes(trimmed)) return trimmed as MaterialStatus;
-  return 'レビュー待';
+  if (trimmed === '') return { value: '金属合金', unknown: false };
+  if ((CATEGORY_VALUES as string[]).includes(trimmed)) {
+    return { value: trimmed as MaterialCategory, unknown: false };
+  }
+  // 英語表記の揺らぎ吸収
+  const lower = trimmed.toLowerCase();
+  if (lower.includes('metal') || lower.includes('alloy')) return { value: '金属合金', unknown: false };
+  if (lower.includes('ceram')) return { value: 'セラミクス', unknown: false };
+  if (lower.includes('polymer') || lower.includes('plastic')) return { value: 'ポリマー', unknown: false };
+  if (lower.includes('composite') || lower.includes('cfrp') || lower.includes('cmc')) {
+    return { value: '複合材料', unknown: false };
+  }
+  return { value: '金属合金', unknown: true };
+}
+
+function coerceStatus(value: string): CoercionResult<MaterialStatus> {
+  const trimmed = value.trim();
+  if (trimmed === '') return { value: 'レビュー待', unknown: false };
+  if ((STATUS_VALUES as string[]).includes(trimmed)) {
+    return { value: trimmed as MaterialStatus, unknown: false };
+  }
+  return { value: 'レビュー待', unknown: true };
 }
 
 function coerceProvenance(value: string): Provenance | undefined {
@@ -212,7 +227,9 @@ export interface BuildMaterialsResult {
   warnings: string[];
 }
 
-const REQUIRED_FIELDS: MaterialField[] = ['id', 'name'];
+// UI 側でも参照するため公開（旧版は MaimlConvertPage.tsx で再定義していたが
+// single source of truth に集約）。
+export const REQUIRED_FIELDS: MaterialField[] = ['id', 'name'];
 const REQUIRED_NUMERIC_FIELDS: MaterialField[] = ['hv', 'ts'];
 
 /**
@@ -252,6 +269,10 @@ export function buildMaterialsFromCsv(
     return row[idx];
   };
 
+  // CSV 内で同一 ID が複数行に現れたら 2 行目以降は warning に落として skip
+  // （IMPORT 時に上書きされて静かに 1 件消えるのを防ぐ）
+  const seenIds = new Set<string>();
+
   csv.rows.forEach((row, rowIdx) => {
     const lineNo = rowIdx + 2; // 1: header, 2-: data
 
@@ -261,6 +282,11 @@ export function buildMaterialsFromCsv(
       warnings.push(`行 ${lineNo}: id または name が空のためスキップしました`);
       return;
     }
+    if (seenIds.has(id)) {
+      warnings.push(`行 ${lineNo}: ID "${id}" が CSV 内で重複しているためスキップしました`);
+      return;
+    }
+    seenIds.add(id);
 
     const numericOrZero = (field: MaterialField): number => {
       const raw = get(row, field);
@@ -280,10 +306,22 @@ export function buildMaterialsFromCsv(
     const provenanceRaw = get(row, 'provenance');
     const provenance = provenanceRaw ? coerceProvenance(provenanceRaw) : undefined;
 
+    const catRaw = get(row, 'cat') ?? '';
+    const catCoerced = coerceCategory(catRaw);
+    if (catCoerced.unknown) {
+      warnings.push(`行 ${lineNo} (${id}): カテゴリ "${catRaw.trim()}" を認識できず "金属合金" にフォールバックしました`);
+    }
+
+    const statusRaw = get(row, 'status') ?? '';
+    const statusCoerced = coerceStatus(statusRaw);
+    if (statusCoerced.unknown) {
+      warnings.push(`行 ${lineNo} (${id}): ステータス "${statusRaw.trim()}" を認識できず "レビュー待" にフォールバックしました`);
+    }
+
     const material: Material = {
       id,
       name,
-      cat: coerceCategory(get(row, 'cat') ?? ''),
+      cat: catCoerced.value,
       hv: numericOrZero('hv'),
       ts: numericOrZero('ts'),
       el: numericOrZero('el'),
@@ -294,7 +332,7 @@ export function buildMaterialsFromCsv(
       batch: (get(row, 'batch') ?? '').trim(),
       date: (get(row, 'date') ?? new Date().toISOString().slice(0, 10)).trim(),
       author: (get(row, 'author') ?? '').trim(),
-      status: coerceStatus(get(row, 'status') ?? ''),
+      status: statusCoerced.value,
       ai: false,
       memo: (get(row, 'memo') ?? '').trim(),
     };
@@ -336,6 +374,22 @@ export function convertCsvToMaiml(
   });
   return { materials, warnings, maiml };
 }
+
+// ----- サンプル CSV -----
+//
+// 実ファイルを用意せずに動作確認できるよう「サンプルで試す」ボタンから読み込む。
+// 中身はアプリ初期データ (Ti-6Al-4V / SUS316L / Inconel718) と整合させ、
+// 既存 ID と重複する設計にして「IMPORT 時に skip される挙動」もそのまま見せる。
+// ヘッダは日英混在で揺らぎ吸収の効きも体感できるようにしてある。
+export const SAMPLE_CSV_FILENAME = 'matlens-sample.csv';
+export const SAMPLE_CSV = [
+  'ID,材料名,Category,HV,Tensile Strength,弾性率,伸び,密度,担当者,状態,組成,備考',
+  'M-101,Ti-6Al-4V (PoC),金属合金,340,950,113,14,4.43,a.ito,登録済,Ti-6Al-4V,航空機エンジン用',
+  'M-102,SUS316L (PoC),金属合金,180,520,193,40,8.0,a.ito,レビュー待,Fe-Cr-Ni-Mo,耐食用途',
+  'M-103,Inconel 718 (PoC),金属合金,420,1240,200,12,8.19,a.ito,承認済,Ni-Cr-Fe-Nb,高温強度',
+  'M-104,Al2O3 (PoC),セラミクス,1500,400,380,0,3.95,a.ito,登録済,Al2O3,セラミクスサンプル',
+  'M-105,CFRP T800 (PoC),複合材料,30,2900,165,1.8,1.6,a.ito,レビュー待,Carbon Fiber,軽量構造材',
+].join('\n');
 
 export const ALL_MATERIAL_FIELDS: { field: MaterialField; label: string; required?: boolean }[] = [
   { field: 'id', label: 'ID (材料 ID)', required: true },


### PR DESCRIPTION
## Summary

- 現場の元データである **Excel エクスポート (CSV / UTF-8) を MaiML XML に変換** する画面を MaiML Studio に追加
- 純 TS の `csvToMaiml` サービス（パース + 推測マッピング + Material[] 構築 + MaiML serialize 連携）と、drop → preview → commit のページ実装
- 「Excel 散在 → MaiML → ラボ計測器 / OEM」の経路が 1 画面で完結

## 背景

ユーザフィードバック: Matlens は MaiML を中心に展開され、現場の元データは Excel である事が多い、という想定がアプリでカバーできているかという問い。
調査の結果、MaiML 中核 (Studio) は実装済だが Import 入口は `.maiml,.xml` のみで、`docs/onsite/pain-points.md` で 🔥 級と認識している「過去切削条件が Excel に散在」（B1）への画面が無いギャップがあった。最小コストで現場直結する CSV → MaiML 変換を新規サブ画面として追加する。

## 主な変更

- `src/services/csvToMaiml.ts` (新規 / 純 TS / framework-agnostic 境界内)
  - RFC 4180 風 CSV パーサ + UTF-8 BOM 吸収 + CRLF 対応
  - `inferColumnMapping`: 日本語 / 英語ヘッダ揺らぎ吸収（材料名 / SampleName / 引張強さ / Tensile Strength 等）
  - `buildMaterialsFromCsv`: 必須数値が読めない行は 0 + warning に落として継続（silent failure 禁止）
  - `convertCsvToMaiml`: ワンショット API
- `src/services/csvToMaiml.test.ts` (新規 16 テスト)
- `src/features/maiml/MaimlConvertPage.tsx` (新規)
  - drop → ヘッダ検出 + 推測マッピング → ユーザ修正 → preview → `.maiml` ダウンロード or Studio Import に commit
- 配線: `App.tsx` ルート / `constants.ts` サイドバー (NEW) + `PAGE_GUIDES` / `MaimlStudioHubPage` カード / `index.ts` barrel
- ドキュメント連動: `announcements.ts` 先頭 / `README.md` 機能表 + 5 分 demo

## なぜ xlsx を直読みしないか

SheetJS は ~400KB あり、bundle size と framework-agnostic 境界（純 TS 維持）に影響する。
Excel 「名前を付けて保存 → CSV (UTF-8)」運用で現場痛みは解消できるため、まず CSV で出してから xlsx は遅延ロードで後追いする方針を `PAGE_GUIDES` Tips に明記した。

## 検証

- `pnpm typecheck` ✅
- `pnpm lint` 0 errors / 95 warnings（既存のみ、新規追加分は a11y 警告も含めゼロ）
- `pnpm vitest run` 871 passed (855 → +16) / 2 skipped
- `pnpm verify:agnostic` ✅ services 1942 → 2301 SLOC（純 TS 移植可能領域に増加）

## Test plan

- [ ] MaiML Studio Hub に「CSV → MaiML 変換」カードが NEW バッジ付きで表示される
- [ ] サイドバー「コア > MaiML Studio」配下に「CSV→MaiML 変換」が追加されている
- [ ] CSV ファイル（UTF-8 / 日本語ヘッダ）を drop すると推測マッピングが埋まる
- [ ] 必須カラム未割当時は警告が出てプレビューが出ない
- [ ] プレビュー後、`.maiml` ダウンロードでファイルが取得できる
- [ ] 「アプリに取り込む」で材料データ一覧に反映される（ID 重複は skip + 件数表示）
- [ ] 4 テーマ (light / dark / eng / cae) で UI が崩れない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV/TSVファイルをドラッグ&ドロップで読み込み、列マッピング・プレビュー後にMaiML（.maiml）としてダウンロードまたはアプリへインポートできる変換ページとナビ導線を追加。変換結果は重複除外や必須列検証を行います。

* **UI**
  * ハブ画面に「CSV → MaiML 変換」カードをNEWバッジで追加し、サイドバー導線とページガイドを登録。

* **Documentation**
  * READMEの「5分でわかる Matlens」と主な機能表に手順・説明を追記。

* **Tests**
  * CSV変換ロジックの包括的な単体テストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoxPistols/Matlens/pull/129)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->