### PR TITLE
fix(maiml): csv → maiml の任意数値 / provenance / date の silent failure を warning に揃える

### DIFF
--- a/src/features/maiml/MaimlConvertPage.tsx
+++ b/src/features/maiml/MaimlConvertPage.tsx
@@ -344,43 +344,85 @@ const MappingTable = ({ headers, mapping, onChange }: MappingTableProps) => (
     className="rounded-lg border border-[var(--border-faint)] overflow-hidden"
   >
     <div className="text-[12px] text-[var(--text-lo)] px-3 py-1.5 bg-[var(--bg-sunken)] border-b border-[var(--border-faint)]">
-      カラムマッピング — Material のフィールドに、CSV のどのヘッダを割り当てるか選択
+      カラムマッピング — 各 Material フィールドに、CSV のどのヘッダを割り当てるか選択（右側のセレクトをクリック）
     </div>
     <table className="w-full text-[12px]">
       <thead>
         <tr className="bg-[var(--bg-raised)] border-b border-[var(--border-faint)]">
           <th className="px-3 py-1.5 text-left font-semibold w-[40%]">Material フィールド</th>
-          <th className="px-3 py-1.5 text-left font-semibold">CSV ヘッダ</th>
+          <th className="px-2 py-1.5 text-center font-semibold w-[40px] text-[var(--text-lo)]" aria-hidden="true">←</th>
+          <th className="px-3 py-1.5 text-left font-semibold">CSV ヘッダ（クリックで変更）</th>
         </tr>
       </thead>
       <tbody>
-        {ALL_MATERIAL_FIELDS.map(({ field, label, required }) => (
-          <tr key={field} className="border-b border-[var(--border-faint)]">
-            <td className="px-3 py-1.5">
-              {label}
-              {required && (
-                <span className="ml-1 text-[var(--err,#dc2626)] font-bold">*</span>
-              )}
-            </td>
-            <td className="px-3 py-1">
-              <select
-                value={mapping[field] ?? ''}
-                onChange={(e) => onChange(field, e.target.value)}
-                className="text-[12px] px-2 py-1 rounded border border-[var(--border-default)] bg-[var(--bg-base)] min-w-[160px]"
-                aria-label={`${label} のカラム`}
-              >
-                <option value="">— 未割当 —</option>
-                {headers.map((h) => (
-                  <option key={h} value={h}>{h}</option>
-                ))}
-              </select>
-            </td>
-          </tr>
-        ))}
+        {ALL_MATERIAL_FIELDS.map(({ field, label, required }) => {
+          const selected = mapping[field];
+          return (
+            <tr key={field} className="border-b border-[var(--border-faint)]">
+              <td className="px-3 py-1.5">
+                {label}
+                {required && (
+                  <span className="ml-1 text-[var(--err,#dc2626)] font-bold">*</span>
+                )}
+              </td>
+              <td className="px-2 py-1 text-center text-[var(--text-lo)]" aria-hidden="true">←</td>
+              <td className="px-3 py-1.5">
+                <MappingSelect
+                  label={label}
+                  value={selected ?? ''}
+                  headers={headers}
+                  onChange={(v) => onChange(field, v)}
+                  required={required}
+                />
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   </section>
 );
+
+interface MappingSelectProps {
+  label: string;
+  value: string;
+  headers: string[];
+  onChange: (value: string) => void;
+  required?: boolean;
+}
+
+const MappingSelect = ({ label, value, headers, onChange, required }: MappingSelectProps) => {
+  const unassigned = value === '';
+  return (
+    <div
+      className={`relative inline-flex items-center min-w-[200px] rounded border-2 transition-colors ${
+        unassigned && required
+          ? 'border-[var(--err,#dc2626)] bg-[rgba(220,38,38,0.06)]'
+          : unassigned
+          ? 'border-dashed border-[var(--border-default)] bg-[var(--bg-sunken)]'
+          : 'border-[var(--accent,#2563eb)] bg-[var(--bg-raised)]'
+      } hover:bg-[var(--hover)]`}
+    >
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="appearance-none text-[12px] pl-2 pr-7 py-1 bg-transparent cursor-pointer focus:outline-none w-full"
+        aria-label={`${label} に割り当てる CSV ヘッダ`}
+      >
+        <option value="">— 未割当 —</option>
+        {headers.map((h) => (
+          <option key={h} value={h}>{h}</option>
+        ))}
+      </select>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute right-2 text-[10px] text-[var(--text-lo)]"
+      >
+        ▼
+      </span>
+    </div>
+  );
+};
 
 const PreviewTable = ({ materials }: { materials: Material[] }) => (
   <section

--- a/src/services/csvToMaiml.test.ts
+++ b/src/services/csvToMaiml.test.ts
@@ -226,6 +226,22 @@ describe('buildMaterialsFromCsv', () => {
     expect(materials[1]?.date).toBe('2026-05-15T10:00:00Z');
     expect(warnings).toEqual([]);
   });
+
+  it('date が YYYY-MM-DD で始まっても末尾にゴミがあれば warning', () => {
+    const data = parseCsvWithHeader('ID,Name,登録日\nM-001,Ti,2026-05-15garbage');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', date: '登録日' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(warnings.some((w) => w.includes('2026-05-15garbage'))).toBe(true);
+  });
+
+  it('pf の不正値 warning は「未設定 (null)」と表現する', () => {
+    const data = parseCsvWithHeader('ID,Name,耐力\nM-001,Ti,abc');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', pf: '耐力' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.pf).toBe(null);
+    expect(warnings.some((w) => w.includes('未設定') && w.includes('null'))).toBe(true);
+  });
 });
 
 describe('REQUIRED_FIELDS', () => {

--- a/src/services/csvToMaiml.test.ts
+++ b/src/services/csvToMaiml.test.ts
@@ -161,6 +161,71 @@ describe('buildMaterialsFromCsv', () => {
     expect(materials[1]?.id).toBe('M-002');
     expect(warnings.some((w) => w.includes('M-001') && w.includes('重複'))).toBe(true);
   });
+
+  it('任意数値の不正値 (—, abc 等) は 0 + warning に落とす', () => {
+    const data = parseCsvWithHeader('ID,Name,弾性率,密度\nM-001,Ti,—,3.95\nM-002,Al,abc,2.7');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', el: '弾性率', dn: '密度' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials).toHaveLength(2);
+    expect(materials[0]?.el).toBe(0);
+    expect(materials[0]?.dn).toBe(3.95);
+    expect(materials[1]?.el).toBe(0);
+    expect(warnings.some((w) => w.includes('M-001') && w.includes('el') && w.includes('—'))).toBe(true);
+    expect(warnings.some((w) => w.includes('M-002') && w.includes('el') && w.includes('abc'))).toBe(true);
+  });
+
+  it('任意数値の空欄は silent に 0 で通る（warning 出さない）', () => {
+    const data = parseCsvWithHeader('ID,Name,弾性率\nM-001,Ti,');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', el: '弾性率' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.el).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it('pf の不正値は null + warning に落とす', () => {
+    const data = parseCsvWithHeader('ID,Name,耐力\nM-001,Ti,—');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', pf: '耐力' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.pf).toBe(null);
+    expect(warnings.some((w) => w.includes('pf') && w.includes('—'))).toBe(true);
+  });
+
+  it('未認識 provenance は warning + undefined にフォールバック', () => {
+    const data = parseCsvWithHeader('ID,Name,Provenance\nM-001,Ti,unknown-src');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', provenance: 'Provenance' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.provenance).toBeUndefined();
+    expect(warnings.some((w) => w.includes('provenance') && w.includes('unknown-src'))).toBe(true);
+  });
+
+  it('provenance 空欄は silent に undefined', () => {
+    const data = parseCsvWithHeader('ID,Name,Provenance\nM-001,Ti,');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', provenance: 'Provenance' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.provenance).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
+  it('date の形式違反は warning + 今日の日付にフォールバック', () => {
+    const data = parseCsvWithHeader('ID,Name,登録日\nM-001,Ti,2026/5/10\nM-002,Al,未定');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', date: '登録日' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials).toHaveLength(2);
+    // フォールバック値は今日の日付 (YYYY-MM-DD)
+    expect(materials[0]?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(materials[1]?.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(warnings.some((w) => w.includes('M-001') && w.includes('2026/5/10'))).toBe(true);
+    expect(warnings.some((w) => w.includes('M-002') && w.includes('未定'))).toBe(true);
+  });
+
+  it('date が ISO datetime / YYYY-MM-DD ならそのまま通る', () => {
+    const data = parseCsvWithHeader('ID,Name,登録日\nM-001,Ti,2026-05-15\nM-002,Al,2026-05-15T10:00:00Z');
+    const mapping: ColumnMapping = { id: 'ID', name: 'Name', date: '登録日' };
+    const { materials, warnings } = buildMaterialsFromCsv(data, mapping);
+    expect(materials[0]?.date).toBe('2026-05-15');
+    expect(materials[1]?.date).toBe('2026-05-15T10:00:00Z');
+    expect(warnings).toEqual([]);
+  });
 });
 
 describe('REQUIRED_FIELDS', () => {

--- a/src/services/csvToMaiml.ts
+++ b/src/services/csvToMaiml.ts
@@ -219,10 +219,11 @@ function coerceProvenance(value: string): CoercionResult<Provenance | undefined>
   return { value: undefined, unknown: true };
 }
 
-// date は YYYY-MM-DD もしくは ISO datetime を期待。形式違反のセルが MaiML に
-// 静かに混入するのを防ぐため、簡易バリデータで弾いて warning に落とす。
-// 仕様: 4桁年-2桁月-2桁日 で始まり、Date でパースして有効ならOK。
-const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}/;
+// date は YYYY-MM-DD もしくは ISO 8601 datetime を期待。形式違反のセルが MaiML に
+// 静かに混入するのを防ぐため、末尾までを $ で固定したパターンで弾く。
+// 接頭マッチだけだと "2026-05-15garbage" のような末尾ゴミ付きも Date.parse が
+// 通ってしまうため必ず末尾固定する。
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
 function isValidDateString(value: string): boolean {
   if (!DATE_PATTERN.test(value)) return false;
   const d = new Date(value);
@@ -339,7 +340,7 @@ export function buildMaterialsFromCsv(
       if (pfTrimmed !== '') {
         const parsed = coerceNumberOrNull(pfTrimmed);
         if (parsed === null) {
-          warnings.push(`行 ${lineNo} (${id}): pf "${pfTrimmed}" を数値として読めず null を入れました`);
+          warnings.push(`行 ${lineNo} (${id}): pf "${pfTrimmed}" を数値として読めず未設定 (null) にしました`);
         }
         pf = parsed;
       }

--- a/src/services/csvToMaiml.ts
+++ b/src/services/csvToMaiml.ts
@@ -206,10 +206,27 @@ function coerceStatus(value: string): CoercionResult<MaterialStatus> {
   return { value: 'レビュー待', unknown: true };
 }
 
-function coerceProvenance(value: string): Provenance | undefined {
-  const trimmed = value.trim().toLowerCase();
-  if ((PROVENANCE_VALUES as string[]).includes(trimmed)) return trimmed as Provenance;
-  return undefined;
+// provenance も cat / status と同じく「空欄は silent / 非空だが未認識は unknown=true」に揃え、
+// 4 種類 enum (instrument / manual / ai / simulation) のいずれにも当たらない値が
+// 静かに undefined になる silent failure を防ぐ。
+function coerceProvenance(value: string): CoercionResult<Provenance | undefined> {
+  const trimmed = value.trim();
+  if (trimmed === '') return { value: undefined, unknown: false };
+  const lower = trimmed.toLowerCase();
+  if ((PROVENANCE_VALUES as string[]).includes(lower)) {
+    return { value: lower as Provenance, unknown: false };
+  }
+  return { value: undefined, unknown: true };
+}
+
+// date は YYYY-MM-DD もしくは ISO datetime を期待。形式違反のセルが MaiML に
+// 静かに混入するのを防ぐため、簡易バリデータで弾いて warning に落とす。
+// 仕様: 4桁年-2桁月-2桁日 で始まり、Date でパースして有効ならOK。
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}/;
+function isValidDateString(value: string): boolean {
+  if (!DATE_PATTERN.test(value)) return false;
+  const d = new Date(value);
+  return Number.isFinite(d.getTime());
 }
 
 function coerceNumberOrNull(value: string): number | null {
@@ -288,23 +305,52 @@ export function buildMaterialsFromCsv(
     }
     seenIds.add(id);
 
+    // 数値フィールドは空欄は silent、「非空だが Number にできない」値（"—" "N/A" 等）は
+    // 必須/任意問わず warning に落として 0 フォールバックする。
+    // 現場の Excel では未測定が空欄でなく "—" / "未測定" 等で入る事例が多く、
+    // それを 0 と区別できないまま MaiML に混入させないようにする目的。
     const numericOrZero = (field: MaterialField): number => {
       const raw = get(row, field);
-      const n = coerceNumberOrNull(raw ?? '');
-      if (n === null) {
+      // mapping 自体が割り当てられていない場合は silent に 0
+      // （ユーザは「この列は使わない」と意図的に外した可能性）
+      if (raw === undefined) return 0;
+      const trimmed = raw.trim();
+      if (trimmed === '') {
+        // mapping あり / 値空欄: 必須なら警告、任意なら silent
         if (REQUIRED_NUMERIC_FIELDS.includes(field)) {
-          warnings.push(`行 ${lineNo} (${id}): ${field} が数値として読めず 0 を入れました`);
+          warnings.push(`行 ${lineNo} (${id}): 必須数値 ${field} が空のため 0 を入れました`);
         }
+        return 0;
+      }
+      const n = coerceNumberOrNull(trimmed);
+      if (n === null) {
+        warnings.push(`行 ${lineNo} (${id}): ${field} "${trimmed}" を数値として読めず 0 を入れました`);
         return 0;
       }
       return n;
     };
 
+    // pf は number | null なので unmapped / 空欄はどちらも silent に null。
+    // 「値があるが Number にできない」ケースだけ warning に落として null を入れる。
     const pfRaw = get(row, 'pf');
-    const pf = pfRaw === undefined || pfRaw.trim() === '' ? null : coerceNumberOrNull(pfRaw);
+    let pf: number | null = null;
+    if (pfRaw !== undefined) {
+      const pfTrimmed = pfRaw.trim();
+      if (pfTrimmed !== '') {
+        const parsed = coerceNumberOrNull(pfTrimmed);
+        if (parsed === null) {
+          warnings.push(`行 ${lineNo} (${id}): pf "${pfTrimmed}" を数値として読めず null を入れました`);
+        }
+        pf = parsed;
+      }
+    }
 
-    const provenanceRaw = get(row, 'provenance');
-    const provenance = provenanceRaw ? coerceProvenance(provenanceRaw) : undefined;
+    const provenanceRaw = get(row, 'provenance') ?? '';
+    const provenanceCoerced = coerceProvenance(provenanceRaw);
+    if (provenanceCoerced.unknown) {
+      warnings.push(`行 ${lineNo} (${id}): provenance "${provenanceRaw.trim()}" を認識できず未設定にしました（instrument / manual / ai / simulation のいずれか）`);
+    }
+    const provenance = provenanceCoerced.value;
 
     const catRaw = get(row, 'cat') ?? '';
     const catCoerced = coerceCategory(catRaw);
@@ -330,12 +376,24 @@ export function buildMaterialsFromCsv(
       dn: numericOrZero('dn'),
       comp: (get(row, 'comp') ?? '').trim(),
       batch: (get(row, 'batch') ?? '').trim(),
-      date: (get(row, 'date') ?? new Date().toISOString().slice(0, 10)).trim(),
+      // date は下で改めて検証 + 警告込みで設定する。ここはプレースホルダ。
+      date: '',
       author: (get(row, 'author') ?? '').trim(),
       status: statusCoerced.value,
       ai: false,
       memo: (get(row, 'memo') ?? '').trim(),
     };
+
+    // date 検証: 空欄は silent に今日の日付、形式違反は warning に落として今日の日付。
+    const dateRaw = (get(row, 'date') ?? '').trim();
+    if (dateRaw === '') {
+      material.date = new Date().toISOString().slice(0, 10);
+    } else if (isValidDateString(dateRaw)) {
+      material.date = dateRaw;
+    } else {
+      warnings.push(`行 ${lineNo} (${id}): 日付 "${dateRaw}" を YYYY-MM-DD 形式として読めず本日の日付にフォールバックしました`);
+      material.date = new Date().toISOString().slice(0, 10);
+    }
 
     if (provenance) material.provenance = provenance;
     const micro = get(row, 'microstructure');


### PR DESCRIPTION
## Summary

ユーザフィードバック「ヘッダーがあれば中のバリューも必要 / それは大丈夫なのか」を受けて、
**MaiML Convert で「ヘッダ割当はあるが値が Material 型に乗らない」3 ケースの silent failure を warning に揃える**。

## 背景

`buildMaterialsFromCsv` の coerce ロジックを精査したところ、以下が silent fall-back していた:

1. **任意数値 (`el` / `el2` / `dn` / `pf`)** — 「弾性率」列に `—` や `N/A` が入ると無言で 0 / null に落ちる
2. **`provenance`** — 4 種類 enum (instrument / manual / ai / simulation) のいずれにも当たらない値が無言で undefined になる
3. **`date`** — `2026/5/10` や `未定` のような形式違反が素通りして MaiML へ混入

Mock Repository 実装パターン（2026-04-19 memory）の **silent failure 禁止** ポリシーに合わせて、3 箇所すべて warning に揃える。

## 主な変更

- `numericOrZero` を以下の 3 階層に整理:
  - mapping 自体が無い → silent（ユーザは「使わない」と意図的に外した可能性）
  - mapping あり / 値空欄 → 必須なら warning、任意なら silent
  - 値があるが Number にできない → 必須 / 任意問わず warning
- `coerceProvenance` を `coerceCategory` / `coerceStatus` と同じ `CoercionResult<T>` パターンに統一
- `isValidDateString`: `^\d{4}-\d{2}-\d{2}` + `Date.parse` の簡易バリデータ追加
- `Material.date` の代入を build 後にずらし、形式違反を warning に拾ってから今日にフォールバック

## 副次的に直したバグ

旧 `numericOrZero` は **必須数値 (`hv` / `ts`) の mapping を外しただけのテストでも warning が誤発火していた**（行ごとに `必須数値 hv が空のため 0 を入れました` が出ていた）。これを「mapping 自体無しは silent / 値空欄のみ warning」に整理して解消。

## 検証

- `pnpm typecheck` ✅
- `pnpm vitest run` 883 passed / 2 skipped（871 → +12: 任意数値 / pf / provenance 認識・未認識・空欄 / date 形式違反・有効 ISO / YYYY-MM-DD）
- `pnpm lint` 0 errors / 95 warnings（既存のみ）

## Test plan

- [ ] MaiML Studio → CSV→MaiML 変換 で `弾性率` 列に `—` を含む CSV を読み込むと、警告 details に該当行 + フィールド名 + 元の値が表示される
- [ ] `Provenance` 列に `unknown-src` を入れると警告が出て、当該行の provenance が未設定になる
- [ ] `登録日` 列に `2026/5/10` を入れると警告が出て、今日の日付にフォールバックする
- [ ] `登録日` 列が `2026-05-15` や ISO datetime ならそのまま通って警告ゼロ
- [ ] `Provenance` 列を割り当てずに変換してもエラーにならない（mapping 無し = silent）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Mapping テーブルのUI改善：ヘッダーテキストの更新、固定矢印列の追加、選択UIコンポーネントの分離

* **改善**
  * CSV取り込み時の数値・日付・その他フィールドの型変換ロジックを改善し、より詳細なフォールバック処理と警告制御に対応

* **テスト**
  * CSV変換機能の新しいテストケースを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BoxPistols/Matlens/pull/135)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->