### PR TITLE
fix(maiml): csv マッピング表の select が key に見える問題を改善

### DIFF
--- a/src/features/maiml/MaimlConvertPage.tsx
+++ b/src/features/maiml/MaimlConvertPage.tsx
@@ -169,6 +169,17 @@ export const MaimlConvertPage = ({ db, dispatch, onNav }: MaimlConvertPageProps)
               </div>
             </header>
 
+            <CsvPreview csv={loaded.csv} mapping={mapping} />
+
+            <div className="rounded-lg border border-[var(--border-faint)] bg-[rgba(37,99,235,0.04)] p-3 text-[12px] text-[var(--text-md)]">
+              <div className="font-semibold mb-1">この後の手順</div>
+              <ol className="list-decimal list-inside flex flex-col gap-0.5 text-[var(--text-lo)]">
+                <li>下表で <strong>Matlens 内部フィールド（左）</strong> に <strong>CSV のヘッダ（右）</strong> を割り当てます</li>
+                <li>ヘッダ名が違っても紐づけられます（例: CSV の <code className="font-mono">材料ID</code> → Matlens の <code className="font-mono">ID</code>）</li>
+                <li>必須項目（<span className="text-[var(--err,#dc2626)]">*</span> 印）が埋まればプレビューが出ます</li>
+              </ol>
+            </div>
+
             <MappingTable
               headers={loaded.csv.headers}
               mapping={mapping}
@@ -329,6 +340,73 @@ const DropZone = ({ onFile, onSample }: DropZoneProps) => {
         <span className="text-[var(--text-lo)]">で挙動を試せます（Ti-6Al-4V / SUS316L 等 5 件 / 日英ヘッダ混在）</span>
       </div>
     </div>
+  );
+};
+
+// 取込元 CSV の先頭数行 + ヘッダを表示し、「これからこの中身を Material に
+// マッピングする」という視覚的アンカーをユーザに与える。
+// マッピング済みのヘッダは accent 色でハイライトされ、左右の対応が一目で分かる。
+interface CsvPreviewProps {
+  csv: CsvParseResult;
+  mapping: ColumnMapping;
+}
+
+const PREVIEW_ROW_LIMIT = 3;
+
+const CsvPreview = ({ csv, mapping }: CsvPreviewProps) => {
+  const mappedHeaderSet = useMemo(
+    () => new Set(Object.values(mapping).filter(Boolean) as string[]),
+    [mapping],
+  );
+  const previewRows = csv.rows.slice(0, PREVIEW_ROW_LIMIT);
+  return (
+    <section
+      aria-label="CSV 元データプレビュー"
+      className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
+    >
+      <div className="text-[12px] text-[var(--text-lo)] px-3 py-1.5 bg-[var(--bg-sunken)] border-b border-[var(--border-faint)]">
+        CSV 元データ（先頭 {previewRows.length} 行）— 着色されたヘッダは下のマッピング表で割当済み
+      </div>
+      <div className="overflow-auto">
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="bg-[var(--bg-raised)] border-b border-[var(--border-faint)]">
+              {csv.headers.map((h) => {
+                const mapped = mappedHeaderSet.has(h);
+                return (
+                  <th
+                    key={h}
+                    className={`px-3 py-1.5 text-left font-semibold whitespace-nowrap ${
+                      mapped
+                        ? 'text-[var(--accent,#2563eb)] bg-[var(--accent-dim)]'
+                        : 'text-[var(--text-lo)]'
+                    }`}
+                  >
+                    {h}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {previewRows.map((row, ri) => (
+              <tr key={ri} className="border-b border-[var(--border-faint)]">
+                {csv.headers.map((h, ci) => (
+                  <td key={h} className="px-3 py-1 whitespace-nowrap font-mono">
+                    {row[ci] ?? ''}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {csv.rows.length > PREVIEW_ROW_LIMIT && (
+        <div className="px-3 py-1.5 text-[12px] text-[var(--text-lo)]">
+          他 {csv.rows.length - PREVIEW_ROW_LIMIT} 行
+        </div>
+      )}
+    </section>
   );
 };
 

--- a/src/services/csvToMaiml.test.ts
+++ b/src/services/csvToMaiml.test.ts
@@ -82,6 +82,30 @@ describe('inferColumnMapping', () => {
     const mapping = inferColumnMapping(['hardness', 'HV']);
     expect(mapping.hv).toBe('hardness');
   });
+
+  it('単位入りヘッダ (Hardness(HV) / Tensile(MPa) 等) を fallback で拾う', () => {
+    const mapping = inferColumnMapping([
+      'Hardness(HV)',
+      'Tensile(MPa)',
+      'Young(GPa)',
+      'Elongation(%)',
+      '0.2%Proof(MPa)',
+      'Density',
+    ]);
+    expect(mapping.hv).toBe('Hardness(HV)');
+    expect(mapping.ts).toBe('Tensile(MPa)');
+    expect(mapping.el).toBe('Young(GPa)');
+    expect(mapping.el2).toBe('Elongation(%)');
+    expect(mapping.pf).toBe('0.2%Proof(MPa)');
+    expect(mapping.dn).toBe('Density');
+  });
+
+  it('空白入りヘッダ (Sample Name / バッチ No 等) を吸収する', () => {
+    const mapping = inferColumnMapping(['Sample Name', 'バッチ No', '材料ID']);
+    expect(mapping.name).toBe('Sample Name');
+    expect(mapping.batch).toBe('バッチ No');
+    expect(mapping.id).toBe('材料ID');
+  });
 });
 
 describe('buildMaterialsFromCsv', () => {

--- a/src/services/csvToMaiml.ts
+++ b/src/services/csvToMaiml.ts
@@ -125,35 +125,51 @@ export type ColumnMapping = Partial<Record<MaterialField, string>>;
 
 /** ヘッダ名（日本語 / 英語表記の代表的な揺らぎ）→ MaterialField */
 const HEADER_HINTS: Record<MaterialField, string[]> = {
-  id: ['id', 'sampleid', 'sample id', '材料id', '試料id', '管理番号'],
+  id: ['id', 'sampleid', 'sample id', '材料id', '試料id', '管理番号', 'materialid'],
   name: ['name', 'samplename', 'sample name', '材料名', '試料名', '名称'],
   cat: ['category', 'cat', '分類', 'カテゴリ', '材料分類'],
-  comp: ['composition', 'comp', '組成'],
-  batch: ['batch', 'lot', 'ロット', 'バッチ'],
-  date: ['date', 'registeredon', '登録日', '日付'],
+  comp: ['composition', 'comp', '組成', '成分'],
+  batch: ['batch', 'lot', 'ロット', 'バッチ', 'batchno', 'lotno', 'バッチno'],
+  date: ['date', 'registeredon', '登録日', '日付', 'createdat'],
   author: ['author', 'operator', '担当', '担当者', '作成者'],
   status: ['status', '状態', 'ステータス'],
-  memo: ['memo', 'note', 'remarks', '備考', 'メモ'],
-  hv: ['hv', 'hardness', '硬度', '硬さ'],
-  ts: ['ts', 'tensile', 'tensilestrength', '引張強さ', '引張強度'],
-  el: ['el', 'elastic', 'elasticmodulus', 'youngs', 'ヤング率', '弾性率'],
+  memo: ['memo', 'note', 'notes', 'remarks', '備考', 'メモ'],
+  hv: ['hv', 'hardness', '硬度', '硬さ', 'hardnesshv'],
+  ts: ['ts', 'tensile', 'tensilestrength', '引張強さ', '引張強度', 'tensilempa'],
+  el: ['el', 'elastic', 'elasticmodulus', 'youngs', 'young', 'youngmodulus', 'ヤング率', '弾性率'],
   el2: ['elongation', 'el2', '伸び', '伸び率'],
-  pf: ['pf', 'proof', 'proofstress', '耐力', '0.2%耐力'],
+  pf: ['pf', 'proof', 'proofstress', '耐力', '0.2%耐力', '02proof', 'proofmpa'],
   dn: ['dn', 'density', '密度'],
   provenance: ['provenance', 'source', '出所', 'データ出所'],
   microstructure: ['microstructure', 'micro', '組織', '金属組織'],
   testMethod: ['testmethod', 'method', '試験方法', '規格'],
 };
 
+// fallback の含有判定で使う最小 hint 長。
+// 2-3 文字の短い hint (hv / ts / cat 等) で誤爆させないため。
+const MIN_HINT_LENGTH_FOR_FALLBACK = 4;
+
 function normalizeHeader(h: string): string {
-  return h.toLowerCase().replace(/[\s_-]+/g, '');
+  return h.toLowerCase().replace(/[\s_\-()（）]+/g, '');
 }
 
-/** ヘッダ一覧から推測でマッピングを埋める。確信が無い列は触らない。 */
+/**
+ * ヘッダ一覧から推測でマッピングを埋める。
+ *
+ * 2 段階で推測する:
+ *   パス 1: 正規化後の完全一致 (高信頼)
+ *   パス 2: 残ったヘッダに対し、長い hint から順に「ヘッダが hint を含む」を許可
+ *           (例: "Hardness (HV)" -> hv, "Tensile(MPa)" -> ts)
+ *
+ * 短い hint (2-3 文字) は含有判定だと誤爆しやすいので fallback では除外する。
+ */
 export function inferColumnMapping(headers: string[]): ColumnMapping {
   const mapping: ColumnMapping = {};
   const used = new Set<string>();
-  for (const [field, hints] of Object.entries(HEADER_HINTS) as [MaterialField, string[]][]) {
+  const fieldsAndHints = Object.entries(HEADER_HINTS) as [MaterialField, string[]][];
+
+  // パス 1: 正規化後の完全一致
+  for (const [field, hints] of fieldsAndHints) {
     for (const header of headers) {
       if (used.has(header)) continue;
       const norm = normalizeHeader(header);
@@ -164,6 +180,29 @@ export function inferColumnMapping(headers: string[]): ColumnMapping {
       }
     }
   }
+
+  // パス 2: ヘッダが hint を含む (長い hint から優先) — fallback
+  const sortedFields = fieldsAndHints.map(([field, hints]) => ({
+    field,
+    normalizedHints: hints
+      .map(normalizeHeader)
+      .filter((h) => h.length >= MIN_HINT_LENGTH_FOR_FALLBACK)
+      .sort((a, b) => b.length - a.length),
+  }));
+
+  for (const { field, normalizedHints } of sortedFields) {
+    if (mapping[field]) continue;
+    for (const header of headers) {
+      if (used.has(header)) continue;
+      const norm = normalizeHeader(header);
+      if (normalizedHints.some((h) => norm.includes(h))) {
+        mapping[field] = header;
+        used.add(header);
+        break;
+      }
+    }
+  }
+
   return mapping;
 }
 
@@ -437,17 +476,22 @@ export function convertCsvToMaiml(
 // ----- サンプル CSV -----
 //
 // 実ファイルを用意せずに動作確認できるよう「サンプルで試す」ボタンから読み込む。
-// 中身はアプリ初期データ (Ti-6Al-4V / SUS316L / Inconel718) と整合させ、
-// 既存 ID と重複する設計にして「IMPORT 時に skip される挙動」もそのまま見せる。
-// ヘッダは日英混在で揺らぎ吸収の効きも体感できるようにしてある。
+//
+// ヘッダはあえて「現場の Excel でありがち」な揺らぎを混ぜている:
+//   - 材料ID (Matlens 表示は "ID (材料 ID)")
+//   - Sample Name (空白 + 英語、Matlens 表示は "名前")
+//   - Hardness(HV) / Tensile(MPa) / Young(GPa) / Elongation(%) / 0.2%Proof(MPa) (単位入り)
+//   - バッチ No (空白) / Notes (英語)
+// これにより「CSV のヘッダ名と Matlens 内部フィールドが違う -> マッピングする意味がある」
+// ことが体感できる。
 export const SAMPLE_CSV_FILENAME = 'matlens-sample.csv';
 export const SAMPLE_CSV = [
-  'ID,材料名,Category,HV,Tensile Strength,弾性率,伸び,密度,担当者,状態,組成,備考',
-  'M-101,Ti-6Al-4V (PoC),金属合金,340,950,113,14,4.43,a.ito,登録済,Ti-6Al-4V,航空機エンジン用',
-  'M-102,SUS316L (PoC),金属合金,180,520,193,40,8.0,a.ito,レビュー待,Fe-Cr-Ni-Mo,耐食用途',
-  'M-103,Inconel 718 (PoC),金属合金,420,1240,200,12,8.19,a.ito,承認済,Ni-Cr-Fe-Nb,高温強度',
-  'M-104,Al2O3 (PoC),セラミクス,1500,400,380,0,3.95,a.ito,登録済,Al2O3,セラミクスサンプル',
-  'M-105,CFRP T800 (PoC),複合材料,30,2900,165,1.8,1.6,a.ito,レビュー待,Carbon Fiber,軽量構造材',
+  '材料ID,Sample Name,分類,成分,バッチ No,登録日,担当,状態,Notes,Hardness(HV),Tensile(MPa),Young(GPa),Elongation(%),0.2%Proof(MPa),Density',
+  'M-101,Ti-6Al-4V,金属合金,Ti-6Al-4V,LOT-A23,2026-04-12,山田,登録済,航空機エンジン用,340,950,113,14,880,4.43',
+  'M-102,SUS316L,金属合金,Fe-Cr-Ni-Mo,LOT-B07,2026-04-18,鈴木,レビュー待,耐食用途,180,520,193,40,205,8.0',
+  'M-103,Inconel 718,金属合金,Ni-Cr-Fe-Nb,LOT-C11,2026-04-22,佐藤,承認済,高温強度,420,1240,200,12,1100,8.19',
+  'M-104,Al2O3 (alumina),セラミクス,Al2O3,LOT-D02,2026-04-25,田中,登録済,セラミクスサンプル,1500,400,380,0,,3.95',
+  'M-105,CFRP T800,複合材料,Carbon Fiber,LOT-E15,2026-04-28,a.ito,レビュー待,軽量構造材,30,2900,165,1.8,,1.6',
 ].join('\n');
 
 export const ALL_MATERIAL_FIELDS: { field: MaterialField; label: string; required?: boolean }[] = [


### PR DESCRIPTION
## Summary

CSV → MaiML 変換画面のカラムマッピング UI を見直し。

実画面スクリーンショットで「右側 select の現在値も短いラベル (ID / Category) なので、左列と並ぶと key = key の対応表に見え、クリックで変更できることに気付きにくい」UX 問題を指摘されたため修正。

## 変更点

- テーブルを **3 列構成** に変更し、中央列に \"←\" を入れて Material ← CSV ヘッダ の関係を視覚化
- select を `MappingSelect` コンポーネントに切り出し、**明示的な ▼ chevron を絶対配置** （OS native の薄い chevron に依存しない）
- 状態に応じた **色分け**:
  - 未割当 + 必須 → 赤枠 + 薄赤背景
  - 未割当 + 任意 → 破線枠 + sunken 背景
  - 割当済み → accent 色の太枠 + raised 背景
- ヘッダ文言を「**CSV ヘッダ（クリックで変更）**」と明示

## 検証

- \`pnpm typecheck\` ✅
- \`pnpm vitest run src/services/csvToMaiml.test.ts\` ✅ 21/21
- \`pnpm lint\` 0 errors (95 warnings は既存のみ)

## Test plan

- [ ] サンプル CSV を読み込んだ後、マッピング表で右側がクリック可能なドロップダウンと一目で分かる
- [ ] 必須フィールド (id / name) を未割当にすると赤枠になる
- [ ] 任意フィールドの未割当は破線枠で目立たない
- [ ] 割当済みフィールドは accent 色で強調される
- [ ] 4 テーマ (light / dark / eng / cae) で崩れない